### PR TITLE
Implement a searching / filtering  abstraction layer

### DIFF
--- a/app/models/date_range_filter.rb
+++ b/app/models/date_range_filter.rb
@@ -1,0 +1,49 @@
+class DateRangeFilter
+
+  def initialize(parameter, ranges = [])
+    @parameter = parameter
+    @ranges = ranges
+  end
+
+  def apply_to_search(searcher, param, value)
+    if handles?(param)
+      date_range_filter = filter_for(value)
+      searcher.filter *date_range_filter
+    end
+  end
+
+  def register_filter(searcher)
+    # These must be local variables to be passed into the Tire searcher
+    local_parameter = @parameter
+    local_ranges = @ranges
+
+    searcher.facet local_parameter do
+      range local_parameter, local_ranges
+    end
+  end
+
+  def filter_for(value)
+    filter_values = FilterRangeValues.new(value)
+    [
+      :range,
+      @parameter => { from: filter_values.from, to: filter_values.to }
+    ]
+  end
+
+  private
+
+  def handles?(parameter_of_concern)
+    @parameter == parameter_of_concern.to_sym
+  end
+
+  class FilterRangeValues
+    attr_reader :from, :to
+
+    def initialize(time_value)
+      @from, @to = time_value.split(Notice::RANGE_SEPARATOR, 2).map do |str|
+        Time.at(str.to_i / 1000)
+      end
+    end
+  end
+
+end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -14,6 +14,7 @@ class Notice < ActiveRecord::Base
   )
 
   REDACTABLE_FIELDS = %i( legal_other body )
+  PER_PAGE = 10
 
   UNDER_REVIEW_VALUE = 'Under review'
   RANGE_SEPARATOR = '..'

--- a/app/models/notice_searcher.rb
+++ b/app/models/notice_searcher.rb
@@ -1,0 +1,52 @@
+class NoticeSearcher
+
+  def initialize(params = {})
+    @params = params
+    @page = params[:page] || 1
+    @per_page = params[:per_page] || Notice::PER_PAGE
+  end
+
+  def register(search_type)
+    registry << search_type
+  end
+
+  def registry
+    @registry ||= []
+  end
+
+  def search
+    @search = Tire.search(Notice.index_name)
+    register_filters
+
+    @params.each do |param, value|
+      if value.present?
+        add_searches_for(param, value)
+      end
+    end
+
+    @search.highlight(*Notice::HIGHLIGHTS)
+    @search.size @per_page
+    @search.from this_page
+
+    @search
+  end
+
+  private
+
+  def this_page
+    @per_page.to_i * (@page.to_i - 1)
+  end
+
+  def register_filters
+    registry.each do |filter|
+      filter.register_filter(@search)
+    end
+  end
+
+  def add_searches_for(param, value)
+    registry.each do |search_type|
+      search_type.apply_to_search(@search, param, value)
+    end
+  end
+
+end

--- a/app/models/term_filter.rb
+++ b/app/models/term_filter.rb
@@ -1,0 +1,35 @@
+class TermFilter
+
+  def initialize(parameter, indexed_attribute = nil)
+    @parameter = parameter
+    @indexed_attribute = indexed_attribute || parameter
+  end
+
+  def filter_for(value)
+    [:terms, @indexed_attribute => [ value ]]
+  end
+
+  def apply_to_search(searcher, param, value)
+    if handles?(param)
+      term_filter = filter_for(value)
+      searcher.filter *term_filter
+    end
+  end
+
+  def register_filter(searcher)
+    # These must be local variables to be passed into the Tire searcher
+    local_indexed_attribute = @indexed_attribute
+    local_parameter = @parameter
+
+    searcher.facet local_parameter do
+      terms local_indexed_attribute
+    end
+  end
+
+  private
+
+  def handles?(parameter_of_concern)
+    @parameter == parameter_of_concern.to_sym
+  end
+
+end

--- a/app/models/term_search.rb
+++ b/app/models/term_search.rb
@@ -1,0 +1,32 @@
+class TermSearch
+
+  def initialize(parameter, field)
+    @parameter = parameter
+    @field = field
+  end
+
+  def query_for(value)
+    field = @field
+    lambda do |query|
+      query.must { match(field, value) }
+    end
+  end
+
+  def apply_to_search(searcher, param, value)
+    if handles?(param)
+      searcher.query do |q|
+        term_query = query_for(value)
+        q.boolean &term_query
+      end
+    end
+  end
+
+  def register_filter(noop)
+  end
+
+  private
+
+  def handles?(parameter_of_concern)
+    @parameter == parameter_of_concern.to_sym
+  end
+end

--- a/app/views/entities/_entity.html.erb
+++ b/app/views/entities/_entity.html.erb
@@ -1,6 +1,6 @@
 <section class="<%= css_class %>">
 <h5><%= css_class %></h5>
-<h6><%= entity.name %></h6>
+<h6><%= link_to(entity.name, facetted_search_path("#{role}_name" => entity.name)) %></h6>
 <span class="private">[Private]</span>
 <span><%= entity.city %>, <%= entity.state %>, <%= entity.zip %>, <%= entity.country_code %></span>
 <span><%= entity.kind %></span>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -6,10 +6,10 @@
   <section class="body">
     <header id="entities">
       <% if @notice.submitter %>
-        <%= render @notice.submitter, css_class: 'sender' %>
+        <%= render @notice.submitter, css_class: 'sender', role: :submitter %>
       <% end %>
       <% if @notice.recipient %>
-        <%= render @notice.recipient, css_class: 'receiver' %>
+        <%= render @notice.recipient, css_class: 'receiver', role: :recipient %>
       <% end %>
     </header>
 

--- a/app/views/searches/_result.html.erb
+++ b/app/views/searches/_result.html.erb
@@ -3,9 +3,9 @@
   <div class="metadata">
     <div class="date-received"><%= date_received(result) %></div>
     <div class="sender-receiver">
-      <a href="#" class="sender"><%= result.submitter_name %></a>
+      <%= link_to(result.submitter_name, facetted_search_path(submitter_name: result.submitter_name), class: 'sender' )%>
       <span class="arrow"><%= image_tag 'arrow-small.svg' %></span>
-      <a href="#" class="receiver"><%= result.recipient_name %></a>
+      <%= link_to(result.recipient_name, facetted_search_path(recipient_name: result.recipient_name), class: 'receiver' )%>
     </div>
     <ol class="excerpt">
       <% result.with_excerpts do |excerpt| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,5 +15,7 @@ Chill::Application.routes.draw do
 
   resource :search, only: [:show]
 
+  resource :facetted_search, only: [:show], controller: :searches
+
   root to: 'home#index'
 end

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -2,14 +2,13 @@ require 'spec_helper'
 
 describe SearchesController do
   context "#show" do
-    it "executes a search based on query, and assigns results" do
-      results = double("Results")
-      Notice.should_receive(:search).and_return(results)
+    it "uses NoticeSearcher" do
+      searcher = NoticeSearcher.new
+      NoticeSearcher.should_receive(:new).and_return(searcher)
 
       get :show
 
       expect(response).to be_successful
-      expect(assigns(:results)).to eq results
     end
   end
 end

--- a/spec/integration/search_spec.rb
+++ b/spec/integration/search_spec.rb
@@ -26,6 +26,20 @@ feature "Search", search: true do
     end
   end
 
+  scenario "paginates properly" do
+    3.times do
+      create(:notice, title: "The Lion King on Youtube")
+    end
+    sleep 1
+
+    visit "/search?page=2&per_page=1&term=lion"
+    within('.pagination') do
+      expect(page).to have_css('em.current', text: 2)
+      expect(page).to have_css('a[rel="next"]')
+      expect(page).to have_css('a[rel="prev start"]')
+    end
+  end
+
   context "within associated models" do
     scenario "for category names" do
       category = create(:category, name: "Lion King")

--- a/spec/models/date_range_filter_spec.rb
+++ b/spec/models/date_range_filter_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe DateRangeFilter do
+
+  it_behaves_like 'a search filter'
+
+  it "properly creates facet parameters" do
+    to = Time.now
+    from = to - 1.month
+
+    date_range_filter = described_class.new(:date_facet, [])
+
+    filter = date_range_filter.filter_for(
+      "#{from.to_i * 1000}..#{to.to_i * 1000}"
+    )
+
+    expect(filter[0]).to eq :range
+    expect(filter[1][:date_facet][:to]).to be_within(1).of(to)
+    expect(filter[1][:date_facet][:from]).to be_within(1).of(from)
+  end
+
+end

--- a/spec/models/notice_searcher_spec.rb
+++ b/spec/models/notice_searcher_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe NoticeSearcher do
+
+  it "returns an elasticsearch search instance" do
+    expect(subject.search).to be_instance_of(Tire::Search::Search)
+  end
+
+  it "allows searches / filters to be registered" do
+    title_filter = TermFilter.new(:title)
+
+    subject.register title_filter
+
+    expect(subject.registry.first).to eq title_filter
+  end
+
+  context 'filters' do
+
+    it "correctly configures facets" do
+      subject.register TermFilter.new(:title)
+      expect(subject.search.facets[:title]).to be
+    end
+
+    it "asks for the filter" do
+      filter = TermFilter.new(:title)
+      searcher = described_class.new(params_hash)
+      searcher.register filter
+
+      filter.should_receive(:filter_for).with(params_hash[:title]).and_return(
+        [ bleep: { foo: ['as'] } ]
+      )
+      searcher.search
+    end
+  end
+
+  context 'searches' do
+    it "dispatches to a registered term search" do
+      all_fields = TermSearch.new(:term, :_all)
+      searcher = described_class.new(params_hash)
+      searcher.register all_fields
+
+      all_fields.should_receive(:query_for).with(params_hash[:term])
+
+      searcher.search
+    end
+  end
+end
+
+def params_hash
+  {
+    term: 'foo',
+    title: 'A title'
+  }
+end

--- a/spec/models/term_filter_spec.rb
+++ b/spec/models/term_filter_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe TermFilter do
+
+  it_behaves_like 'a search filter'
+
+  it "has an indexed attribute that defaults to the parameter name" do
+    term_search = described_class.new(:term_facet)
+    expect(term_search.filter_for('foo')).to eq(
+      [:terms, :term_facet => [ 'foo' ]]
+    )
+  end
+
+  it "can override the indexed attribute name" do
+    term_search = described_class.new(:term_facet, :indexed_attribute_name)
+    expect(term_search.filter_for('foo')).to eq(
+      [:terms, :indexed_attribute_name => [ 'foo' ]]
+    )
+  end
+
+end

--- a/spec/models/term_search_spec.rb
+++ b/spec/models/term_search_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe TermSearch do
+
+  before do
+    @term_search = described_class.new(:term, :_all)
+    @searcher = double("NoticeSearcher Instance")
+  end
+
+  it "queries the searcher given a param it handles" do
+    @searcher.should_receive(:query)
+    @term_search.apply_to_search(@searcher, :term, 'foo')
+  end
+
+  it "does not query with a parameter it is not bound to" do
+    @searcher.should_not_receive(:query)
+    @term_search.apply_to_search(@searcher, :unknown_term, 'foo')
+  end
+
+end

--- a/spec/support/shared_examples/filters.rb
+++ b/spec/support/shared_examples/filters.rb
@@ -1,0 +1,31 @@
+shared_examples "a search filter" do
+
+  before do
+    @filter = described_class.new(:facet, [])
+    @searcher = double("NoticeSearcher Instance")
+  end
+
+  it "registers a facet" do
+    @searcher.should_receive(:facet)
+
+    @filter.register_filter(@searcher)
+  end
+
+  it "registers a filter" do
+    @searcher.should_receive(:filter)
+
+    @filter.apply_to_search(@searcher, :facet, '')
+  end
+
+  it "queries the searcher given a param it handles" do
+    @searcher.should_receive(:filter)
+
+    @filter.apply_to_search(@searcher, :facet, 'foo')
+  end
+
+  it "does not query with a parameter it is not bound to" do
+    @searcher.should_not_receive(:filter)
+
+    @filter.apply_to_search(@searcher, :unknown_term, 'foo')
+  end
+end

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -57,6 +57,19 @@ describe 'notices/show.html.erb' do
     end
   end
 
+  it "displays submitter_names such that they are clickable" do
+    notice = create(:notice, role_names: ['submitter', 'recipient'])
+
+    assign(:notice, notice)
+
+    render
+
+    within('#entities') do
+      expect(page).to have_facet_link(:submitter_name, notice.submitter_name)
+      expect(page).to have_facet_link(:recipient_name, notice.recipient_name)
+    end
+  end
+
   it "displays a notice with all relevant questions" do
     category_question = create(:relevant_question, question: "Q 1", answer: "A 1")
     notice_question = create(:relevant_question, question: "Q 2", answer: "A 2")
@@ -135,6 +148,13 @@ describe 'notices/show.html.erb' do
         )
       end
     end
+  end
+
+  def have_facet_link(facet, value)
+    have_css(
+      "a[href='#{facetted_search_path(facet => value)}']",
+      text: value
+    )
   end
 
 end

--- a/spec/views/searches/show.html.erb_spec.rb
+++ b/spec/views/searches/show.html.erb_spec.rb
@@ -34,8 +34,10 @@ describe 'searches/show.html.erb' do
 
     within('.result') do
       expect(page).to have_css('.title', text: 'A notice')
-      expect(page).to have_css('.sender-receiver', text: notice.recipient.name)
-      expect(page).to have_css('.sender-receiver', text: notice.submitter.name)
+      expect(page).to have_css('.sender-receiver', text: notice.recipient_name)
+      expect(page).to have_css('.sender-receiver', text: notice.submitter_name)
+      expect(page).to have_facetted_search_role_link(:submitter_name, notice)
+      expect(page).to have_facetted_search_role_link(:recipient_name, notice)
       expect(page).to have_css(
         '.date-received', text: notice.date_received.to_s(:simple)
       )
@@ -106,6 +108,10 @@ describe 'searches/show.html.erb' do
         [{ "from" => 1371583484000.0, "to" => 1371669884000.0, "count" => 1}]
       }
     }
+  end
+
+  def have_facetted_search_role_link(role, notice)
+    have_css(%Q(a[href="#{facetted_search_path(role => notice.send(role))}"]), text: notice.send(role))
   end
 
 end


### PR DESCRIPTION
- Implement NoticeSearcher, a class to make searching notices easier
- Allow for term search queries to be created on the searcher
- Allow for term facet/filters
- Allow for date range filters
- Light up a couple relevant facets on search results and notice pages
- Build it all as a framework that will easy granular search creation in
  the future
- Allow a per_page value to be specified in query parameters
