### PR TITLE
RiskTriggers and hiding of redacted fields

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -13,6 +13,7 @@ class NoticesController < ApplicationController
 
     respond_to do |format|
       if @notice.save
+        @notice.mark_for_review
         format.html { redirect_to :root, notice: "Notice created!" }
         format.json { head :created, location: @notice }
       else
@@ -40,6 +41,7 @@ class NoticesController < ApplicationController
       :title,
       :subject,
       :body,
+      :legal_other,
       :date_received,
       :source,
       :tag_list,

--- a/app/models/risk_assessment.rb
+++ b/app/models/risk_assessment.rb
@@ -1,0 +1,17 @@
+class RiskAssessment
+  def initialize(notice)
+    @notice = notice
+  end
+
+  def high_risk?
+    risk_triggers.any? { |trigger| trigger.risky?(notice) }
+  end
+
+  private
+
+  attr_reader :notice
+
+  def risk_triggers
+    RiskTrigger.all
+  end
+end

--- a/app/models/risk_trigger.rb
+++ b/app/models/risk_trigger.rb
@@ -1,0 +1,26 @@
+class RiskTrigger < ActiveRecord::Base
+
+  def risky?(notice)
+    field_present?(notice) && condition_matches?(notice)
+
+  rescue NoMethodError => ex
+    Rails.logger.warn "Invalid risk trigger (#{id}): #{ex}"
+
+    false
+  end
+
+  private
+
+  def field_present?(notice)
+    notice.send(field).present?
+  end
+
+  def condition_matches?(notice)
+    if negated?
+      notice.send(condition_field) != condition_value
+    else
+      notice.send(condition_field) == condition_value
+    end
+  end
+
+end

--- a/app/views/notices/new.html.erb
+++ b/app/views/notices/new.html.erb
@@ -23,6 +23,7 @@
       </div>
       <div class="body-wrapper right attach">
         <%= form.input :body, label: "Notice Body" %>
+        <%= form.input :legal_other, label: "Legal (Other)" %>
         <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
           <%= file_uploads_form.input :file, label: 'Attach Notice' %>
         <% end %>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -15,6 +15,9 @@
     <div class="main">
       <h2 class="notice-title">Re: <%= @notice.subject %></h2>
       <p class="source">Sent via: <%= @notice.source || 'Unknown' %></p>
+      <p class="legal-other">
+        Legal (Other): <%= @notice.redacted(:legal_other) %>
+      </p>
 
       <ol id="works" class="copyright-claims">
         <%= render @notice.works %>

--- a/db/migrate/20130621172709_create_risk_triggers.rb
+++ b/db/migrate/20130621172709_create_risk_triggers.rb
@@ -1,0 +1,10 @@
+class CreateRiskTriggers < ActiveRecord::Migration
+  def change
+    create_table(:risk_triggers) do |t|
+      t.string :field
+      t.string :condition_field
+      t.string :condition_value
+      t.boolean :negated
+    end
+  end
+end

--- a/db/migrate/20130621173246_add_legal_other_to_notices.rb
+++ b/db/migrate/20130621173246_add_legal_other_to_notices.rb
@@ -1,0 +1,6 @@
+class AddLegalOtherToNotices < ActiveRecord::Migration
+  def change
+    add_column(:notices, :legal_other, :text)
+    add_column(:notices, :legal_other_original, :text)
+  end
+end

--- a/db/migrate/20130621174322_add_review_required_to_notices.rb
+++ b/db/migrate/20130621174322_add_review_required_to_notices.rb
@@ -1,0 +1,5 @@
+class AddReviewRequiredToNotices < ActiveRecord::Migration
+  def change
+    add_column(:notices, :review_required, :boolean)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130620152026) do
+ActiveRecord::Schema.define(:version => 20130621174322) do
 
   create_table "blog_entries", :force => true do |t|
     t.integer  "user_id"
@@ -141,13 +141,16 @@ ActiveRecord::Schema.define(:version => 20130620152026) do
   add_index "infringing_urls_works", ["work_id"], :name => "index_infringing_urls_works_on_work_id"
 
   create_table "notices", :force => true do |t|
-    t.string   "title",         :null => false
+    t.string   "title",                :null => false
     t.text     "body"
     t.datetime "date_received"
-    t.datetime "created_at",    :null => false
-    t.datetime "updated_at",    :null => false
+    t.datetime "created_at",           :null => false
+    t.datetime "updated_at",           :null => false
     t.string   "source"
     t.string   "subject"
+    t.text     "legal_other"
+    t.text     "legal_other_original"
+    t.boolean  "review_required"
   end
 
   create_table "notices_relevant_questions", :force => true do |t|
@@ -185,6 +188,13 @@ ActiveRecord::Schema.define(:version => 20130620152026) do
   create_table "relevant_questions", :force => true do |t|
     t.text "question", :null => false
     t.text "answer",   :null => false
+  end
+
+  create_table "risk_triggers", :force => true do |t|
+    t.string  "field"
+    t.string  "condition_field"
+    t.string  "condition_value"
+    t.boolean "negated"
   end
 
   create_table "taggings", :force => true do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,12 @@
 Notice.index.delete
 Notice.create_elasticsearch_index
 
-#Execute seeds in a logical order
-%w(relevant_questions.rb categories.rb blog_entries.rb).each do|file|
-  load("db/seeds/#{file}")
-end
+# Execute seeds in a logical order
+seed_files = %w(
+  relevant_questions.rb categories.rb blog_entries.rb risk_triggers.rb
+)
+
+seed_files.each { |file| load("db/seeds/#{file}") }
 
 class FakeNotice
   attr_reader :title, :source, :subject, :date_received

--- a/db/seeds/risk_triggers.rb
+++ b/db/seeds/risk_triggers.rb
@@ -1,0 +1,6 @@
+RiskTrigger.create!(
+  field: :legal_other,
+  condition_field: :country_code,
+  condition_value: 'United States',
+  negated: true
+)

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -124,6 +124,9 @@ describe NoticesController do
   end
 
   def notice_double
-    double("Notice", save: true, notice_id: 1)
+    Notice.new.tap do |notice|
+      notice.stub(:save).and_return(true)
+      notice.stub(:mark_for_review)
+    end
   end
 end

--- a/spec/integration/reviewable_notice_spec.rb
+++ b/spec/integration/reviewable_notice_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+feature "Publishing high risk notices" do
+  let(:harmless_text) { "Some harmless text" }
+
+  scenario "A non-US notice with Legal (Other) text" do
+    create_non_us_risk_trigger
+
+    submit_notice_from('Spain') do
+      fill_in "Legal (Other)", with: harmless_text
+    end
+
+    open_recent_notice
+    within('.legal-other') do
+      expect(page).to have_content Notice::UNDER_REVIEW_VALUE
+    end
+  end
+
+  scenario "A non-US notice with no Legal (Other) text" do
+    create_non_us_risk_trigger
+
+    submit_notice_from('Spain')
+
+    open_recent_notice
+    within('.legal-other') do
+      expect(page).not_to have_content Notice::UNDER_REVIEW_VALUE
+    end
+  end
+
+  scenario "A US notice with Legal (Other) text" do
+    create_non_us_risk_trigger
+
+    submit_notice_from('United States') do
+      fill_in "Legal (Other)", with: harmless_text
+    end
+
+    open_recent_notice
+    within('.legal-other') do
+      expect(page).to have_content harmless_text
+    end
+  end
+
+  def create_non_us_risk_trigger
+    RiskTrigger.create!(
+      field: 'legal_other',
+      condition_field: 'country_code',
+      condition_value: 'United States',
+      negated: true
+    )
+  end
+
+  def submit_notice_from(country)
+    submit_recent_notice do
+      within('section.recipient') do
+        select country, from: "Country"
+      end
+
+      yield if block_given?
+    end
+  end
+end

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -151,42 +151,4 @@ feature "notice submission" do
     end
   end
 
-  private
-
-  def submit_recent_notice(title = "A title")
-    visit "/notices/new"
-
-    fill_in "Title", with: title
-    fill_in "Date received", with: Time.now
-
-    within('section.recipient') do
-      fill_in "Name", with: "Recipient the first"
-    end
-    within('section.submitter') do
-      fill_in "Name", with: "Submitter the first"
-    end
-
-    fill_in 'Work URL', with: 'http://www.example.com/original_work.pdf'
-    fill_in 'Kind of Work', with: 'movie'
-    fill_in 'Work Description', with: 'A series of videos and still images'
-    fill_in 'Infringing URL', with: "http://example.com/infringing_url1"
-
-    yield if block_given?
-
-    click_on "Submit"
-  end
-
-  def open_recent_notice(title = "A title")
-    within('#recent-notices') { click_on title }
-  end
-
-  def attach_notice_file(content)
-    Tempfile.open('notice_file') do |fh|
-      fh.write content
-      fh.flush
-
-      attach_file "Attach Notice", fh.path
-    end
-  end
-
 end

--- a/spec/models/risk_assessment_spec.rb
+++ b/spec/models/risk_assessment_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe RiskAssessment do
+  it "returns true if any trigger triggers" do
+    triggers = [
+      trigger_1 = double("Trigger 1"),
+      trigger_2 = double("Trigger 2"),
+      trigger_3 = double("Trigger 3")
+    ]
+    RiskTrigger.stub(:all).and_return(triggers)
+    notice = double("Notice")
+    trigger_1.should_receive(:risky?).with(notice).and_return(false)
+    trigger_2.should_receive(:risky?).with(notice).and_return(true)
+    trigger_3.should_not_receive(:risky?) # enforce short-circuit logic
+
+    assessment = RiskAssessment.new(notice)
+
+    expect(assessment).to be_high_risk
+  end
+
+  it "returns false if no trigger triggers" do
+    RiskTrigger.stub(:all).and_return([
+      double("Trigger 1", risky?: false),
+      double("Trigger 2", risky?: false),
+      double("Trigger 3", risky?: false)
+    ])
+    notice = double("Notice")
+
+    assessment = RiskAssessment.new(notice)
+
+    expect(assessment).not_to be_high_risk
+  end
+end

--- a/spec/models/risk_trigger_spec.rb
+++ b/spec/models/risk_trigger_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe RiskTrigger do
+  it "sees a risky notice as risky" do
+    notice = double("Notice", country_code: 'Spain', legal_other: "nonempty")
+
+    expect(example_trigger).to be_risky(notice)
+  end
+
+  it "sees a safe notice as safe" do
+    notice_1 = double("Notice", country_code: 'United States', legal_other: "nonempty")
+    notice_2 = double("Notice", country_code: 'Spain', legal_other: nil)
+
+    expect(example_trigger).not_to be_risky(notice_1)
+    expect(example_trigger).not_to be_risky(notice_2)
+  end
+
+  it "gracefully handles non-existent notice attributes" do
+    invalid_trigger =RiskTrigger.new(
+      field: :i_dont_exist,
+      condition_field: :either_do_i,
+    )
+
+    expect(invalid_trigger).not_to be_risky(Notice.new)
+  end
+
+  def example_trigger
+    RiskTrigger.new(
+      field: :legal_other,
+      condition_field: :country_code,
+      condition_value: 'United States',
+      negated: true
+    )
+  end
+end

--- a/spec/support/notice_actions.rb
+++ b/spec/support/notice_actions.rb
@@ -1,0 +1,41 @@
+module NoticeActions
+  def submit_recent_notice(title = "A title")
+    visit "/notices/new"
+
+    fill_in "Title", with: title
+    fill_in "Date received", with: Time.now
+
+    within('section.recipient') do
+      fill_in "Name", with: "Recipient the first"
+    end
+    within('section.submitter') do
+      fill_in "Name", with: "Submitter the first"
+    end
+
+    fill_in 'Work URL', with: 'http://www.example.com/original_work.pdf'
+    fill_in 'Kind of Work', with: 'movie'
+    fill_in 'Work Description', with: 'A series of videos and still images'
+    fill_in 'Infringing URL', with: "http://example.com/infringing_url1"
+
+    yield if block_given?
+
+    click_on "Submit"
+  end
+
+  def open_recent_notice(title = "A title")
+    within('#recent-notices') { click_on title }
+  end
+
+  def attach_notice_file(content)
+    Tempfile.open('notice_file') do |fh|
+      fh.write content
+      fh.flush
+
+      attach_file "Attach Notice", fh.path
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include NoticeActions, type: :request
+end


### PR DESCRIPTION
- Create RiskTriggers in rails_admin
- If any trigger hits, the notice is flagged as `review_required`
- Redacted fields aren't shown while the Notice is pending review

RiskTriggers define a field of interest (legal_other), and a 
property/value to be checked (country_code/US). Optionally, check 
negated to create a "not something" trigger.

The presentation layer then uses `Notice#redacted(field)` which returns 
the field's actual value only if review is not presently required
