### PR TITLE
Integrate schema_migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'devise'
 gem 'rails_admin', '~>0.4.8'
 gem 'redcarpet', '~>2.3.0'
 gem 'country_select'
+gem 'schema_validations'
 
 group :assets do
   gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,11 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
+    schema_plus (1.1.2)
+      rails (>= 3.2)
+      valuable
+    schema_validations (0.2.2)
+      schema_plus
     sham_rack (1.3.6)
       rack
     shoulda-matchers (2.1.0)
@@ -278,6 +283,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    valuable (0.9.8)
     warden (1.2.1)
       rack (>= 1.0)
     xpath (2.0.0)
@@ -321,6 +327,7 @@ DEPENDENCIES
   redcarpet (~> 2.3.0)
   rspec-rails
   sass-rails
+  schema_validations
   sham_rack
   shoulda-matchers
   simple_form

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,11 +1,8 @@
 class Category < ActiveRecord::Base
-
   has_and_belongs_to_many :notices
   has_and_belongs_to_many :relevant_questions
 
   has_ancestry
-
-  validates_presence_of :name
 
   def description_html
     Markdown.render(description.to_s)

--- a/app/models/category_manager.rb
+++ b/app/models/category_manager.rb
@@ -1,7 +1,3 @@
 class CategoryManager < ActiveRecord::Base
-
   has_and_belongs_to_many :categories
-
-  validates_presence_of :name
-
 end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -5,6 +5,5 @@ class Entity < ActiveRecord::Base
 
   KINDS = %w[organization individual]
 
-  validates_presence_of :name, :kind
   validates_inclusion_of :kind, in: KINDS
 end

--- a/app/models/entity_notice_role.rb
+++ b/app/models/entity_notice_role.rb
@@ -12,7 +12,6 @@ class EntityNoticeRole < ActiveRecord::Base
     end
   end
 
-  validates_presence_of :entity, :notice, :name
   validates_inclusion_of :name, in: ROLES
 
 end

--- a/app/models/infringing_url.rb
+++ b/app/models/infringing_url.rb
@@ -2,7 +2,5 @@ class InfringingUrl < ActiveRecord::Base
   has_and_belongs_to_many :works
   has_many :notices, through: :works
 
-  validates_presence_of :url
-  validates_length_of :url, maximum: 1.kilobyte
   validates_format_of :url, with: /^([a-z]{3,5}:)?\/\/.+/i
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -13,8 +13,6 @@ class Notice < ActiveRecord::Base
 
   acts_as_taggable
 
-  validates_presence_of :title
-
   def self.recent
     where('date_received > ?', 1.week.ago).order('date_received DESC')
   end

--- a/app/models/relevant_question.rb
+++ b/app/models/relevant_question.rb
@@ -1,8 +1,5 @@
 class RelevantQuestion < ActiveRecord::Base
 
-  validates_presence_of :question
-  validates_presence_of :answer
-
   def answer_html
     Markdown.render(answer.to_s)
   end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -2,7 +2,5 @@ class Work < ActiveRecord::Base
   has_and_belongs_to_many :notices
   has_and_belongs_to_many :infringing_urls
 
-  validates_presence_of :url
-  validates_length_of :url, maximum: 1.kilobyte
   validates_format_of :url, with: /^([a-z]{3,5}:)?\/\/.+/i
 end

--- a/config/initializers/schema_plus.rb
+++ b/config/initializers/schema_plus.rb
@@ -1,0 +1,1 @@
+SchemaPlus.config.foreign_keys.auto_create = false

--- a/db/migrate/20130604155451_schema_validation_fixes.rb
+++ b/db/migrate/20130604155451_schema_validation_fixes.rb
@@ -1,0 +1,16 @@
+class SchemaValidationFixes < ActiveRecord::Migration
+  def change
+    change_column :categories, :name, :string, null: false
+
+    change_column :category_managers, :name, :string, null: false
+
+    change_column :entity_notice_roles, :notice_id, :integer, null: false
+    change_column :entity_notice_roles, :entity_id, :integer, null: false
+    change_column :entity_notice_roles, :name, :string, null: false
+
+    change_column :notices, :title, :string, null: false
+
+    change_column :relevant_questions, :question, :string, null: false
+    change_column :relevant_questions, :answer, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,42 +11,38 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130604152238) do
+ActiveRecord::Schema.define(:version => 20130604155451) do
 
   create_table "categories", :force => true do |t|
-    t.string "name"
+    t.string "name",        :null => false
     t.text   "description"
     t.string "ancestry"
+    t.index ["ancestry"], :name => "index_categories_on_ancestry", :order => {"ancestry" => :asc}
   end
-
-  add_index "categories", ["ancestry"], :name => "index_categories_on_ancestry"
 
   create_table "categories_category_managers", :force => true do |t|
     t.integer "category_id"
     t.integer "category_manager_id"
+    t.index ["category_id"], :name => "index_categories_category_managers_on_category_id", :order => {"category_id" => :asc}
+    t.index ["category_manager_id"], :name => "index_categories_category_managers_on_category_manager_id", :order => {"category_manager_id" => :asc}
   end
-
-  add_index "categories_category_managers", ["category_id"], :name => "index_categories_category_managers_on_category_id"
-  add_index "categories_category_managers", ["category_manager_id"], :name => "index_categories_category_managers_on_category_manager_id"
 
   create_table "categories_notices", :force => true do |t|
     t.integer "category_id"
     t.integer "notice_id"
+    t.index ["category_id"], :name => "index_categories_notices_on_category_id", :order => {"category_id" => :asc}
+    t.index ["notice_id"], :name => "index_categories_notices_on_notice_id", :order => {"notice_id" => :asc}
   end
-
-  add_index "categories_notices", ["category_id"], :name => "index_categories_notices_on_category_id"
-  add_index "categories_notices", ["notice_id"], :name => "index_categories_notices_on_notice_id"
 
   create_table "categories_relevant_questions", :force => true do |t|
     t.integer "category_id"
     t.integer "relevant_question_id"
+    t.index ["category_id"], :name => "index_categories_relevant_questions_on_category_id", :order => {"category_id" => :asc}
+    t.index ["relevant_question_id"], :name => "index_categories_relevant_questions_on_relevant_question_id", :order => {"relevant_question_id" => :asc}
   end
 
-  add_index "categories_relevant_questions", ["category_id"], :name => "index_categories_relevant_questions_on_category_id"
-  add_index "categories_relevant_questions", ["relevant_question_id"], :name => "index_categories_relevant_questions_on_relevant_question_id"
-
   create_table "category_managers", :force => true do |t|
-    t.string "name"
+    t.string "name", :null => false
   end
 
   create_table "delayed_jobs", :force => true do |t|
@@ -61,9 +57,8 @@ ActiveRecord::Schema.define(:version => 20130604152238) do
     t.string   "queue"
     t.datetime "created_at",                :null => false
     t.datetime "updated_at",                :null => false
+    t.index ["priority", "run_at"], :name => "delayed_jobs_priority", :order => {"priority" => :asc, "run_at" => :asc}
   end
-
-  add_index "delayed_jobs", ["priority", "run_at"], :name => "delayed_jobs_priority"
 
   create_table "entities", :force => true do |t|
     t.string "name",                                     :null => false
@@ -78,20 +73,18 @@ ActiveRecord::Schema.define(:version => 20130604152238) do
     t.string "ancestry"
     t.string "city"
     t.string "zip"
+    t.index ["ancestry"], :name => "index_entities_on_ancestry", :order => {"ancestry" => :asc}
   end
-
-  add_index "entities", ["ancestry"], :name => "index_entities_on_ancestry"
 
   create_table "entity_notice_roles", :force => true do |t|
-    t.integer  "entity_id"
-    t.integer  "notice_id"
-    t.string   "name"
+    t.integer  "entity_id",  :null => false
+    t.integer  "notice_id",  :null => false
+    t.string   "name",       :null => false
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
+    t.index ["entity_id"], :name => "index_entity_notice_roles_on_entity_id", :order => {"entity_id" => :asc}
+    t.index ["notice_id"], :name => "index_entity_notice_roles_on_notice_id", :order => {"notice_id" => :asc}
   end
-
-  add_index "entity_notice_roles", ["entity_id"], :name => "index_entity_notice_roles_on_entity_id"
-  add_index "entity_notice_roles", ["notice_id"], :name => "index_entity_notice_roles_on_notice_id"
 
   create_table "file_uploads", :force => true do |t|
     t.integer  "notice_id"
@@ -100,9 +93,8 @@ ActiveRecord::Schema.define(:version => 20130604152238) do
     t.string   "file_content_type"
     t.integer  "file_file_size"
     t.datetime "file_updated_at"
+    t.index ["notice_id"], :name => "index_file_uploads_on_notice_id", :order => {"notice_id" => :asc}
   end
-
-  add_index "file_uploads", ["notice_id"], :name => "index_file_uploads_on_notice_id"
 
   create_table "infringing_urls", :force => true do |t|
     t.string   "url",        :limit => 1024, :null => false
@@ -113,13 +105,12 @@ ActiveRecord::Schema.define(:version => 20130604152238) do
   create_table "infringing_urls_works", :id => false, :force => true do |t|
     t.integer "infringing_url_id", :null => false
     t.integer "work_id",           :null => false
+    t.index ["infringing_url_id"], :name => "index_infringing_urls_works_on_infringing_url_id", :order => {"infringing_url_id" => :asc}
+    t.index ["work_id"], :name => "index_infringing_urls_works_on_work_id", :order => {"work_id" => :asc}
   end
 
-  add_index "infringing_urls_works", ["infringing_url_id"], :name => "index_infringing_urls_works_on_infringing_url_id"
-  add_index "infringing_urls_works", ["work_id"], :name => "index_infringing_urls_works_on_work_id"
-
   create_table "notices", :force => true do |t|
-    t.string   "title"
+    t.string   "title",         :null => false
     t.text     "body"
     t.datetime "date_received"
     t.datetime "created_at",    :null => false
@@ -131,18 +122,16 @@ ActiveRecord::Schema.define(:version => 20130604152238) do
   create_table "notices_relevant_questions", :force => true do |t|
     t.integer "notice_id"
     t.integer "relevant_question_id"
+    t.index ["notice_id"], :name => "index_notices_relevant_questions_on_notice_id", :order => {"notice_id" => :asc}
+    t.index ["relevant_question_id"], :name => "index_notices_relevant_questions_on_relevant_question_id", :order => {"relevant_question_id" => :asc}
   end
-
-  add_index "notices_relevant_questions", ["notice_id"], :name => "index_notices_relevant_questions_on_notice_id"
-  add_index "notices_relevant_questions", ["relevant_question_id"], :name => "index_notices_relevant_questions_on_relevant_question_id"
 
   create_table "notices_works", :id => false, :force => true do |t|
     t.integer "notice_id"
     t.integer "work_id"
+    t.index ["notice_id"], :name => "index_notices_works_on_notice_id", :order => {"notice_id" => :asc}
+    t.index ["work_id"], :name => "index_notices_works_on_work_id", :order => {"work_id" => :asc}
   end
-
-  add_index "notices_works", ["notice_id"], :name => "index_notices_works_on_notice_id"
-  add_index "notices_works", ["work_id"], :name => "index_notices_works_on_work_id"
 
   create_table "rails_admin_histories", :force => true do |t|
     t.text     "message"
@@ -153,16 +142,15 @@ ActiveRecord::Schema.define(:version => 20130604152238) do
     t.integer  "year",       :limit => 8
     t.datetime "created_at",              :null => false
     t.datetime "updated_at",              :null => false
+    t.index ["item"], :name => "index_rails_admin_histories_on_item", :order => {"item" => :asc}
+    t.index ["month"], :name => "index_rails_admin_histories_on_month", :order => {"month" => :asc}
+    t.index ["table"], :name => "index_rails_admin_histories_on_table", :order => {"table" => :asc}
+    t.index ["year"], :name => "index_rails_admin_histories_on_year", :order => {"year" => :asc}
   end
 
-  add_index "rails_admin_histories", ["item"], :name => "index_rails_admin_histories_on_item"
-  add_index "rails_admin_histories", ["month"], :name => "index_rails_admin_histories_on_month"
-  add_index "rails_admin_histories", ["table"], :name => "index_rails_admin_histories_on_table"
-  add_index "rails_admin_histories", ["year"], :name => "index_rails_admin_histories_on_year"
-
   create_table "relevant_questions", :force => true do |t|
-    t.text "question"
-    t.text "answer"
+    t.string "question", :null => false
+    t.string "answer",   :null => false
   end
 
   create_table "taggings", :force => true do |t|
@@ -173,10 +161,9 @@ ActiveRecord::Schema.define(:version => 20130604152238) do
     t.string   "tagger_type"
     t.string   "context",       :limit => 128
     t.datetime "created_at"
+    t.index ["tag_id"], :name => "index_taggings_on_tag_id", :order => {"tag_id" => :asc}
+    t.index ["taggable_id", "taggable_type", "context"], :name => "index_taggings_on_taggable_id_and_taggable_type_and_context", :order => {"taggable_id" => :asc, "taggable_type" => :asc, "context" => :asc}
   end
-
-  add_index "taggings", ["tag_id"], :name => "index_taggings_on_tag_id"
-  add_index "taggings", ["taggable_id", "taggable_type", "context"], :name => "index_taggings_on_taggable_id_and_taggable_type_and_context"
 
   create_table "tags", :force => true do |t|
     t.string "name"
@@ -190,11 +177,10 @@ ActiveRecord::Schema.define(:version => 20130604152238) do
     t.string   "authentication_token"
     t.datetime "created_at",                             :null => false
     t.datetime "updated_at",                             :null => false
+    t.index ["authentication_token"], :name => "index_users_on_authentication_token", :unique => true, :order => {"authentication_token" => :asc}
+    t.index ["email"], :name => "index_users_on_email", :unique => true, :order => {"email" => :asc}
+    t.index ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true, :order => {"reset_password_token" => :asc}
   end
-
-  add_index "users", ["authentication_token"], :name => "index_users_on_authentication_token", :unique => true
-  add_index "users", ["email"], :name => "index_users_on_email", :unique => true
-  add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
 
   create_table "works", :force => true do |t|
     t.string   "url",         :limit => 1024, :null => false

--- a/spec/models/category_manager_spec.rb
+++ b/spec/models/category_manager_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe CategoryManager do
-  it { should validate_presence_of :name }
+  context 'schema_validations' do
+    it { should validate_presence_of :name }
+    it { should ensure_length_of(:name).is_at_most(255) }
+  end
   it { should have_and_belong_to_many :categories }
 end

--- a/spec/models/entity_notice_role_spec.rb
+++ b/spec/models/entity_notice_role_spec.rb
@@ -3,9 +3,12 @@ require 'spec_helper'
 describe EntityNoticeRole do
   it{ should belong_to :entity }
   it{ should belong_to :notice }
-  it{ should validate_presence_of :name }
-  it{ should validate_presence_of :entity }
-  it{ should validate_presence_of :notice }
+  context 'schema_validations' do
+    it{ should validate_presence_of :name }
+    it{ should validate_presence_of :entity }
+    it{ should validate_presence_of :notice }
+    it{ should ensure_length_of(:name).is_at_most(255) }
+  end
   it{ should have_db_index :entity_id }
   it{ should have_db_index :notice_id }
   it{ should ensure_inclusion_of(:name).in_array(EntityNoticeRole::ROLES) }

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -1,8 +1,12 @@
 require "spec_helper"
 
 describe Entity do
-  it { should validate_presence_of :name }
-  it { should validate_presence_of :kind }
+  context 'schema_validations' do
+    it { should validate_presence_of :name }
+    it { should validate_presence_of :kind }
+    it { should ensure_length_of(:address_line_1).is_at_most(255) }
+  end
+
   it { should have_many :entity_notice_roles }
   it { should have_many(:notices).through(:entity_notice_roles)  }
   it { should ensure_inclusion_of(:kind).in_array(Entity::KINDS) }

--- a/spec/models/file_upload_spec.rb
+++ b/spec/models/file_upload_spec.rb
@@ -4,4 +4,7 @@ describe FileUpload do
   it { should have_attached_file(:file) }
   it { should belong_to :notice }
   it { should have_db_index :notice_id }
+  context 'schema_validations' do
+    it { should ensure_length_of(:kind).is_at_most(255) }
+  end
 end

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 
 describe Notice do
-  it { should validate_presence_of :title }
+  context 'schema_validations' do
+    it { should validate_presence_of :title }
+    it { should ensure_length_of(:title).is_at_most(255) }
+  end
+
   it { should have_many :file_uploads }
   it { should have_many :entity_notice_roles }
   it { should have_and_belong_to_many :works }

--- a/spec/models/relevant_question_spec.rb
+++ b/spec/models/relevant_question_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 
 describe RelevantQuestion do
-  it { should validate_presence_of(:question) }
-  it { should validate_presence_of(:answer) }
+  context 'schema_validations' do
+    it { should validate_presence_of(:question) }
+    it { should validate_presence_of(:answer) }
+  end
 
   context "#answer_html" do
     it "converts the answer from markdown" do

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -4,6 +4,10 @@ describe Work do
   it { should have_and_belong_to_many :notices }
   it { should have_and_belong_to_many :infringing_urls }
 
+  context 'schema_validations' do
+    it { should ensure_length_of(:kind).is_at_most(255) }
+  end
+
   context '#url' do
     it_behaves_like 'an object with a url'
   end


### PR DESCRIPTION
This adds validates_presence_of, validates_length_of and uniqueness 
validators automatically based on migrations. This will ensure that API users
don't get postgres-level errors and will instead get validation errors when
attempting to submit field values larger than postgres is able to store.
