### PR TITLE
Implement index-updating on association changes

### DIFF
--- a/app/models/categorization.rb
+++ b/app/models/categorization.rb
@@ -1,0 +1,4 @@
+class Categorization < ActiveRecord::Base
+  belongs_to :notice, touch: true
+  belongs_to :category
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,8 +1,12 @@
 class Category < ActiveRecord::Base
-  has_and_belongs_to_many :notices
+  has_many :categorizations, dependent: :destroy
+  has_many :notices, through: :categorizations
+
   has_and_belongs_to_many :relevant_questions
 
   has_ancestry
+
+  after_update { notices.each(&:touch) }
 
   def description_html
     Markdown.render(description.to_s)

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -6,4 +6,6 @@ class Entity < ActiveRecord::Base
   KINDS = %w[organization individual]
 
   validates_inclusion_of :kind, in: KINDS
+
+  after_update { notices.each(&:touch) }
 end

--- a/app/models/entity_notice_role.rb
+++ b/app/models/entity_notice_role.rb
@@ -1,6 +1,6 @@
 class EntityNoticeRole < ActiveRecord::Base
   belongs_to :entity
-  belongs_to :notice
+  belongs_to :notice, touch: true
 
   ROLES = %w[principal agent recipient submitter target]
 

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -7,7 +7,8 @@ class Notice < ActiveRecord::Base
   HIGHLIGHTS = [ :title, :tags, :'categories.name', :submitter_name,
                  :recipient_name, :'infringing_urls.url' ]
 
-  has_and_belongs_to_many :categories
+  has_many :categorizations, dependent: :destroy
+  has_many :categories, through: :categorizations
   has_many :category_relevant_questions,
     through: :categories, source: :relevant_questions
   has_many :entity_notice_roles, dependent: :destroy, inverse_of: :notice
@@ -28,6 +29,8 @@ class Notice < ActiveRecord::Base
   accepts_nested_attributes_for :entity_notice_roles
 
   accepts_nested_attributes_for :works
+
+  after_touch { tire.update_index }
 
   def self.recent
     order('created_at DESC').limit(RECENT_LIMIT)

--- a/db/migrate/20130613142221_rename_categories_notices_to_categorizations.rb
+++ b/db/migrate/20130613142221_rename_categories_notices_to_categorizations.rb
@@ -1,0 +1,5 @@
+class RenameCategoriesNoticesToCategorizations < ActiveRecord::Migration
+  def change
+    rename_table(:categories_notices, :categorizations)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130611203318) do
+ActiveRecord::Schema.define(:version => 20130613142221) do
 
   create_table "blog_entries", :force => true do |t|
     t.integer  "user_id"
@@ -38,18 +38,18 @@ ActiveRecord::Schema.define(:version => 20130611203318) do
     t.index ["category_manager_id"], :name => "index_categories_category_managers_on_category_manager_id", :order => {"category_manager_id" => :asc}
   end
 
-  create_table "categories_notices", :force => true do |t|
-    t.integer "category_id"
-    t.integer "notice_id"
-    t.index ["category_id"], :name => "index_categories_notices_on_category_id", :order => {"category_id" => :asc}
-    t.index ["notice_id"], :name => "index_categories_notices_on_notice_id", :order => {"notice_id" => :asc}
-  end
-
   create_table "categories_relevant_questions", :force => true do |t|
     t.integer "category_id"
     t.integer "relevant_question_id"
     t.index ["category_id"], :name => "index_categories_relevant_questions_on_category_id", :order => {"category_id" => :asc}
     t.index ["relevant_question_id"], :name => "index_categories_relevant_questions_on_relevant_question_id", :order => {"relevant_question_id" => :asc}
+  end
+
+  create_table "categorizations", :force => true do |t|
+    t.integer "category_id"
+    t.integer "notice_id"
+    t.index ["category_id"], :name => "index_categorizations_on_category_id", :order => {"category_id" => :asc}
+    t.index ["notice_id"], :name => "index_categorizations_on_notice_id", :order => {"notice_id" => :asc}
   end
 
   create_table "category_managers", :force => true do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -18,8 +18,8 @@ FactoryGirl.define do
 
     after :build do |notice, evaluator|
       evaluator.role_names.each do |role_name|
-        notice.entity_notice_roles <<
-          build(:entity_notice_role, notice: notice, name: role_name)
+        role = notice.entity_notice_roles.build(name: role_name)
+        role.entity = build(:entity)
       end
     end
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Category do
   it { should validate_presence_of :name }
-  it { should have_and_belong_to_many :notices }
+  it { should have_many(:categorizations).dependent(:destroy) }
+  it { should have_many(:notices).through(:categorizations) }
   it { should have_and_belong_to_many :relevant_questions }
 
   context "#description_html" do

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -14,7 +14,8 @@ describe Notice do
   it { should have_and_belong_to_many :works }
   it { should have_many(:infringing_urls).through(:works) }
   it { should have_many(:entities).through(:entity_notice_roles)  }
-  it { should have_and_belong_to_many :categories }
+  it { should have_many(:categorizations).dependent(:destroy) }
+  it { should have_many(:categories).through(:categorizations) }
   it { should have_and_belong_to_many :relevant_questions }
 
   context ".recent" do
@@ -122,6 +123,44 @@ describe Notice do
       questions = notice.all_relevant_questions.map(&:question)
 
       expect(questions).to match_array %w( Q1 Q2 )
+    end
+  end
+
+  context "search index" do
+    before do
+      tire = double("Tire proxy").as_null_object
+      Notice.any_instance.stub(:tire).and_return(tire)
+    end
+
+    it "updates the index after touch" do
+      notice = create(:notice)
+      notice.tire.should_receive(:update_index)
+
+      notice.touch
+    end
+
+    it "is touched on category changes" do
+      notice = create(:notice)
+      notice.tire.should_receive(:update_index).exactly(3).times
+
+      category = notice.categories.create!(name: "name 1")
+      category.update_attributes!(name: "name 2")
+      category.destroy
+    end
+
+    it "is touched on entity changes" do
+      notice = create(:notice)
+      entity = create(:entity)
+      notice.tire.should_receive(:update_index).exactly(3).times
+
+      create(
+        :entity_notice_role,
+        name: 'submitter',
+        notice: notice,
+        entity: entity
+      )
+      entity.update_attributes!(name: "name 2")
+      entity.destroy
     end
   end
 end


### PR DESCRIPTION
- Category Add/Remove/Update triggers targeted index refresh
- Entity Add/Remove/Update triggers targeted index refresh
- Reifies a CategoriesNotice join model
- Updates index in after_touch
- Uses touch: true for Add/Remove actions
- Uses after_update for Update actions
