### PR TITLE
Add Kaminari initializer

### DIFF
--- a/config/initializers/kaminari.rb
+++ b/config/initializers/kaminari.rb
@@ -1,0 +1,5 @@
+# Prevents conflicts between Kaminari (used by rails_admin) and
+# will_paginate.
+Kaminari.configure do |config|
+  config.page_method_name = :per_page_kaminari
+end


### PR DESCRIPTION
rails_admin uses Kaminari which conflicts with will_paginate causing errors
when viewing record lists in /admin.

This fixes that.
