### PR TITLE
Implement Redact Everywhere

### DIFF
--- a/app/assets/javascripts/rails_admin/custom/ui.js.coffee
+++ b/app/assets/javascripts/rails_admin/custom/ui.js.coffee
@@ -3,10 +3,11 @@ selectedField = null
 class Redactable
   constructor: (@input) ->
 
+  storeSelection: ->
+    $("#selected_text").val(this._selectedText())
+
   redactSelection: ->
-    selectedText = @input.value.substring(
-      @input.selectionStart, @input.selectionEnd
-    )
+    selectedText = this._selectedText()
 
     if selectedText
       @input.value = @input.value.replace(
@@ -18,6 +19,11 @@ class Redactable
   unredact: ->
     if originalInput = $("##{@input.id}_original")[0]
       @input.value = originalInput.value
+
+  _selectedText: ->
+    @input.value.substring(
+      @input.selectionStart, @input.selectionEnd
+    )
 
   _literal: (text) ->
     text.replace /([\.\+\*\?\(\[\{\)\]\}])/g, '\\$1'
@@ -32,10 +38,13 @@ addHandlers = ->
     $(textarea).focus ->
       selectedField = new Redactable this
 
-  $("button#redact-selected").click ->
+  $("#redact-selected").click ->
     selectedField?.redactSelection()
 
-  $("button#unredact-selected").click ->
+  $("#redact-selected-everywhere").click ->
+    selectedField?.storeSelection()
+
+  $("#unredact-selected").click ->
     selectedField?.unredact()
 
 $(document).ready -> addHandlers()

--- a/app/helpers/rails_admin_helper.rb
+++ b/app/helpers/rails_admin_helper.rb
@@ -1,0 +1,16 @@
+module RailsAdminHelper
+  def redact_notice_form(abstract_model, object, params, method = :post, &block)
+    options = {
+      url: redact_notice_path(
+        abstract_model, object.id, next_notices: params[:next_notices]
+      ),
+      as: abstract_model.param_key,
+      html: {
+        multipart: true,
+        method: method
+      }
+    }
+
+    simple_form_for(object, options, &block)
+  end
+end

--- a/app/views/rails_admin/application/_redact_everywhere_form.html.erb
+++ b/app/views/rails_admin/application/_redact_everywhere_form.html.erb
@@ -1,0 +1,14 @@
+<%= redact_notice_form(abstract_model, object, params) do |form| %>
+  <%= hidden_field_tag(:selected_text) %>
+  <%=
+    number_affected = params.fetch(:next_notices, []).length + 1
+
+    form.submit(
+      'Redact selection everywhere',
+      name: 'redact_everywhere',
+      id: "redact-selected-everywhere",
+      class: 'btn',
+      confirm: "Redact selected text in #{number_affected} notices?"
+    )
+  %>
+<% end %>

--- a/app/views/rails_admin/application/_redaction_form.html.erb
+++ b/app/views/rails_admin/application/_redaction_form.html.erb
@@ -1,0 +1,29 @@
+<%= redact_notice_form(abstract_model, object, params, :put) do |form| %>
+  <div id="redacted-fields">
+    <% redactable_fields.each do |field| %>
+      <%= form.input(field) %>
+    <% end %>
+  </div>
+
+  <div id="original-fields">
+    <% redactable_fields.each do |field| %>
+      <%= form.input(:"#{field}_original", input_html: { readonly: true }) %>
+    <% end %>
+  </div>
+
+  <div id="review-required">
+    <%= form.input(:review_required) %>
+    <%= form.hint "Uncheck to publish" %>
+  </div>
+
+  <div class="form-actions">
+    <%= form.submit('Save', class: 'btn btn-primary') %>
+
+    <% if next_notice_path %>
+      <%= form.submit('Save and next', name: 'save_and_next', class: 'btn btn-info') %>
+      <%= link_to('Next', next_notice_path, class: 'btn') %>
+    <% end %>
+
+    <%= link_to('Done', redact_queue_path(abstract_model), class: 'btn') %>
+  </div>
+<% end %>

--- a/app/views/rails_admin/application/redact_notice.html.erb
+++ b/app/views/rails_admin/application/redact_notice.html.erb
@@ -3,51 +3,26 @@
   <%= time_ago_in_words(@object.created_at) %>
 </p>
 
-<section id="redaction-tools">
-  <button id="redact-selected" class="btn">Redact selected text</button>
-  <button id="unredact-selected" class="btn">Unredact selected field</button>
-</section>
+<aside id="redaction-tools">
+  <%=
+    render(
+      'redact_everywhere_form',
+      abstract_model: @abstract_model,
+      object: @object
+    )
+  %>
+  <button id="redact-selected" class="btn">Redact selection</button>
+  <button id="unredact-selected" class="btn">Unredact field</button>
+</aside>
 
 <section id="redaction-form">
-  <%
-    form_options = {
-      url: redact_notice_path(
-        @abstract_model, @object.id, next_notices: params[:next_notices]
-      ),
-      as: @abstract_model.param_key,
-      html: {
-        method: :put,
-        multipart: true,
-      }
-    }
+  <%=
+    render(
+      'redaction_form',
+      abstract_model: @abstract_model,
+      object: @object,
+      redactable_fields: @redactable_fields,
+      next_notice_path: @next_notice_path
+    )
   %>
-  <%= simple_form_for(@object, form_options) do |form| %>
-    <div id="redacted-fields">
-      <% @redactable_fields.each do |field| %>
-          <%= form.input(field) %>
-      <% end %>
-    </div>
-
-    <div id="original-fields">
-      <% @redactable_fields.each do |field| %>
-        <%= form.input(:"#{field}_original", input_html: { readonly: true }) %>
-      <% end %>
-    </div>
-
-    <div id="review-required">
-      <%= form.input(:review_required) %>
-      <%= form.hint "Uncheck to publish" %>
-    </div>
-
-    <div class="form-actions">
-      <%= form.submit('Save', class: 'btn btn-primary') %>
-
-      <% if @next_notice_path %>
-        <%= form.submit('Save and next', name: 'save_and_next', class: 'btn btn-info') %>
-        <%= link_to('Next', @next_notice_path, class: 'btn') %>
-      <% end %>
-
-      <%= link_to('Done', redact_queue_path(@abstract_model), class: 'btn') %>
-    </div>
-  <% end %>
 </section>

--- a/lib/rails_admin/config/actions/redact_notice.rb
+++ b/lib/rails_admin/config/actions/redact_notice.rb
@@ -1,50 +1,105 @@
 require 'rails_admin/config/actions'
 require 'rails_admin/config/actions/base'
 
-RedactNoticeProc = Proc.new do
-  @redactable_fields = Notice::REDACTABLE_FIELDS
+ActionResponder = Struct.new(:context, :abstract_model, :object)
 
-  if params[:next_notices].present?
+class PostResponder < ActionResponder
+  def handle(params)
+    if params[:selected_text].present?
+      redactor = RedactsNotices.new([
+        RedactsNotices::RedactsContent.new(params[:selected_text])
+      ])
+
+      next_notice_ids = params.fetch(:next_notices, []).map(&:to_i)
+
+      redactor.redact_all([object.id] + next_notice_ids)
+    end
+
+    redirect_to_current(params)
+  end
+
+  private
+
+  def redirect_to_current(params)
+    context.redirect_to(context.redact_notice_path(
+      abstract_model, object.id, next_notices: params[:next_notices]
+    ))
+  end
+end
+
+class PutResponder < ActionResponder
+  def handle(params)
+    attributes = params[abstract_model.param_key]
+
+    Notice::REDACTABLE_FIELDS.each do |field|
+      object.send(:"#{field}=", attributes[field])
+      object.send(:"#{field}_original=", attributes["#{field}_original"])
+    end
+
+    object.review_required = attributes[:review_required]
+
+    if object.save
+      context.respond_to do |format|
+        format.html { respond_html(params) }
+        format.js { respond_json }
+      end
+    else
+      handle_error
+    end
+  end
+
+  private
+
+  def respond_html(params)
+    if params[:save_and_next]
+      save_and_next(params)
+    else
+      context.redirect_to context.redact_queue_path(abstract_model)
+    end
+  end
+
+  def respond_json
+    context.render json: { id: object.id.to_s, label: "Redact notice" }
+  end
+
+  def handle_error
+    context.handle_save_error :redact_notice
+  end
+
+  def save_and_next(params)
     next_notice, *next_notices = params[:next_notices]
 
-    @next_notice_path = redact_notice_path(
-      @abstract_model, next_notice, next_notices: next_notices
-    )
+    context.redirect_to(context.redact_notice_path(
+      abstract_model, next_notice, next_notices: next_notices
+    ))
+  end
+end
+
+RedactNoticeProc = Proc.new do
+  if request.post?
+    post_responder = PostResponder.new(self, @abstract_model, @object)
+    post_responder.handle(params)
+  end
+
+  if request.put?
+    put_responder = PutResponder.new(self, @abstract_model, @object)
+    put_responder.handle(params)
   end
 
   if request.get?
+    @redactable_fields = Notice::REDACTABLE_FIELDS
+
+    if params[:next_notices].present?
+      next_notice, *next_notices = params[:next_notices]
+
+      @next_notice_path = redact_notice_path(
+        @abstract_model, next_notice, next_notices: next_notices
+      )
+    end
+
     respond_to do |format|
       format.html { render @action.template_name }
       format.js   { render @action.template_name, :layout => false }
-    end
-  elsif request.put?
-    attributes = params[@abstract_model.param_key]
-
-    @redactable_fields.each do |field|
-      @object.send(:"#{field}=", attributes[field])
-      @object.send(:"#{field}_original=", attributes["#{field}_original"])
-    end
-
-    @object.review_required = attributes[:review_required]
-
-    if @object.save
-      respond_to do |format|
-        format.html {
-          if params[:save_and_next] && @next_notice_path
-            redirect_to @next_notice_path
-          else
-            redirect_to redact_queue_path(@abstract_model)
-          end
-        }
-        format.js {
-          render json: {
-            id: @object.id.to_s,
-            label: @model_config.with(object: @object).object_label
-          }
-        }
-      end
-    else
-      handle_save_error :redact_notice
     end
   end
 end
@@ -52,10 +107,12 @@ end
 module RailsAdmin
   module Config
     module Actions
-      class RedactNotice < Edit
+      class RedactNotice < Base
         register_instance_option(:only) { 'Notice' }
-        register_instance_option(:action_name) { :redact_notice }
         register_instance_option(:link_icon) { 'icon-adjust' }
+        register_instance_option(:action_name) { :redact_notice }
+        register_instance_option(:member) { true }
+        register_instance_option(:http_methods) { %i( get post put ) }
         register_instance_option(:controller) { RedactNoticeProc }
         register_instance_option :visible? do
           bindings && (object = bindings[:object]) &&

--- a/spec/integration/redaction_spec.rb
+++ b/spec/integration/redaction_spec.rb
@@ -27,8 +27,6 @@ feature "Redactable fields" do
     end
 
     context "Manual redaction" do
-      before { FakeWeb.allow_net_connect = true }
-
       scenario "Redacting selected text in #{field}", js: true do
         visit_redact_notice
         redactable_field = RedactableFieldOnPage.new(field)
@@ -73,32 +71,6 @@ feature "Redactable fields" do
         visit "/admin/notice/#{notice.id}/redact_notice"
 
         notice
-      end
-
-      class RedactableFieldOnPage < PageObject
-        def initialize(name)
-          @name = name
-        end
-
-        def unredact
-          page.find("#notice_#{@name}").click
-
-          click_on "Unredact selected field"
-        end
-
-        def select_and_redact
-          page.execute_script <<-EOS
-            document.getElementById('notice_#{@name}').focus();
-            document.getElementById('notice_#{@name}').select();
-          EOS
-
-          click_on 'Redact selected text'
-        end
-
-        def has_content?(content)
-          page.find("#notice_#{@name}").value == content
-        end
-
       end
     end
   end

--- a/spec/integration/submit_notice_via_api_spec.rb
+++ b/spec/integration/submit_notice_via_api_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 feature "notice submission" do
   include CurbHelpers
 
-  before do
-    FakeWeb.allow_net_connect = true
-  end
-
   scenario "submitting an incomplete notice", js: true do
     with_curb_post_for_json('notices','{"notice": {"title": "foo" } }') do |curb_response|
       expect(curb_response.response_code).to eq 422

--- a/spec/support/live_searching.rb
+++ b/spec/support/live_searching.rb
@@ -1,7 +1,6 @@
 RSpec.configure do |config|
   config.before(:each, search: false) do
     # Mock Elasticsearch for non-search scenarios
-    FakeWeb.allow_net_connect = false
     FakeWeb.register_uri(:any, %r|\Ahttp://localhost:9200|, :body => "{}")
   end
 

--- a/spec/support/page_objects/redactable_field_on_page.rb
+++ b/spec/support/page_objects/redactable_field_on_page.rb
@@ -1,0 +1,30 @@
+require_relative '../page_object'
+
+class RedactableFieldOnPage < PageObject
+  def initialize(name)
+    @name = name
+  end
+
+  def unredact
+    page.find("#notice_#{@name}").click
+
+    click_on "Unredact field"
+  end
+
+  def select
+    page.execute_script <<-EOS
+      document.getElementById('notice_#{@name}').focus();
+      document.getElementById('notice_#{@name}').select();
+    EOS
+  end
+
+  def select_and_redact
+    select
+
+    click_on 'Redact selection'
+  end
+
+  def has_content?(content)
+    page.find("#notice_#{@name}").value == content
+  end
+end

--- a/spec/support/page_objects/redaction_queue_on_page.rb
+++ b/spec/support/page_objects/redaction_queue_on_page.rb
@@ -1,0 +1,68 @@
+require_relative '../page_object'
+
+class RedactionQueueOnPage < PageObject
+  def visit_as(user)
+    visit '/users/sign_in'
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password
+    click_on "Sign in"
+
+    visit "/admin/notice/redact_queue"
+  end
+
+  def fill
+    within_profiles { click_on 'Fill' }
+  end
+
+  def select_category_profile(category)
+    select category.name, from: "In categories"
+  end
+
+  def select_submitter_profile(entity)
+    select entity.name, from: "Submitted by"
+  end
+
+  def has_notices?(notices)
+    actual_ids = page.all(".queue_item").map { |element| element[:id] }
+    expected_ids = notices.map { |notice| "notice_#{notice.id}" }
+
+    actual_ids.sort == expected_ids.sort
+  end
+
+  def select_notice(notice)
+    within("tr#notice_#{notice.id}") { check "selected[]" }
+  end
+
+  def process_selected
+    click_on 'Process selected'
+  end
+
+  def redact_everywhere
+    page.execute_script 'window.original_confirm = window.confirm'
+    page.execute_script 'window.confirm = function(msg) { return true; }'
+
+    click_on 'Redact selection everywhere'
+  ensure
+    page.execute_script 'window.confirm = window.original_confirm'
+  end
+
+  def publish_and_next
+    uncheck 'Review required'
+    click_on 'Save and next'
+  end
+
+  def publish
+    uncheck 'Review required'
+    click_on 'Save'
+  end
+
+  def has_next?
+    has_css?("input[value='Save and next']")
+  end
+
+  private
+
+  def within_profiles(&block)
+    within('#refill-queue', &block)
+  end
+end

--- a/spec/support/rails_admin_action_context.rb
+++ b/spec/support/rails_admin_action_context.rb
@@ -8,7 +8,7 @@ module RailsAdminActionContext
     @format = double("Format", html: nil, js: nil)
     @params = HashWithIndifferentAccess.new
 
-    @object = double("Object", save: false).as_null_object
+    @object = double("Object", id: 1, save: false).as_null_object
     @action = double("Action", template_name: '')
     @abstract_model = double("Abstract model", param_key: nil)
     @model_config = double("Model config", with: nil)


### PR DESCRIPTION
- Refactors RedactsNotices to redact static text and redact multiple 
  notices at once
- Refactors custom Rails Action Proc into separate "Responder" classes
- Adds button to Redact tool to POST
- Implement PostResponder to redact all enqueued notices via 
  RedactsNotices#redact_all
