### PR TITLE
Move create-notice link example to other view spec

### DIFF
--- a/spec/support/contain_link.rb
+++ b/spec/support/contain_link.rb
@@ -1,0 +1,16 @@
+module ContainLink
+  def contain_link(path, title = nil)
+    selector = "a[href='#{path}']"
+
+    if title
+      selector << ":contains('#{title}')"
+    end
+
+    have_css(selector)
+  end
+end
+
+RSpec.configure do |config|
+  config.include ContainLink, type: :view
+  config.include ContainLink, type: :request
+end

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -1,15 +1,6 @@
 require 'spec_helper'
 
 describe 'home/index.html.erb' do
-
-  it 'shows a link to create a new notice' do
-    assign(:notices, [])
-
-    render
-
-    expect(page).to contain_link(new_notice_path)
-  end
-
   it 'shows metadata and a link to each of its notices' do
     notices = build_stubbed_list(:notice, 3, date_received: 1.hour.ago)
     assign(:notices, notices)
@@ -24,9 +15,4 @@ describe 'home/index.html.erb' do
       end
     end
   end
-
-  def contain_link(path)
-    have_css(%{a[href="#{path}"]})
-  end
-
 end

--- a/spec/views/shared/_category_list.html.erb_spec.rb
+++ b/spec/views/shared/_category_list.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe 'shared/_category_list.html.erb' do
     render 'shared/category_list', categories: categories
 
     categories.each do |category|
-      expect(page).to have_link_to(category_path(category), category.name)
+      expect(page).to contain_link(category_path(category), category.name)
     end
   end
 
@@ -17,11 +17,5 @@ describe 'shared/_category_list.html.erb' do
     render 'shared/category_list', categories: categories
 
     expect(page).to have_content(/^#{categories.map(&:name).join(', ')}$/)
-  end
-
-  private
-
-  def have_link_to(path, text)
-    have_css(%{a[href="#{path}"]:contains("#{text}")})
   end
 end

--- a/spec/views/shared/_navigation.html.erb_spec.rb
+++ b/spec/views/shared/_navigation.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'shared/_navigation.html.erb' do
+  it 'shows a link to create a new notice' do
+    render
+
+    expect(page).to contain_link(new_notice_path)
+  end
+
+  def contain_link(path, title = nil)
+    selector = %{a[href="#{path}"]}
+
+    if title
+      selector << ":contains('#{title}')"
+    end
+
+    have_css(selector)
+  end
+end


### PR DESCRIPTION
Factors out a contains_link helper too.
