### PR TITLE
Implement date_sent

### DIFF
--- a/app/assets/javascripts/notices_new.js.coffee
+++ b/app/assets/javascripts/notices_new.js.coffee
@@ -3,5 +3,8 @@ $('#new_notice select').each ->
     placeholder: ''
     width: 'off'
 
+$('#notice_date_sent').datepicker
+  format: 'yyyy-mm-dd'
+
 $('#notice_date_received').datepicker
   format: 'yyyy-mm-dd'

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -43,6 +43,7 @@ class NoticesController < ApplicationController
       :subject,
       :body,
       :legal_other,
+      :date_sent,
       :date_received,
       :source,
       :tag_list,

--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -1,7 +1,15 @@
 module NoticesHelper
-  def date_received(notice)
-    if date = notice.date_received
+  def display_date_field(record, field)
+    if date = record.send(field)
       time_tag date, date.to_s(:simple)
     end
+  end
+
+  def date_sent(notice)
+    display_date_field(notice, :date_sent)
+  end
+
+  def date_received(notice)
+    display_date_field(notice, :date_received)
   end
 end

--- a/app/serializers/notice_serializer.rb
+++ b/app/serializers/notice_serializer.rb
@@ -1,5 +1,5 @@
 class NoticeSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :date_received,
+  attributes :id, :title, :body, :date_sent, :date_received,
     :categories, :submitter_name, :recipient_name, :works
 
   def categories

--- a/app/views/notices/new.html.erb
+++ b/app/views/notices/new.html.erb
@@ -10,6 +10,7 @@
       <div class="body-wrapper left main">
         <%= form.input :title, label: "Notice Title" %>
         <%= form.input :subject %>
+        <%= form.input :date_sent, as: :string, placeholder: "YYYY-MM-DD" %>
         <%= form.input :date_received, as: :string, placeholder: "YYYY-MM-DD" %>
         <%= form.input :source, label: "Sent via", placeholder: 'Online form, Email, Postal mail, etc.' %>
         <%= form.input :tag_list, placeholder: 'movie, youtube, video, etc.' %>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -1,5 +1,6 @@
 <article class="notice-show">
   <h1><%= @notice.title %></h1>
+  <span class="date-sent">Date Sent: <%= date_sent(@notice) %></span>
   <span class="date-received">Date Received: <%= date_received(@notice) %></span>
 
   <section class="body">

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -12,6 +12,19 @@ RailsAdmin.config do |config|
   end
 
   config.model 'Notice' do
+    list do
+      field :id
+      field :title
+      field(:date_sent)     { label 'Sent' }
+      field(:date_received) { label 'Received' }
+      field(:created_at)    { label 'Submitted' }
+      field :source
+      field :review_required
+      field :body
+      field :entities
+      field :categories
+      field :works
+    end
     edit do
       configure(:categorizations) { hide }
       configure(:blog_categorizations) { hide }

--- a/db/migrate/20130703144431_add_date_sent_to_notices.rb
+++ b/db/migrate/20130703144431_add_date_sent_to_notices.rb
@@ -1,0 +1,5 @@
+class AddDateSentToNotices < ActiveRecord::Migration
+  def change
+    add_column(:notices, :date_sent, :datetime)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130702185326) do
+ActiveRecord::Schema.define(:version => 20130703144431) do
 
   create_table "blog_entries", :force => true do |t|
     t.integer  "user_id"
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(:version => 20130702185326) do
     t.text     "legal_other_original"
     t.boolean  "review_required"
     t.text     "body_original"
+    t.datetime "date_sent"
   end
 
   create_table "notices_relevant_questions", :force => true do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ seed_files = %w(
 seed_files.each { |file| load("db/seeds/#{file}") }
 
 class FakeNotice
-  attr_reader :title, :source, :subject, :date_received
+  attr_reader :title, :source, :subject, :date_sent, :date_received
 
   def initialize
     @title = [
@@ -19,6 +19,7 @@ class FakeNotice
 
     @source = ["Online form", "Email", "Phone"].sample
     @subject = "Websearch Infringment Notification via #{@source}"
+    @date_sent = (0..100).to_a.sample.days.ago
     @date_received = (0..100).to_a.sample.days.ago
   end
 
@@ -124,6 +125,7 @@ unless ENV['SKIP_FAKE_DATA']
     Notice.create!(
       title: fake.title,
       subject: fake.subject,
+      date_sent: fake.date_sent,
       date_received: fake.date_received,
       source: fake.source,
       category_ids: fake.categories.map(&:id),

--- a/doc/api_documentation.mkd
+++ b/doc/api_documentation.mkd
@@ -19,6 +19,7 @@ Authentication is not required for now.
 | ---                            | ---                | ---
 | title                          | string             | Required
 | subject                        | string             |
+| date_sent                      | string             | Any parseable time value, e.g. "2013-05-21", "2013-05-21 10:01:01 -04:00"
 | date_received                  | string             | Any parseable time value, e.g. "2013-05-21", "2013-05-21 10:01:01 -04:00"
 | source                         | string             | How did you receive this notice - mail? online form?
 | category_ids                   | [int]              | An array of integers representing category ids - See **Request a list of Categories** below.
@@ -69,6 +70,7 @@ curl -H "Accept: application/json" -H "Content-type: application/json" 'http://c
   "notice": {
     "title": "DMCA (Copyright) Complaint to Google",
     "subject": "Infringement Notfication via Blogger Complaint",
+    "date_sent": "2013-05-22",
     "date_received": "2013-05-23",
     "source": "Online form",
     "category_ids": [19, 27],
@@ -174,6 +176,7 @@ Return a JSON-encoded representation of selected notice attributes.
     "id":1,
     "title":"Lion King on YouTube",
     "body":null,
+    "date_sent":"2013-06-04T19:23:12Z",
     "date_received":"2013-06-05T20:31:44Z",
     "categories":[
       "Anticircumvention (DMCA)",

--- a/lib/rails_admin/config/actions/redact_notice.rb
+++ b/lib/rails_admin/config/actions/redact_notice.rb
@@ -52,6 +52,7 @@ module RailsAdmin
         register_instance_option(:action_name) { :redact_notice }
         register_instance_option(:link_icon) { 'icon-adjust' }
         register_instance_option(:controller) { RedactNoticeProc }
+        register_instance_option(:visible?) { bindings[:object].review_required? }
       end
 
       register RedactNotice

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -11,6 +11,18 @@ feature "notice submission" do
     end
   end
 
+  scenario "submitting a notice with dates" do
+    submit_recent_notice do
+      fill_in "Date sent", with: Time.local(2013, 5, 4)
+      fill_in "Date received", with: Time.local(2013, 5, 5)
+    end
+
+    open_recent_notice
+
+    expect(page).to have_content("Date Sent: May 04, 2013")
+    expect(page).to have_content("Date Received: May 05, 2013")
+  end
+
   scenario "submitting a notice with an attached file" do
     submit_recent_notice do
       attach_notice_file("Some content")

--- a/spec/support/shared_examples/serialized_notice.rb
+++ b/spec/support/shared_examples/serialized_notice.rb
@@ -2,7 +2,7 @@ shared_examples 'a serialized notice' do
 
   it 'includes base notice metadata' do
     with_a_serialized_notice do |notice, json|
-      %i(title body date_received submitter_name recipient_name).each do |att|
+      %i(title body date_sent date_received submitter_name recipient_name).each do |att|
         expect(json[att]).to eq notice.send(att)
       end
     end

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -10,6 +10,14 @@ describe 'notices/show.html.erb' do
     expect(rendered).to include notice.title
   end
 
+  it "displays the date sent in the proper format" do
+    assign(:notice, build(:notice, date_sent: Time.local(2013, 5, 4)))
+
+    render
+
+    expect(rendered).to include "May 04, 2013"
+  end
+
   it "displays the date received in the proper format" do
     assign(:notice, build(:notice, date_received: Time.local(2013, 6, 5)))
 


### PR DESCRIPTION
Didn't get a real confirmation from Wendy yet, but I figure it can't 
hurt to accept it, store it, and display it in html/json responses.

We should pin this down before adding it as a search facet though.
