### PR TITLE
Bring back addresses then partially hide them.

### DIFF
--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -6,19 +6,10 @@ class Entity < ActiveRecord::Base
   has_many :entity_notice_roles, dependent: :destroy
   has_many :notices, through: :entity_notice_roles
 
-  KINDS = %w( organization individual )
-
-  ADDRESS_FIELDS = %i(
-    address_line_1 address_line_2 city state zip country_code
-  )
+  KINDS = %w[organization individual]
 
   validates_inclusion_of :kind, in: KINDS
   validates_uniqueness_of :name
 
   after_update { notices.each(&:touch) }
-
-  def addressed?
-    ADDRESS_FIELDS.any? { |field| send(field).present? }
-  end
-
 end

--- a/app/views/entities/_entity.html.erb
+++ b/app/views/entities/_entity.html.erb
@@ -1,8 +1,7 @@
-<section class="<%= role %>">
-  <h5><%= role %></h5>
-  <h6><%= entity.name %></h6>
-  <% if entity.addressed? %>
-    <span class="redacted">[Address Redacted]</span>
-  <% end %>
-  <span><%= entity.kind %></span>
+<section class="<%= css_class %>">
+<h5><%= css_class %></h5>
+<h6><%= entity.name %></h6>
+<span class="private">[Private]</span>
+<span><%= entity.city %>, <%= entity.state %>, <%= entity.zip %>, <%= entity.country_code %></span>
+<span><%= entity.kind %></span>
 </section>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -5,10 +5,10 @@
   <section class="body">
     <header id="entities">
       <% if @notice.submitter %>
-        <%= render @notice.submitter, role: 'sender' %>
+        <%= render @notice.submitter, css_class: 'sender' %>
       <% end %>
       <% if @notice.recipient %>
-        <%= render @notice.recipient, role: 'receiver' %>
+        <%= render @notice.recipient, css_class: 'receiver' %>
       <% end %>
     </header>
 

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -56,28 +56,6 @@ feature "notice submission" do
       within('section.recipient') do
         fill_in "Name", with: "Recipient the first"
         select "organization", from: "Recipient Kind"
-      end
-
-      within('section.submitter') do
-        fill_in "Name", with: "Submitter the first"
-      end
-    end
-
-    open_recent_notice
-
-    within('#entities') do
-      expect(page).to have_content "Recipient the first"
-      expect(page).to have_content "organization"
-      expect(page).to have_content "Submitter the first"
-      expect(page).to_not have_content "[Address Redacted]"
-    end
-  end
-
-  scenario "submitting a notice with addressed entities" do
-    submit_recent_notice do
-      within('section.recipient') do
-        fill_in "Name", with: "Recipient the first"
-        select "organization", from: "Recipient Kind"
         fill_in "Address Line 1", with: "Recipient Line 1"
         fill_in "Address Line 2", with: "Recipient Line 2"
         fill_in "City", with: "Recipient City"
@@ -93,7 +71,39 @@ feature "notice submission" do
     open_recent_notice
 
     within('#entities') do
-      expect(page).to have_content "[Address Redacted]"
+      expect(page).to have_content "Recipient the first"
+      expect(page).to have_content "organization"
+      expect(page).to have_content "[Private]"
+      expect(page).to have_content "Recipient City"
+      expect(page).to have_content "MA"
+      expect(page).to have_content "United States"
+
+      expect(page).to have_content "Submitter the first"
+    end
+  end
+
+  scenario "entity addresses are partially private" do
+    submit_recent_notice do
+      within('section.recipient') do
+        fill_in "Name", with: "Recipient the first"
+        fill_in "Address Line 1", with: "Recipient Line 1"
+        fill_in "Address Line 2", with: "Recipient Line 2"
+      end
+
+      within('section.submitter') do
+        fill_in "Name", with: "Submitter the first"
+        fill_in "Address Line 1", with: "Submitter Line 1"
+        fill_in "Address Line 2", with: "Submitter Line 2"
+      end
+    end
+
+    open_recent_notice
+
+    within('#entities') do
+      expect(page).not_to have_content "Recipient Line 1"
+      expect(page).not_to have_content "Recipient Line 2"
+      expect(page).not_to have_content "Submitter Line 1"
+      expect(page).not_to have_content "Submitter Line 2"
     end
   end
 

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -24,20 +24,4 @@ describe Entity do
     end
   end
 
-  context "#addressed?" do
-    it "returns false when all address fields are empty" do
-      entity = Entity.new
-
-      expect(entity).to_not be_addressed
-    end
-
-    Entity::ADDRESS_FIELDS.each do |field|
-      it "returns true when '#{field}' is present" do
-        entity = Entity.new(field => "not-empty")
-
-        expect(entity).to be_addressed
-      end
-    end
-  end
-
 end

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -39,7 +39,12 @@ describe 'notices/show.html.erb' do
     within('#entities') do
       notice.entities.each do |entity|
         expect(page).to have_content(entity.name)
-        expect(page).to have_content("[Address Redacted]")
+        expect(page).to have_content(entity.city)
+        expect(page).to have_content(entity.state)
+        expect(page).to have_content(entity.country_code)
+        expect(page).to have_content("[Private]")
+        expect(page).not_to have_content(entity.address_line_1)
+        expect(page).not_to have_content(entity.address_line_2)
       end
     end
   end


### PR DESCRIPTION
This time I used the text `[Private]` to match the existing site.

I noticed that the view basically expects an address to be there. How do 
we feel about that? Handling it properly felt like too much for this 
card, but maybe we want to add one to do something about it later.
