### PR TITLE
Implement facetting and improved type mapping

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -7,6 +7,27 @@ class SearchesController < ApplicationController
     @results = Notice.search(page: p) do
       query { match(:_all, q) }
 
+      facet :submitter_name do
+        terms :submitter_name_facet
+      end
+
+      facet :recipient_name do
+        terms :recipient_name_facet
+      end
+
+      facet :categories do
+        terms :category_facet
+      end
+
+      facet :date_received do
+        range :date_received, [
+          { from: Time.now - 1.day, to: Time.now },
+          { from: Time.now - 1.month, to: Time.now },
+          { from: Time.now - 6.months, to: Time.now},
+          { from: Time.now - 12.months, to: Time.now}
+        ]
+      end
+
       highlight(*Notice::HIGHLIGHTS)
     end
 

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -6,4 +6,8 @@ module SearchHelper
       end
     end
   end
+
+  def formatted_facet_range_time(time)
+    Time.at(time / 1000).to_datetime.to_s(:simple)
+  end
 end

--- a/app/views/searches/_range_facet.html.erb
+++ b/app/views/searches/_range_facet.html.erb
@@ -1,0 +1,8 @@
+<li class="<%= type %>">
+  <span><%= type.titleize %></span>
+  <select class="facet" name="<%= type %>">
+    <% results.facets[type]['ranges'].each do |range| %>
+      <option>From today to <%= formatted_facet_range_time(range['from']) %> - <%= range['count'] %> total</option>
+    <% end %>
+  </select>
+</li>

--- a/app/views/searches/_term_facet.html.erb
+++ b/app/views/searches/_term_facet.html.erb
@@ -1,0 +1,8 @@
+<li class="<%= type %>">
+  <span><%= type.titleize %></span>
+  <select class="facet" name="<%= type %>">
+    <% results.facets[type]['terms'].each do |term| %>
+      <option><%= term['term'] %> - <%= term['count'] %> total</option>
+    <% end %>
+  </select>
+</li>

--- a/app/views/searches/show.html.erb
+++ b/app/views/searches/show.html.erb
@@ -2,6 +2,16 @@
   <header>
     <div class="result-stats">About <%= @results.total_entries %> results</div>
   </header>
+  <%= form_tag(search_path, method: :get) do %>
+    <% if @results.facets %>
+      <ol class="results-facets">
+        <%= render 'term_facet', type: 'submitter_name', results: @results %>
+        <%= render 'term_facet', type: 'recipient_name', results: @results %>
+        <%= render 'term_facet', type: 'categories', results: @results %>
+        <%= render 'range_facet', type: 'date_received', results: @results %>
+      </ol>
+    <% end %>
+  <% end %>
   <ol class="results-list">
     <%= render partial: 'result', collection: @results %>
   </ol>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
-Tire.index(Notice.index_name).delete
+Notice.index.delete
+Notice.create_elasticsearch_index
 
 #Execute seeds in a logical order
 %w(relevant_questions.rb blog_entries.rb categories.rb).each do|file|
@@ -16,7 +17,7 @@ class FakeNotice
 
     @source = ["Online form", "Email", "Phone"].sample
     @subject = "Websearch Infringment Notification via #{@source}"
-    @date_received = (1..10).to_a.sample.days.ago
+    @date_received = (0..100).to_a.sample.days.ago
   end
 
   def categories

--- a/lib/tasks/chillingeffects.rake
+++ b/lib/tasks/chillingeffects.rake
@@ -4,7 +4,7 @@ namespace :chillingeffects do
 
   desc 'Delete elasticsearch index'
   task delete_search_index: :environment do
-    Tire.index(Notice.index_name).delete
+    Notice.index.delete
     sleep 5
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -44,6 +44,12 @@ FactoryGirl.define do
         notice.works = build_list(:work, 3, :with_infringing_urls)
       end
     end
+
+    trait :with_facet_data do
+      with_categories
+      role_names ['submitter', 'recipient']
+      date_received Time.now
+    end
   end
 
   factory :file_upload do

--- a/spec/integration/advanced_search_spec.rb
+++ b/spec/integration/advanced_search_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+feature "Advanced search", search: true do
+  before do
+    enable_live_searches
+  end
+
+  context 'facets' do
+    it 'on submitter names' do
+      notice = create(:notice, :with_facet_data)
+      with_a_facetted_search(
+        :submitter_name, :submitter_name_facet) do |results|
+        expect(results).to have_facets('submitter_name').
+          with_terms([notice.submitter_name])
+      end
+    end
+
+    it 'on recipient names' do
+      notice = create(:notice, :with_facet_data)
+      with_a_facetted_search(
+        :recipient_name, :recipient_name_facet) do |results|
+        expect(results).to have_facets('recipient_name').
+          with_terms([notice.recipient_name])
+      end
+    end
+
+    it 'on categories' do
+      notice = create(:notice, :with_facet_data)
+      with_a_facetted_search(
+        :categories, :category_facet) do |results|
+        expect(results).to have_facets('categories').
+          with_terms(notice.categories.map(&:name).uniq)
+      end
+    end
+
+    it 'on date_received' do
+      notice = create(:notice, :with_facet_data)
+      sleep 1
+
+      results = Notice.search do
+        query { match(:_all, 'title') }
+        facet :date_received do
+          range :date_received, [
+            { from: Time.now - 1.day, to: Time.now }
+          ]
+        end
+      end
+      expect(results.facets['date_received']['ranges'].length).to eq 1
+      expect(results.facets['date_received']['ranges'].first['count']).
+        to eq 1
+    end
+  end
+
+  def with_a_facetted_search(facet_name, facet_attribute_name)
+    sleep 1
+    results = Notice.search do
+      query { match(:_all, 'title') }
+      facet facet_name do
+        terms facet_attribute_name, size: 10
+      end
+    end
+    yield results
+  end
+end

--- a/spec/integration/api_search_spec.rb
+++ b/spec/integration/api_search_spec.rb
@@ -2,10 +2,7 @@ require 'spec_helper'
 
 feature "Searching via the API", search: true do
   before do
-    FakeWeb.clean_registry
-    FakeWeb.allow_net_connect = true
-
-    Tire.index(Notice.index_name).delete
+    enable_live_searches
   end
 
   scenario "the results array has relevant metadata" do

--- a/spec/integration/search_spec.rb
+++ b/spec/integration/search_spec.rb
@@ -3,10 +3,7 @@ require 'yaml'
 
 feature "Search", search: true do
   before do
-    FakeWeb.clean_registry
-    FakeWeb.allow_net_connect = true
-
-    Tire.index(Notice.index_name).delete
+    enable_live_searches
   end
 
   scenario "displays search terms" do
@@ -125,6 +122,14 @@ feature "Search", search: true do
     within('.result') do
       expect(page).to have_content(notice.title)
 
+      yield if block_given?
+    end
+  end
+
+  def within_search_facets(term, notice)
+    submit_search(term)
+
+    within('.results-facets') do
       yield if block_given?
     end
   end

--- a/spec/support/live_searching.rb
+++ b/spec/support/live_searching.rb
@@ -1,0 +1,13 @@
+module LiveSearching
+  def enable_live_searches
+    FakeWeb.clean_registry
+    FakeWeb.allow_net_connect = true
+
+    Notice.index.delete
+    Notice.create_elasticsearch_index
+  end
+end
+
+RSpec.configure do |config|
+  config.include LiveSearching
+end

--- a/spec/support/matchers/facet_with_value.rb
+++ b/spec/support/matchers/facet_with_value.rb
@@ -1,0 +1,21 @@
+# results.facets['submitter_name']['terms'].map{|f| f['term']}
+
+RSpec::Matchers.define :have_facets do |facet|
+  match do |results|
+    result = results.facets &&
+       results.facets[facet] &&
+        results.facets[facet]['terms'].map { |t| t['term'] }
+
+    return_value = result
+
+    if @check_terms
+      return_value = (result == @expected_terms)
+    end
+    return_value
+  end
+
+  chain :with_terms do |values|
+    @check_terms = true
+    @expected_terms = values
+  end
+end

--- a/spec/views/searches/show.html.erb_spec.rb
+++ b/spec/views/searches/show.html.erb_spec.rb
@@ -9,6 +9,17 @@ describe 'searches/show.html.erb' do
     expect(page).to have_css('.result', count: 5)
   end
 
+  it "includes facets" do
+    mock_results(build_list(:notice, 5))
+
+    render
+
+    expect(page).to have_css('.submitter_name option', count: 2)
+    expect(page).to have_css('.recipient_name option', count: 1)
+    expect(page).to have_css('.categories option', count: 3)
+    expect(page).to have_css('.date_received option', count: 1)
+  end
+
   it "includes the notice data" do
     notice = create(
       :notice,
@@ -59,6 +70,31 @@ describe 'searches/show.html.erb' do
     end
     notices.stub(:total_entries).and_return(notices.length)
     notices.stub(:total_pages).and_return(1)
+    notices.stub(:facets).and_return(facet_data)
     assign(:results, notices)
+  end
+
+  def facet_data
+    {
+      "submitter_name" => { "terms" =>
+        [
+          { "term" => "Mike Itten", "count" => 27 },
+          { "term" => "Imak Itten", "count" => 27 }
+        ]
+      },
+      "recipient_name" => { "terms" =>
+        [{ "term" => "Twitter", "count" => 10 }]
+      },
+      "categories" => { "terms" =>
+        [
+          { "term" => "DMCA", "count" => 10 },
+          { "term" => "DMCA Takedown", "count" => 10 },
+          { "term" => "DMCA Giveup", "count" => 10 }
+        ]
+      },
+      "date_received"=>{ "ranges"=>
+        [{ "from" => 1371583484000.0, "to" => 1371669884000.0, "count" => 1}]
+      }
+    }
   end
 end


### PR DESCRIPTION
- Remove Notice#as_indexed_json as mapping now defines how notices are
  indexed,
- Display facets on the search results pages with counts,
- Fix index creation to properly use mapping types.
