### PR TITLE
Short URLs for notices

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Chill::Application.routes.draw do
 
   resources :notices, only: [:show, :new, :create]
 
+  get '/n/:id', to: 'notices#show'
+
   resources :categories, only: [:show]
 
   scope format: true, constraints: { format: :json } do

--- a/spec/routing/short_urls_spec.rb
+++ b/spec/routing/short_urls_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe "Notices" do
+  it "routes /n/notice_id to NoticesController#show" do
+    expect(get: '/n/1234').to route_to(
+      controller:  "notices",
+      action: "show",
+      id: "1234"
+    )
+  end
+
+end


### PR DESCRIPTION
GET requests for URLs in the form of "/n/notice_id" are now routed properly.
