### PR TITLE
Display recipient and submitter entities on notices.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'ancestry'
 gem 'devise'
 gem 'rails_admin', '~>0.4.8'
 gem 'redcarpet', '~>2.3.0'
+gem 'country_select'
 
 group :assets do
   gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.6.2)
+    country_select (1.1.3)
     database_cleaner (1.0.1)
     debug_inspector (0.0.2)
     delayed_job (4.0.0.beta1)
@@ -296,6 +297,7 @@ DEPENDENCIES
   bourne
   capybara-webkit (~> 1.0.0)
   coffee-rails
+  country_select
   database_cleaner
   delayed_job_active_record (>= 4.0.0.beta2)
   devise

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -22,7 +22,8 @@ class SubmissionsController < ApplicationController
 
   def submission_params
     params.require(:submission).permit(
-      :title, :body, :date_received, :file, :tag_list, category_ids: [], entities: [:name, :role]
+      :title, :body, :date_received, :file, :tag_list, category_ids: [],
+      entities: valid_entity_fields
     )
   end
 
@@ -30,6 +31,11 @@ class SubmissionsController < ApplicationController
     error_message = errors.full_messages.join(', ')
 
     render text: error_message, status: :bad_request
+  end
+
+  def valid_entity_fields
+    [:name, :role, :address_line_1, :address_line_2, :city, :state, :zip,
+      :country_code, :phone, :email, :url]
   end
 
 end

--- a/app/helpers/submission_helper.rb
+++ b/app/helpers/submission_helper.rb
@@ -2,15 +2,22 @@ module SubmissionHelper
 
   def entity_form_input(form, entity_type)
     output = ''
-    output << form.input(
-      :name,
-      required: false,
-      label: "#{entity_type} Name",
-      input_html: {
-        name: 'submission[entities][][name]',
-        id: "submission_entities_#{entity_type.downcase}_name"
-      }
-    )
+    [
+      :name, :address_line_1, :address_line_2, :city, :state, :zip,
+      :country_code, :phone, :email, :url
+    ].each do |field_name|
+
+      output << form.input(
+        field_name,
+        required: false,
+        label: "#{entity_type} #{field_name.to_s.titleize}",
+        input_html: {
+          name: "submission[entities][][#{field_name}]",
+          id: "submission_entities_#{entity_type.downcase}_#{field_name}"
+        }
+      )
+    end
+
     output << form.input(
       :role,
       as: :hidden,

--- a/app/models/associates_entities.rb
+++ b/app/models/associates_entities.rb
@@ -1,0 +1,38 @@
+class AssociatesEntities
+
+  def initialize(entity_params, notice, submission)
+    @entity_params = entity_params
+    @notice = notice
+    @submission = submission
+  end
+
+  def associate_entity_models
+    if entities_to_associate?
+      @entity_params.map do|entity_param|
+        entity = Entity.new(valid_entity_params(entity_param))
+        @submission.models << entity
+        @submission.models << EntityNoticeRole.new(
+          notice: @notice,
+          entity: entity,
+          name: entity_param[:role]
+        )
+      end
+    end
+  end
+
+  private
+
+  def valid_entity_params(entity)
+    entity.slice(
+      :name, :kind, :address_line_1, :address_line_1, :address_line_2,
+      :city, :state, :zip, :country_code, :phone, :email, :url
+    )
+  end
+
+  def entities_to_associate?
+    @entity_params.present? &&
+      @entity_params.all? do |entity|
+        entity[:name].present? && entity[:role].present?
+      end
+  end
+end

--- a/app/models/entity_notice_role.rb
+++ b/app/models/entity_notice_role.rb
@@ -4,6 +4,15 @@ class EntityNoticeRole < ActiveRecord::Base
 
   ROLES = %w[principal agent recipient submitter target]
 
+  class << self
+    ROLES.each do |role|
+      define_method(role.pluralize.to_sym) do
+        where(name: role)
+      end
+    end
+  end
+
   validates_presence_of :entity, :notice, :name
   validates_inclusion_of :name, in: ROLES
+
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -27,9 +27,26 @@ class Notice < ActiveRecord::Base
     relevant_questions | category_relevant_questions
   end
 
+  def submitter
+    entities_that_have_submitted.first
+  end
+
+  def recipient
+    entities_that_have_received.first
+  end
+
   private
 
   def first_notice
     file_uploads.notices.first || NullFileUpload.new
   end
+
+  def entities_that_have_submitted
+    entity_notice_roles.submitters.map(&:entity)
+  end
+
+  def entities_that_have_received
+    entity_notice_roles.recipients.map(&:entity)
+  end
+
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -29,9 +29,7 @@ class Submission
       models << FileUpload.new(file: @file, kind: :notice, notice: notice)
     end
 
-    if @entities.present?
-      associate_new_entities_with_notice @entities, notice
-    end
+    AssociatesEntities.new(@entities, notice, self).associate_entity_models
   end
 
   def save
@@ -44,24 +42,11 @@ class Submission
     Category.all
   end
 
-  private
-
-  def associate_new_entities_with_notice(entities, notice)
-    entities.each do |entity_hash|
-      name = entity_hash[:name]
-      role = entity_hash[:role]
-
-      if name.present?
-        entity = Entity.new(name: name)
-        entity_notice_role = EntityNoticeRole.new(
-          entity: entity, notice: notice, name: role
-        )
-
-        models << entity
-        models << entity_notice_role
-      end
-    end
+  def models
+    @models ||= []
   end
+
+  private
 
   def all_models_valid?
     models.all?(&:valid?)
@@ -69,10 +54,6 @@ class Submission
 
   def save_all_models
     models.all?(&:save)
-  end
-
-  def models
-    @models ||= []
   end
 
 end

--- a/app/views/entities/_entity.html.erb
+++ b/app/views/entities/_entity.html.erb
@@ -1,0 +1,6 @@
+<section class="<%= css_class %>">
+<h6><%= entity.name %></h6>
+<span><%= entity.address_line_1 %></span>
+<span><%= entity.address_line_2 %></span>
+<span><%= entity.city %>, <%= entity.state %>, <%= entity.zip %>, <%= entity.country_code %></span>
+</section>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -3,20 +3,13 @@
   <span class="date-recieved">Date Received: <time datetime="<%= @notice.date_received %>"><%= @notice.date_received %></time></span>
 
   <section class="body">
-    <header class="wip">
-      <section class="reciever">
-        <h6>Recipient</h6>
-        <span>[Private]</span>
-        <span>Google, Inc. [Blogger]</span>
-        <span>Mountain View, CA, 94043, USA</span>
-      </section>
-      <section class="sender">
-        <h6>Sender</h6>
-        <span>Jan Krohn</span>
-        <span>Sent by: [Private]</span>
-        <span>[Private]</span>
-        <span>KH</span>
-      </section>
+    <header id="entities" class="wip">
+      <% if @notice.recipient %>
+        <%= render @notice.recipient, css_class: 'reciever' %>
+      <% end %>
+      <% if @notice.submitter %>
+        <%= render @notice.submitter,  css_class: 'sender' %>
+      <% end %>
     </header>
 
     <div class="main">
@@ -45,10 +38,6 @@
       <%= render 'shared/category_list', categories: @notice.categories %>
     </section>
   </footer>
-
-  <section id="entities">
-    <%= render @notice.entity_notice_roles %>
-  </section>
 
   <section id="relevant-questions">
     <%= render @notice.all_relevant_questions %>

--- a/db/migrate/20130531181449_add_city_to_entities.rb
+++ b/db/migrate/20130531181449_add_city_to_entities.rb
@@ -1,0 +1,6 @@
+class AddCityToEntities < ActiveRecord::Migration
+  def change
+    add_column :entities, :city, :string
+    add_column :entities, :zip, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130531170647) do
+ActiveRecord::Schema.define(:version => 20130531181449) do
 
   create_table "categories", :force => true do |t|
     t.string "name"
@@ -76,6 +76,8 @@ ActiveRecord::Schema.define(:version => 20130531170647) do
     t.string "email"
     t.string "url"
     t.string "ancestry"
+    t.string "city"
+    t.string "zip"
   end
 
   add_index "entities", ["ancestry"], :name => "index_entities_on_ancestry"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -9,6 +9,9 @@ FactoryGirl.define do
   end
 
   factory :notice do
+    ignore do
+      roles_for_entities { ['principal'] }
+    end
     title "A title"
 
     trait :with_body do
@@ -48,9 +51,14 @@ FactoryGirl.define do
       end
     end
 
-    factory :notice_with_entities do
-      after(:create) do |notice|
-        create(:entity_notice_role, notice: notice, entity: create(:entity))
+    trait :with_entities do
+      after(:create) do |notice, instance|
+        instance.roles_for_entities.each do |role|
+          create(
+            :entity_notice_role, notice: notice, entity: create(:entity, name: "#{role} name"),
+            name: role
+          )
+        end
       end
     end
   end
@@ -73,12 +81,21 @@ FactoryGirl.define do
   factory :entity_notice_role do
     notice { build(:notice) }
     entity { build(:entity) }
-    name { 'principal' }
+    name 'principal'
   end
 
   factory :entity do
     name "A name"
     kind "individual"
+    address_line_1 "Address 1"
+    address_line_2 "Address 2"
+    city "City"
+    state "State"
+    zip "01222"
+    country_code "US"
+    phone "555-555-1212"
+    email "foo@example.com"
+    url "http://www.example.com"
 
     factory :entity_with_children do
       after(:create) do |parent_entity|

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -77,6 +77,12 @@ feature "notice submission" do
     visit "/submissions/new"
     fill_in "Title", with: "A title"
     fill_in "Recipient Name", with: "Recipient the first"
+    fill_in "Recipient Address Line 1", with: "Recipient Line 1"
+    fill_in "Recipient Address Line 2", with: "Recipient Line 2"
+    fill_in "Recipient City", with: "Recipient City"
+    fill_in "Recipient State", with: "Recipient State"
+    select "United States", from: "Recipient Country Code"
+
     fill_in "Submitter Name", with: "Submitter the first"
     fill_in "Date received", with: Time.now
 
@@ -85,6 +91,12 @@ feature "notice submission" do
     click_on 'A title'
     within('#entities') do
       expect(page).to have_content "Recipient the first"
+      expect(page).to have_content "Recipient Line 1"
+      expect(page).to have_content "Recipient Line 2"
+      expect(page).to have_content "Recipient City"
+      expect(page).to have_content "Recipient State"
+      expect(page).to have_content "United States"
+
       expect(page).to have_content "Submitter the first"
     end
   end

--- a/spec/models/associates_entities_spec.rb
+++ b/spec/models/associates_entities_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe AssociatesEntities do
+
+  context '#associater' do
+    it 'does nothing if there are no valid entities' do
+      entity_params = nil
+      associater = described_class.new(entity_params, double(), double())
+
+      Entity.should_not_receive(:new)
+      EntityNoticeRole.should_not_receive(:new)
+
+      associater.associate_entity_models
+    end
+
+    it 'initializes an Entity with the correct metadata' do
+      Entity.should_receive(:new).with(
+        example_entity.slice(*entity_specific_params)
+      )
+      with_valid_associater do |associater, notice, submission|
+        associater.associate_entity_models
+      end
+    end
+
+    it 'initializes the EntityNoticeRole correctly' do
+      with_valid_associater do |associater, notice, submission|
+        entity_instance = Entity.new
+        Entity.stub(:new).and_return(entity_instance)
+        EntityNoticeRole.should_receive(:new).with(
+          notice: notice, name: example_entity[:role], entity: entity_instance
+        )
+        associater.associate_entity_models
+      end
+    end
+
+    it 'appends to Submission#models' do
+      with_valid_associater do |associater, notice, submission|
+        associater.associate_entity_models
+        expect(submission.models.count).to eq 3
+      end
+    end
+  end
+
+  private
+
+  def example_entity
+    { name: 'An entity name',
+      role: 'submitter',
+      address_line_1: '17 Foobar ave',
+      address_line_2: 'Suite 1337',
+      city: 'Fooville',
+      state: 'MA',
+      country_code: 'US',
+      phone: '781-555-1212',
+      email: 'entity@example.com',
+      url: 'http://www.example.com'
+    }
+  end
+
+  def entity_specific_params
+    [
+      :name, :kind, :address_line_1, :address_line_1, :address_line_2,
+      :city, :state, :country_code, :phone, :email, :url
+    ]
+  end
+
+
+  def with_valid_associater
+    entity_params = [
+      example_entity
+    ]
+    notice = Notice.new
+    submission = Submission.new
+    associater = described_class.new(entity_params, notice, submission)
+    yield associater, notice, submission
+  end
+end

--- a/spec/models/entity_notice_role_spec.rb
+++ b/spec/models/entity_notice_role_spec.rb
@@ -9,4 +9,25 @@ describe EntityNoticeRole do
   it{ should have_db_index :entity_id }
   it{ should have_db_index :notice_id }
   it{ should ensure_inclusion_of(:name).in_array(EntityNoticeRole::ROLES) }
+
+  EntityNoticeRole::ROLES.each do |role|
+    context "getting #{role} instances" do
+      it 'returns the correct role' do
+        instance_with_role = create(:entity_notice_role, name: role)
+        create(:entity_notice_role, name: a_different_role_than(role))
+
+        expect(described_class.all.count).to eq 2
+        expect(described_class.send(role.pluralize.to_sym)).to eq [instance_with_role]
+      end
+    end
+  end
+
+  private
+
+  def a_different_role_than(role)
+    roles = EntityNoticeRole::ROLES.dup
+    roles.delete(role)
+    roles.first
+  end
+
 end

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -22,7 +22,7 @@ describe Notice do
 
       expect(notice.notice_file_content).to eq ''
     end
-  end
+    end
 
   context "#recent" do
     it "returns notices sent in the past week" do
@@ -64,13 +64,39 @@ describe Notice do
     end
   end
 
-  context "notice roles" do
-    it "cleans up notice roles after a notice is destroyed" do
+  context "entity notice roles" do
+    it "clean up notice roles after a notice is destroyed" do
       entity = create(:entity_with_notice_roles)
       notice = entity.notices.first
 
       EntityNoticeRole.any_instance.should_receive(:destroy)
       notice.destroy
+    end
+
+    context 'with entities' do
+      it "has submitters" do
+        notice = create(
+          :notice, :with_entities, roles_for_entities: ['submitter']
+        )
+        expect(notice.submitter).to be_instance_of(Entity)
+        expect(notice.submitter).to eq entity_for_role_from_notice(notice, 'submitter')
+      end
+
+      it "has recipients" do
+        notice = create(
+          :notice, :with_entities, roles_for_entities: ['recipient']
+        )
+        expect(notice.recipient).to be_instance_of(Entity)
+        expect(notice.recipient).to eq entity_for_role_from_notice(notice, 'recipient')
+      end
+    end
+
+    context "without notice roles" do
+      it "returns nil for recipient and submitter" do
+        notice = create(:notice)
+        expect(notice.recipient).to be_nil
+        expect(notice.submitter).to be_nil
+      end
     end
   end
 
@@ -112,5 +138,9 @@ describe Notice do
 
       expect(questions).to match_array %w( Q1 Q2 )
     end
+  end
+
+  def entity_for_role_from_notice(notice, role)
+    notice.entity_notice_roles.where(name: role).first.entity
   end
 end

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -32,14 +32,23 @@ describe 'notices/show.html.erb' do
   end
 
   it "displays a notice with entities" do
-    notice = create(:notice_with_entities)
+    notice = create(
+      :notice,
+      :with_entities, roles_for_entities: ['submitter', 'recipient']
+    )
+
     assign(:notice, notice)
 
     render
 
     within('#entities') do |node|
       notice.entities.each do |entity|
-        expect(node).to have_content(entity.name)
+        expect(page).to have_content(entity.name)
+        expect(page).to have_content(entity.address_line_1)
+        expect(page).to have_content(entity.address_line_2)
+        expect(page).to have_content(entity.city)
+        expect(page).to have_content(entity.state)
+        expect(page).to have_content(entity.country_code)
       end
     end
   end
@@ -81,4 +90,5 @@ describe 'notices/show.html.erb' do
       end
     end
   end
+
 end


### PR DESCRIPTION
- Add scopes for each EntityNoticeRole role.
- Submitter and recipient instance methods on notices
- Entity and role associations extracted to the AssociatesEntities class
- Add missing entity metadata
- Display most metadata in forms and views.
- Add the country_select gem for simple_form
