### PR TITLE
Add RelevantQuestions related directly to Notices

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,11 +1,13 @@
 class Notice < ActiveRecord::Base
 
   has_and_belongs_to_many :categories
+  has_many :category_relevant_questions,
+    through: :categories, source: :relevant_questions
   has_many :entity_notice_roles, dependent: :destroy
   has_many :entities, through: :entity_notice_roles
   has_many :file_uploads
   has_many :infringing_urls, through: :works
-  has_many :relevant_questions, through: :categories
+  has_and_belongs_to_many :relevant_questions
 
   has_and_belongs_to_many :works
 
@@ -19,6 +21,10 @@ class Notice < ActiveRecord::Base
 
   def notice_file_content
     first_notice.read
+  end
+
+  def all_relevant_questions
+    relevant_questions | category_relevant_questions
   end
 
   private

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -46,7 +46,7 @@
   </section>
 
   <section id="relevant-questions">
-    <%= render @notice.relevant_questions %>
+    <%= render @notice.all_relevant_questions %>
   </section>
 
 </article>

--- a/db/migrate/20130530180507_create_notices_relevant_questions.rb
+++ b/db/migrate/20130530180507_create_notices_relevant_questions.rb
@@ -1,0 +1,11 @@
+class CreateNoticesRelevantQuestions < ActiveRecord::Migration
+  def change
+    create_table(:notices_relevant_questions) do |t|
+      t.belongs_to :notice
+      t.belongs_to :relevant_question
+    end
+
+    add_index(:notices_relevant_questions, :notice_id)
+    add_index(:notices_relevant_questions, :relevant_question_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130530154325) do
+ActiveRecord::Schema.define(:version => 20130530180507) do
 
   create_table "categories", :force => true do |t|
     t.string "name"
@@ -125,6 +125,14 @@ ActiveRecord::Schema.define(:version => 20130530154325) do
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end
+
+  create_table "notices_relevant_questions", :force => true do |t|
+    t.integer "notice_id"
+    t.integer "relevant_question_id"
+  end
+
+  add_index "notices_relevant_questions", ["notice_id"], :name => "index_notices_relevant_questions_on_notice_id"
+  add_index "notices_relevant_questions", ["relevant_question_id"], :name => "index_notices_relevant_questions_on_relevant_question_id"
 
   create_table "notices_works", :id => false, :force => true do |t|
     t.integer  "notice_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,16 +4,6 @@ FactoryGirl.define do
 
   factory :category do
     name "Category name"
-
-    trait :with_questions do
-      ignore do
-        questions { build_list(:relevant_question, 3) }
-      end
-
-      before(:create) do |category, evaluator|
-        category.relevant_questions = evaluator.questions
-      end
-    end
   end
 
   factory :notice do
@@ -32,17 +22,6 @@ FactoryGirl.define do
     trait :with_categories do
       before(:create) do |notice|
         notice.categories = build_list(:category, 3)
-      end
-    end
-
-    trait :with_questions do
-      ignore do
-        questions { build_list(:relevant_question, 3) }
-      end
-
-      before(:create) do |notice, evaluator|
-        notice.categories <<
-          create(:category, :with_questions, questions: evaluator.questions)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,9 +13,15 @@ Spork.prefork do
   require 'rspec/autorun'
   require 'capybara/rspec'
   DatabaseCleaner.strategy = :truncation
+
+  # https://github.com/sporkrb/spork/issues/188
+  ActiveRecord::Base.remove_connection
 end
 
 Spork.each_run do
+  # https://github.com/sporkrb/spork/issues/188
+  ActiveRecord::Base.establish_connection
+
   Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
   RSpec.configure do |config|

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -44,22 +44,23 @@ describe 'notices/show.html.erb' do
     end
   end
 
-  it "displays a notice with relevant questions" do
-    notice = create(:notice, :with_questions, questions: [
-      q1 = create(:relevant_question, question: "Q 1", answer: "A 1"),
-      q2 = create(:relevant_question, question: "Q 2", answer: "A 2")
-    ])
-    assign(:notice, notice)
+  it "displays a notice with all relevant questions" do
+    category_question = create(:relevant_question, question: "Q 1", answer: "A 1")
+    notice_question = create(:relevant_question, question: "Q 2", answer: "A 2")
+    assign(:notice, create(:notice,
+      categories: [create(:category, relevant_questions: [category_question])],
+      relevant_questions: [notice_question]
+    ))
 
     render
 
     within('#relevant-questions') do
-      within("#relevant_question_#{q1.id}") do
+      within("#relevant_question_#{category_question.id}") do
         expect(page).to have_content("Q 1")
         expect(page).to have_content("A 1")
       end
 
-      within("#relevant_question_#{q2.id}") do
+      within("#relevant_question_#{notice_question.id}") do
         expect(page).to have_content("Q 2")
         expect(page).to have_content("A 2")
       end


### PR DESCRIPTION
Modifies the Notice API, adding #all_relevant_questions, for use by the 
frontend to display all direct and from-category related questions.
