### PR TITLE
Remove all logic for displaying FileUpload content

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -17,10 +17,6 @@ class Notice < ActiveRecord::Base
     where('date_received > ?', 1.week.ago).order('date_received DESC')
   end
 
-  def notice_file_content
-    first_notice.read
-  end
-
   def all_relevant_questions
     relevant_questions | category_relevant_questions
   end
@@ -34,10 +30,6 @@ class Notice < ActiveRecord::Base
   end
 
   private
-
-  def first_notice
-    file_uploads.notices.first || NullFileUpload.new
-  end
 
   def entities_that_have_submitted
     entity_notice_roles.submitters.map(&:entity)

--- a/app/models/null_file_upload.rb
+++ b/app/models/null_file_upload.rb
@@ -1,6 +1,0 @@
-class NullFileUpload
-  def read
-    ''
-  end
-
-end

--- a/app/serializers/notice_serializer.rb
+++ b/app/serializers/notice_serializer.rb
@@ -1,5 +1,5 @@
 class NoticeSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :date_received, :categories, :notice_file_content
+  attributes :id, :title, :body, :date_received, :categories
 
   def categories
     object.categories.map(&:name)

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -22,10 +22,6 @@
     </div>
   </section>
 
-  <section class="file">
-    <%= @notice.notice_file_content %>
-  </section>
-
   <footer>
     <section id="tags">
       <h6>Tags</h6>

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -32,15 +32,6 @@ describe NoticesController do
       expect(json).to have_key(:date_received).with_value(notice.date_received)
     end
 
-    it "serializes the file content" do
-      notice = create(:notice_with_notice_file, content: "Some content")
-
-      get :show, id: notice.id, format: :json
-
-      json = JSON.parse(response.body)["notice"]
-      expect(json).to have_key(:notice_file_content).with_value("Some content")
-    end
-
     it "includes the notice category names" do
       notice = create(:notice, :with_categories)
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -36,21 +36,6 @@ FactoryGirl.define do
       end
     end
 
-    factory :notice_with_notice_file do
-      ignore do
-        content "Content"
-      end
-
-      after(:create) do |notice, evaluator|
-        create(
-          :file_upload,
-          kind: :notice,
-          notice: notice,
-          content: evaluator.content
-        )
-      end
-    end
-
     trait :with_entities do
       after(:create) do |notice, instance|
         instance.roles_for_entities.each do |role|

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature "notice submission" do
-  scenario "submitting a notice file" do
+  scenario "submitting a notice" do
     submit_recent_notice("A title")
 
     expect(page).to have_css('#flash_notice')
@@ -18,7 +18,7 @@ feature "notice submission" do
 
     open_recent_notice
 
-    expect(page).to have_content "Some content"
+    pending "We don't use the attached file yet"
   end
 
   scenario "submitting a notice with tags" do

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -14,20 +14,6 @@ describe Notice do
   it { should have_and_belong_to_many :categories }
   it { should have_and_belong_to_many :relevant_questions }
 
-  context "#notice_file_content" do
-    it "returns the contents of its uploaded notice file when present" do
-      notice = create(:notice_with_notice_file, content: "Some content")
-
-      expect(notice.notice_file_content).to eq "Some content"
-    end
-
-    it "returns an empty string when there is no uploaded file" do
-      notice = build(:notice)
-
-      expect(notice.notice_file_content).to eq ''
-    end
-    end
-
   context "#recent" do
     it "returns notices sent in the past week" do
       recent_notice = create(:notice, date_received: 1.week.ago + 1.hour)

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -18,15 +18,6 @@ describe 'notices/show.html.erb' do
     expect(rendered).to include "June 05, 2013"
   end
 
-  it "displays the notices file" do
-    notice = create(:notice_with_notice_file, content: "File content")
-    assign(:notice, notice)
-
-    render
-
-    expect(rendered).to include("File content")
-  end
-
   it "displays a notice with tags" do
     notice = create(:notice, :with_tags)
     assign(:notice, notice)


### PR DESCRIPTION
We can bring this back when we need the feature and understand all the 
requirements therein.

We are still allowing upload in the form/API so I kept that aspect of 
the integration spec, but marked it pending in the assertion phase since 
there's no end-user visibility to assert on.
