### PR TITLE
Add works through the API and HTML forms

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -16,9 +16,12 @@ class SubmissionsController < ApplicationController
   private
 
   def submission_params
+    transform_html_parameters
+
     params.require(:submission).permit(
       :title, :body, :date_received, :source, :file, :tag_list,
-      category_ids: [], entities: valid_entity_fields
+      category_ids: [], entities: valid_entity_fields,
+      works: [:url, :description, :kind, infringing_urls: []]
     )
   end
 
@@ -47,6 +50,16 @@ class SubmissionsController < ApplicationController
   def valid_entity_fields
     [:name, :role, :address_line_1, :address_line_2, :city, :state, :zip,
       :country_code, :phone, :email, :url]
+  end
+
+  def transform_html_parameters
+    if html_format?
+      NormalizesParameters.normalize(params)
+    end
+  end
+
+  def html_format?
+    request.format.html?
   end
 
 end

--- a/app/models/associates_entities.rb
+++ b/app/models/associates_entities.rb
@@ -6,7 +6,7 @@ class AssociatesEntities
     @submission = submission
   end
 
-  def associate_entity_models
+  def associate
     if entities_to_associate?
       @entity_params.map do|entity_param|
         entity = Entity.new(valid_entity_params(entity_param))

--- a/app/models/associates_works.rb
+++ b/app/models/associates_works.rb
@@ -1,0 +1,39 @@
+class AssociatesWorks
+
+  def initialize(works_params, notice, submission)
+    @works_params = works_params
+    @notice = notice
+    @submission = submission
+  end
+
+  def associate
+    if works_to_associate?
+      @works_params.map do |work_param|
+        work = Work.find_or_initialize_by_url(
+          work_param[:url],
+          description: work_param[:description],
+          kind: work_param[:kind]
+        )
+        @notice.works << work
+
+        @submission.models << work
+
+        work_param[:infringing_urls].each do |infringing_url_param|
+          infringing_url =
+            InfringingUrl.find_or_initialize_by_url(infringing_url_param)
+          work.infringing_urls << infringing_url
+          @submission.models << infringing_url
+        end
+      end
+    end
+  end
+
+  private
+
+  def works_to_associate?
+    @works_params.present? &&
+      @works_params.all? do |work|
+        work[:url].present? && work[:infringing_urls].present?
+      end
+  end
+end

--- a/app/models/normalizes_parameters.rb
+++ b/app/models/normalizes_parameters.rb
@@ -1,0 +1,22 @@
+class NormalizesParameters
+
+  def self.normalize(params)
+    @params = params
+    if has_works_parameters?
+      works_parameters.each do |work_param_hash|
+        work_param_hash[:infringing_urls] =
+          work_param_hash[:infringing_urls].split(/\r?\n/)
+      end
+    end
+  end
+
+  private
+
+  def self.has_works_parameters?
+    works_parameters
+  end
+
+  def self.works_parameters
+    @params[:submission][:works]
+  end
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -4,7 +4,7 @@ class Submission
   include PsuedoModel
 
   attr_reader :title, :body, :date_received, :source, :file, :tag_list,
-    :category_ids
+    :category_ids, :works
 
   validates_presence_of :title
 
@@ -17,6 +17,7 @@ class Submission
     @tag_list = params[:tag_list]
     @category_ids = params[:category_ids]
     @entities = params[:entities]
+    @works = params[:works]
   end
 
   def save
@@ -28,7 +29,9 @@ class Submission
       models << file_upload
     end
 
-    AssociatesEntities.new(entities, notice, self).associate_entity_models
+    AssociatesEntities.new(entities, notice, self).associate
+
+    AssociatesWorks.new(works, notice, self).associate
 
     if valid? && all_models_valid?
       save_all_models

--- a/app/views/submissions/_works_form.html.erb
+++ b/app/views/submissions/_works_form.html.erb
@@ -1,0 +1,40 @@
+<%= form.input(
+  :url,
+  required: false,
+  label: "Work URL",
+  input_html: {
+    name: "submission[works][][url]",
+    id: "submission_works__url"}
+ )
+%>
+
+<%= form.input(
+  :kind,
+  required: false,
+  label: "Kind of Work",
+  input_html: {
+    name: "submission[works][][kind]",
+    id: "submission_works__kind"}
+ )
+%>
+
+<%= form.input(
+  :description,
+  required: false,
+  label: "Work Description",
+  input_html: {
+    name: "submission[works][][description]",
+    id: "submission_works__description"}
+ )
+%>
+
+<%= form.input(
+  :infringing_urls,
+  as: :text,
+  required: false,
+  label: "Infringing URLs",
+  input_html: {
+    name: "submission[works][][infringing_urls]",
+    id: "submission_works__infringing_urls"}
+ )
+%>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -17,7 +17,12 @@
     <%= raw entity_form_input(entity_form, 'Submitter') %>
   <% end %>
 
+  <%= form.fields_for(:works) do |works_form| %>
+    <%= render partial: 'works_form', locals: { form: works_form } %>
+  <% end %>
+
   <%= form.input :file, as: :file, label: 'Notice File' %>
+
   <div class="buttons-wrapper">
     <%= form.submit "Submit", :class => "submit" %>
   </div>

--- a/app/views/works/_work.html.erb
+++ b/app/views/works/_work.html.erb
@@ -1,5 +1,6 @@
 <%= content_tag_for(:li, work) do %>
   <h6>Copyright claim: #<%= work_counter %></h6>
+  <p>Kind of Work: <%= work.kind %></p>
   <p>Description: <%= work.description %></p>
   <p>URL: <%= work.url %></p>
   <ol>

--- a/db/migrate/20130604134719_add_kind_to_works.rb
+++ b/db/migrate/20130604134719_add_kind_to_works.rb
@@ -1,0 +1,5 @@
+class AddKindToWorks < ActiveRecord::Migration
+  def change
+    add_column :works, :kind, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130603172405) do
+ActiveRecord::Schema.define(:version => 20130604134719) do
 
   create_table "categories", :force => true do |t|
     t.string "name"
@@ -200,6 +200,7 @@ ActiveRecord::Schema.define(:version => 20130603172405) do
     t.text     "description"
     t.datetime "created_at",                  :null => false
     t.datetime "updated_at",                  :null => false
+    t.string   "kind"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -125,22 +125,6 @@ CategoryManager.create!(
 )
 
 ################################################################################
-# Works
-################################################################################
-urls = []
-urls << InfringingUrl.create!(url: "http://example.com/bad_url_1")
-urls << InfringingUrl.create!(url: "http://example.com/bad_url_2")
-urls << InfringingUrl.create!(url: "http://example.com/bad_url_3")
-urls << InfringingUrl.create!(url: "http://example.com/bad_url_4")
-urls << InfringingUrl.create!(url: "http://example.com/bad_url_5")
-
-work = Work.create!(
-  url: "http://disney.com/lion_king.mp4",
-  description: "Lion King Video",
-  infringing_urls: urls
-)
-
-################################################################################
 # Submissions
 ################################################################################
 Submission.new(
@@ -148,6 +132,17 @@ Submission.new(
   date_received: Time.now,
   category_ids: [dmca, bookmarks, chilling].map(&:id),
   tag_list: 'movies, disney, youtube',
+  works: [ {
+    url: "http://disney.com/lion_king.mp4",
+    description: "Lion King Video",
+    infringing_urls: [
+      'http://example.com/bad_url_1',
+      'http://example.com/bad_url_2',
+      'http://example.com/bad_url_3',
+      'http://example.com/bad_url_4',
+      'http://example.com/bad_url_5',
+    ],
+  }],
   entities: [
     { name: 'Google',
       kind: 'organization',
@@ -168,8 +163,3 @@ Submission.new(
       country_code: 'US' }
   ]
 ).save
-
-# TODO: add works/urls via submission interface
-notice = Notice.last
-notice.works << work
-notice.save!

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -32,6 +32,11 @@ describe SubmissionsController do
 
       expect(response.body).to include "Title can't be blank"
     end
+
+    it "does not normalize parameters" do
+      NormalizesParameters.should_not_receive(:normalize)
+      post_valid_submission
+    end
   end
 
   context "#create from HTML" do
@@ -46,7 +51,14 @@ describe SubmissionsController do
 
       expect(response).to render_template(:new)
     end
+
+    it "normalizes HTML form parameters" do
+      NormalizesParameters.should_receive(:normalize)
+      post_valid_submission(format: :html)
+    end
   end
+
+
 
   private
 

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -77,6 +77,30 @@ feature "notice submission" do
     end
   end
 
+  scenario "submitting a notice with works" do
+    submit_recent_notice do
+      fill_in 'Work URL', with: 'http://www.example.com/original_work.pdf'
+      fill_in 'Kind of Work', with: 'movie'
+      fill_in 'Work Description', with: 'A series of videos and still images'
+      fill_in 'Infringing URLs', with: "http://example.com/infringing_url1
+http://example.com/infringing_url2"
+    end
+
+    open_recent_notice
+
+    within('#works') do
+      expect(page).to have_content 'http://www.example.com/original_work.pdf'
+      expect(page).to have_content 'movie'
+      expect(page).to have_content 'A series of videos and still images'
+      expect(page).to have_css(
+        %{.infringing_url:contains("http://example.com/infringing_url1")}
+      )
+      expect(page).to have_css(
+        %{.infringing_url:contains("http://example.com/infringing_url2")}
+      )
+    end
+  end
+
   scenario "submitting a notice with a source" do
     submit_recent_notice do
       fill_in "Sent via", with: "Arbitrary source"

--- a/spec/models/associates_entities_spec.rb
+++ b/spec/models/associates_entities_spec.rb
@@ -10,7 +10,7 @@ describe AssociatesEntities do
       Entity.should_not_receive(:new)
       EntityNoticeRole.should_not_receive(:new)
 
-      associater.associate_entity_models
+      associater.associate
     end
 
     it 'initializes an Entity with the correct metadata' do
@@ -18,7 +18,7 @@ describe AssociatesEntities do
         example_entity.slice(*entity_specific_params)
       )
       with_valid_associater do |associater, notice, submission|
-        associater.associate_entity_models
+        associater.associate
       end
     end
 
@@ -29,13 +29,13 @@ describe AssociatesEntities do
         EntityNoticeRole.should_receive(:new).with(
           notice: notice, name: example_entity[:role], entity: entity_instance
         )
-        associater.associate_entity_models
+        associater.associate
       end
     end
 
     it 'appends the correct models to Submission#models' do
       with_valid_associater do |associater, notice, submission|
-        associater.associate_entity_models
+        associater.associate
         expect(submission.models.detect { |m| m.is_a?(Entity) }).to be
         expect(submission.models.detect { |m| m.is_a?(EntityNoticeRole) }).to be
       end

--- a/spec/models/associates_works_spec.rb
+++ b/spec/models/associates_works_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe AssociatesWorks do
+  it 'does nothing if there are no valid works' do
+    associater = described_class.new(nil, double(), double())
+
+    Work.should_not_receive(:new)
+    InfringingUrl.should_not_receive(:new)
+    associater.associate
+  end
+
+
+  it 'initializes a Work properly' do
+    Work.should_receive(:find_or_initialize_by_url).with(
+      'http://www.example.com/original_work.pdf',
+      description: 'a heartbreaking work of staggering genius',
+      kind: 'book'
+    ).and_return(Work.new)
+
+    with_valid_associater do |associater, notice, submission|
+      associater.associate
+    end
+  end
+
+  it 'initializes InfringingUrls properly' do
+    InfringingUrl.should_receive(:find_or_initialize_by_url).with(
+      'http://www.example.com/infringing_url'
+    ).and_return(InfringingUrl.new)
+
+    with_valid_associater do |associater, notice, submission|
+      associater.associate
+    end
+
+  end
+
+  def with_valid_associater
+    works_params = [
+      example_work
+    ]
+    notice = Notice.new
+    submission = Submission.new
+    associater = described_class.new(works_params, notice, submission)
+    yield associater, notice, submission
+  end
+
+  def example_infringing_urls
+    [
+      'http://www.example.com/infringing_url',
+    ]
+  end
+
+  def example_work
+    {
+      url: 'http://www.example.com/original_work.pdf',
+      description: 'a heartbreaking work of staggering genius',
+      kind: 'book',
+      infringing_urls: example_infringing_urls
+    }
+  end
+
+end

--- a/spec/models/normalizes_parameters_spec.rb
+++ b/spec/models/normalizes_parameters_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe NormalizesParameters do
+
+  context 'with infringing_urls parameters' do
+    it "modifies correctly when given \\n separated urls" do
+      params = example_params_with_infringing_urls("foo\nbar")
+      described_class.normalize(params)
+
+      expect(
+        params[:submission][:works][0][:infringing_urls]
+      ).to eq ['foo','bar']
+    end
+
+    it "modifies correctly when given \\r\\n separated urls" do
+      params = example_params_with_infringing_urls("foo\r\nbar")
+      described_class.normalize(params)
+
+      expect(
+        params[:submission][:works][0][:infringing_urls]
+      ).to eq ['foo','bar']
+    end
+  end
+
+  context 'without infringing_urls parameter' do
+    it 'does not modify the params' do
+      params = { submission: {} }
+      described_class.normalize(params)
+
+      expect(params).to eq params
+    end
+  end
+
+  private
+
+  def example_params_with_infringing_urls(infringing_urls_parameter)
+    {submission: { works: [{ infringing_urls: infringing_urls_parameter }] } }
+  end
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -82,6 +82,37 @@ describe Submission do
     expect(Notice.last.source).to eq "Arbitrary source"
   end
 
+  context "works" do
+    it "creates works with metadata" do
+      submission = Submission.new(
+        title: "A title",
+        works: [
+          { url: 'http://www.example.com/original_work.pdf',
+            description: 'Video and images produced by Foocorp',
+            infringing_urls: [
+              'http://www.example.com/infringing_url1',
+              'http://www.example.com/infringing_url2',
+              'http://www.example.com/infringing_url3',
+              'http://www.example.com/infringing_url4'
+            ]
+          }
+        ]
+      )
+      submission.save
+
+      notice = Notice.last
+      work = notice.works.first
+      expect(notice.works.count).to eq 1
+      expect(work.url).to eq 'http://www.example.com/original_work.pdf'
+      expect(work.infringing_urls.map(&:url)).to eq [
+          'http://www.example.com/infringing_url1',
+          'http://www.example.com/infringing_url2',
+          'http://www.example.com/infringing_url3',
+          'http://www.example.com/infringing_url4'
+      ]
+    end
+  end
+
   private
 
   def with_tempfile(&block)


### PR DESCRIPTION
- Use the Submission composite to accept works attributes, including
  InfringingURLs
- Mutate the infringing_url parameters in the controller in HTML context.
- Add AssociatesWorks class to Work / InfringingURL association.
