### PR TITLE
Add Body as a redactable field

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -13,6 +13,8 @@ class Notice < ActiveRecord::Base
     works.description works.url infringing_urls.url
   )
 
+  REDACTABLE_FIELDS = %i( legal_other body )
+
   UNDER_REVIEW_VALUE = 'Under review'
   RANGE_SEPARATOR = '..'
 

--- a/app/models/redacts_notices.rb
+++ b/app/models/redacts_notices.rb
@@ -3,7 +3,7 @@ class RedactsNotices
     @redactors = redactors
   end
 
-  def redact(notice, field_or_fields = %i( legal_other ))
+  def redact(notice, field_or_fields = Notice::REDACTABLE_FIELDS)
     Array(field_or_fields).each { |field| redact_field(notice, field) }
   end
 

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -15,6 +15,7 @@
     <div class="main">
       <h2>Re: <%= @notice.subject %></h2>
       <p class="source">Sent via: <%= @notice.source || 'Unknown' %></p>
+      <p class="body">Body: <%= @notice.redacted(:body) %></p>
       <p class="legal-other">
         Legal (Other): <%= @notice.redacted(:legal_other) %>
       </p>

--- a/db/migrate/20130702185326_add_body_original_to_notices.rb
+++ b/db/migrate/20130702185326_add_body_original_to_notices.rb
@@ -1,0 +1,5 @@
+class AddBodyOriginalToNotices < ActiveRecord::Migration
+  def change
+    add_column(:notices, :body_original, :text)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130621174322) do
+ActiveRecord::Schema.define(:version => 20130702185326) do
 
   create_table "blog_entries", :force => true do |t|
     t.integer  "user_id"
@@ -151,6 +151,7 @@ ActiveRecord::Schema.define(:version => 20130621174322) do
     t.text     "legal_other"
     t.text     "legal_other_original"
     t.boolean  "review_required"
+    t.text     "body_original"
   end
 
   create_table "notices_relevant_questions", :force => true do |t|

--- a/lib/rails_admin/config/actions/redact_notice.rb
+++ b/lib/rails_admin/config/actions/redact_notice.rb
@@ -2,7 +2,7 @@ require 'rails_admin/config/actions'
 require 'rails_admin/config/actions/base'
 
 RedactNoticeProc = Proc.new do
-  @redactable_fields = %i( legal_other )
+  @redactable_fields = Notice::REDACTABLE_FIELDS
   @next_notice = @object.next_requiring_review
 
   if request.get?

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -50,6 +50,14 @@ FactoryGirl.define do
       role_names ['submitter', 'recipient']
       date_received Time.now
     end
+
+    trait :redactable do
+      legal_other "Some [REDACTED] legal other"
+      legal_other_original "Some sensitive legal other"
+      body "Some [REDACTED] body"
+      body_original "Some sensitive body"
+      review_required true
+    end
   end
 
   factory :file_upload do

--- a/spec/integration/redaction_spec.rb
+++ b/spec/integration/redaction_spec.rb
@@ -1,106 +1,108 @@
 require 'spec_helper'
 
-feature "Auto-redaction" do
-  scenario "Legal (Other) is automatically redacted of phone numbers" do
-    original_text = <<-EOT
-      Please contact my laywer at (123) 456-7890 or, if
-      you prefer I can be reached at 098-765-4321. In
-      case it's useful, my mother's phone number is
-      234.234.2345.
-    EOT
-    redacted_text = <<-EOT
-      Please contact my laywer at [REDACTED] or, if
-      you prefer I can be reached at [REDACTED]. In
-      case it's useful, my mother's phone number is
-      [REDACTED].
-    EOT
+feature "Redactable fields" do
+  Notice::REDACTABLE_FIELDS.each do |field|
 
-    submit_recent_notice do
-      fill_in "Legal (Other)", with: original_text
+    scenario "#{field} is automatically redacted of phone numbers" do
+      original_text = <<-EOT
+        Please contact my laywer at (123) 456-7890 or, if
+        you prefer I can be reached at 098-765-4321. In
+        case it's useful, my mother's phone number is
+        234.234.2345.
+      EOT
+      redacted_text = <<-EOT
+        Please contact my laywer at [REDACTED] or, if
+        you prefer I can be reached at [REDACTED]. In
+        case it's useful, my mother's phone number is
+        [REDACTED].
+      EOT
+
+      submit_recent_notice do
+        fill_in "notice_#{field}", with: original_text
+      end
+
+      open_recent_notice
+      expect(page).to have_content(redacted_text)
+      expect(page).to_not have_content(original_text)
     end
 
-    open_recent_notice
-    expect(page).to have_content(redacted_text)
-    expect(page).to_not have_content(original_text)
-  end
-end
+    context "Manual redaction" do
+      before { FakeWeb.allow_net_connect = true }
 
-feature "Manual redaction" do
-  before { FakeWeb.allow_net_connect = true }
+      scenario "Redacting selected text in #{field}", js: true do
+        visit_redact_notice
+        redactable_field = RedactableFieldOnPage.new(field)
 
-  scenario "Redacting selection", js: true do
-    visit_redact_notice
-    redactable_field = RedactableFieldOnPage.new(:legal_other)
+        redactable_field.select_and_redact
 
-    redactable_field.select_and_redact
+        expect(redactable_field).to have_content('[REDACTED]')
+      end
 
-    expect(redactable_field).to have_content('[REDACTED]')
-  end
+      scenario "Restoring #{field} from original", js: true do
+        notice = visit_redact_notice
+        redactable_field = RedactableFieldOnPage.new(field)
 
-  scenario "Restoring from original", js: true do
-    notice = visit_redact_notice
-    redactable_field = RedactableFieldOnPage.new(:legal_other)
+        redactable_field.unredact
 
-    redactable_field.unredact
+        expect(redactable_field).to have_content(
+          notice.send(:"#{field}_original")
+        )
+      end
 
-    expect(redactable_field).to have_content(notice.legal_other_original)
-  end
+      scenario "Publishing after review" do
+        notice = visit_redact_notice
 
-  scenario "Publishing after review" do
-    notice = visit_redact_notice
+        uncheck 'Review required'
+        click_on 'Save'
 
-    uncheck 'Review required'
-    click_on 'Save'
+        visit "/notices/#{notice.id}"
+        expect(page).not_to have_content(Notice::UNDER_REVIEW_VALUE)
+      end
 
-    visit "/notices/#{notice.id}"
-    expect(page).not_to have_content(Notice::UNDER_REVIEW_VALUE)
-  end
+      private
 
-  private
+      def visit_redact_notice
+        user = create(:user)
+        visit '/users/sign_in'
+        fill_in "Email", with: user.email
+        fill_in "Password", with: user.password
+        click_on "Sign in"
 
-  def visit_redact_notice
-    user = create(:user)
-    visit '/users/sign_in'
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_on "Sign in"
+        notice = create(:notice, :redactable)
 
-    notice = create(
-      :notice,
-      legal_other: "Some [REDACTED] text",
-      legal_other_original: "Some sensitive text",
-      review_required: true
-    )
+        visit "/admin/notice/#{notice.id}/redact_notice"
 
-    visit "/admin/notice/#{notice.id}/redact_notice"
+        notice
+      end
 
-    notice
-  end
+      class RedactableFieldOnPage
+        include Capybara::DSL
 
-  class RedactableFieldOnPage
-    include Capybara::DSL
+        def initialize(name)
+          @name = name
+        end
 
-    def initialize(name)
-      @name = name
+        def unredact
+          page.find("#notice_#{@name}").click
+
+          click_on "Unredact selected field"
+        end
+
+        def select_and_redact
+          page.execute_script <<-EOS
+            document.getElementById('notice_#{@name}').focus();
+            document.getElementById('notice_#{@name}').select();
+          EOS
+
+          click_on 'Redact selected text'
+        end
+
+        def has_content?(content)
+          page.find("#notice_#{@name}").value == content
+        end
+
+      end
     end
 
-    def unredact
-      page.find("#notice_#{@name}").click
-
-      click_on "Unredact selected field"
-    end
-
-    def select_and_redact
-      page.execute_script <<-EOS
-        document.getElementById('notice_legal_other').focus();
-        document.getElementById('notice_legal_other').select();
-      EOS
-
-      click_on 'Redact selected text'
-    end
-
-    def has_content?(content)
-      page.find("#notice_#{@name}").value == content
-    end
   end
 end

--- a/spec/rails_admin/config/actions/redact_notice_spec.rb
+++ b/spec/rails_admin/config/actions/redact_notice_spec.rb
@@ -12,7 +12,7 @@ describe RedactNoticeProc do
   it "sets the correct redactable fields" do
     instance_eval(&RedactNoticeProc)
 
-    expect(@redactable_fields).to match_array %i( legal_other )
+    expect(@redactable_fields).to eq Notice::REDACTABLE_FIELDS
   end
 
   it "sets next requiring review correctly" do


### PR DESCRIPTION
The diff looks messy overall, but the first commit refactors everything 
(including the integration spec) to base off of the new constant. That 
allowed the second commit to be almost a simple as just adding :body to 
that constant.
