### PR TITLE
Make notices rescindable

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -33,7 +33,14 @@ class NoticesController < ApplicationController
     @notice = Notice.find(params[:id])
 
     respond_to do |format|
-      format.html
+      format.html do
+        if @notice.rescinded?
+          render :rescinded
+        else
+          render :show
+        end
+      end
+
       format.json { render json: @notice }
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -28,6 +28,7 @@ class Ability
       can :redact_notice, Notice
       can :redact_queue, Notice
       can :publish, Notice
+      can :rescind, Notice
     end
 
     if user.has_role?(Role.super_admin)

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -59,6 +59,7 @@ class Notice < ActiveRecord::Base
     indexes :id, index: 'not_analyzed', include_in_all: false
     indexes :title
     indexes :date_received, type: 'date', include_in_all: false
+    indexes :rescinded, type: 'boolean', include_in_all: false
     indexes :tag_list, as: 'tag_list'
     indexes :jurisdiction_list, as: 'jurisdiction_list'
     indexes :sender_name, as: 'sender_name'
@@ -112,6 +113,19 @@ class Notice < ActiveRecord::Base
     joins(entity_notice_roles: :entity).
       where('entity_notice_roles.name' => :submitter).
       where('entities.id' => submitters)
+  end
+
+  def self.add_default_filter(search)
+    filter = TermFilter.new(:rescinded)
+    filter.apply_to_search(search, :rescinded, false)
+  end
+
+  def active_model_serializer
+    if rescinded?
+      RescindedNoticeSerializer
+    else
+      super
+    end
   end
 
   def all_relevant_questions

--- a/app/views/notices/rescinded.html.erb
+++ b/app/views/notices/rescinded.html.erb
@@ -1,0 +1,4 @@
+<article class="notice-show">
+  <h1><%= @notice.title %></h1>
+  <h3>Notice Rescinded</h3>
+</article>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -43,6 +43,13 @@ RailsAdmin.config do |config|
           ability.can? :publish, Notice
         end
       end
+
+      configure :rescinded do
+        visible do
+          ability = Ability.new(bindings[:view]._current_user)
+          ability.can? :rescind, Notice
+        end
+      end
     end
   end
 

--- a/db/migrate/20130724184523_add_rescinded_to_notices.rb
+++ b/db/migrate/20130724184523_add_rescinded_to_notices.rb
@@ -1,0 +1,5 @@
+class AddRescindedToNotices < ActiveRecord::Migration
+  def change
+    add_column(:notices, :rescinded, :boolean, null: false, default: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -157,11 +157,11 @@ ActiveRecord::Schema.define(:version => 20130725180215) do
   add_index "infringing_urls_works", ["work_id"], :name => "index_infringing_urls_works_on_work_id"
 
   create_table "notices", :force => true do |t|
-    t.string   "title",                :null => false
+    t.string   "title",                                   :null => false
     t.text     "body"
     t.datetime "date_received"
-    t.datetime "created_at",           :null => false
-    t.datetime "updated_at",           :null => false
+    t.datetime "created_at",                              :null => false
+    t.datetime "updated_at",                              :null => false
     t.string   "source"
     t.string   "subject"
     t.text     "legal_other"
@@ -171,6 +171,7 @@ ActiveRecord::Schema.define(:version => 20130725180215) do
     t.datetime "date_sent"
     t.integer  "reviewer_id"
     t.string   "language"
+    t.boolean  "rescinded",            :default => false, :null => false
   end
 
   add_index "notices", ["reviewer_id"], :name => "index_notices_on_reviewer_id"

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -12,13 +12,22 @@ describe NoticesController do
     end
 
     context "as HTML" do
-      it "renders a template" do
+      it "renders the show template" do
         stub_find_notice
 
         get :show, id: 1
 
         expect(response).to be_successful
         expect(response).to render_template(:show)
+      end
+
+      it "renders the rescinded template if the notice is rescinded" do
+        stub_find_notice(build(:notice, rescinded: true))
+
+        get :show, id: 1
+
+        expect(response).to be_successful
+        expect(response).to render_template(:rescinded)
       end
     end
 
@@ -35,10 +44,23 @@ describe NoticesController do
         expect(json).to have_key(:id).with_value(notice.id)
         expect(json).to have_key(:title).with_value(notice.title)
       end
+
+      it "returns id, title and 'Notice Rescinded' as body for a rescinded notice" do
+        notice = build(:notice, rescinded: true)
+        stub_find_notice(notice)
+
+        get :show, id: 1, format: :json
+
+        json = JSON.parse(response.body)["notice"]
+        expect(json).to have_key(:id).with_value(notice.id)
+        expect(json).to have_key(:title).with_value(notice.title)
+        expect(json).to have_key(:body).with_value("Notice Rescinded")
+      end
     end
 
-    def stub_find_notice
-      Notice.new.tap { |notice| Notice.stub(:find).and_return(notice) }
+    def stub_find_notice(notice = nil)
+      notice ||= Notice.new
+      notice.tap { |n| Notice.stub(:find).and_return(n) }
     end
   end
 

--- a/spec/integration/notice_search_spec.rb
+++ b/spec/integration/notice_search_spec.rb
@@ -5,7 +5,7 @@ feature "Searching Notices" do
   include SearchHelpers
 
   scenario "displays search terms", search: true do
-    notice = create(:notice, title: "The Lion King on Youtube")
+    create(:notice, title: "The Lion King on Youtube")
 
     submit_search 'awesome blossom'
 
@@ -34,6 +34,12 @@ feature "Searching Notices" do
       expect(page).to have_css('a[rel="next"]')
       expect(page).to have_css('a[rel="prev start"]')
     end
+  end
+
+  scenario "it does not include rescinded notices", search: true do
+    notice = create(:notice, title: "arbitrary", rescinded: true)
+
+    expect_search_to_not_find("arbitrary", notice)
   end
 
   context "within associated models" do

--- a/spec/integration/user_authorizes_spec.rb
+++ b/spec/integration/user_authorizes_spec.rb
@@ -130,6 +130,21 @@ feature "User authorization" do
     end
   end
 
+  scenario "Redactors and Publishers cannot rescind notices" do
+    notice = create(:notice)
+    users = [
+      AdminOnPage.new(create(:user, :redactor)),
+      AdminOnPage.new(create(:user, :publisher))
+    ]
+
+    users.each do |user|
+      user.sign_in
+      user.edit(notice)
+
+      expect(page).not_to have_css('input#notice_rescinded')
+    end
+  end
+
   scenario "Admins and Super admins can edit site data" do
     category = create(:category)
     users = [
@@ -142,6 +157,21 @@ feature "User authorization" do
       user.edit(category, Name: "New name #{idx}")
 
       expect(category.reload.name).to eq "New name #{idx}"
+    end
+  end
+
+  scenario "Admins and Super admins can rescind notices" do
+    notice = create(:notice)
+    users = [
+      AdminOnPage.new(create(:user, :admin)),
+      AdminOnPage.new(create(:user, :super_admin))
+    ]
+
+    users.each do |user|
+      user.sign_in
+      user.edit(notice)
+
+      expect(page).to have_css('input#notice_rescinded')
     end
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -27,6 +27,10 @@ describe Ability do
     it "cannot publish" do
       expect(subject.can? :publish, notice).to be_false
     end
+
+    it "cannot rescind" do
+      expect(subject.can? :rescind, notice).to be_false
+    end
   end
 
   context "a publisher" do
@@ -36,6 +40,10 @@ describe Ability do
 
     it "can publish" do
       expect(subject.can? :publish, notice).to be_true
+    end
+
+    it "cannot rescind" do
+      expect(subject.can? :rescind, notice).to be_false
     end
   end
 
@@ -52,6 +60,10 @@ describe Ability do
       expect(subject.can? :edit, notice).to be_true
       expect(subject.can? :edit, category).to be_true
       expect(subject.can? :edit, blog_entry).to be_true
+    end
+
+    it "can rescind" do
+      expect(subject.can? :rescind, notice).to be_true
     end
 
     it "cannot edit users or role" do


### PR DESCRIPTION
- Add a boolean flag to notices, only admin+ can access
- Use custom serializer for rescinded notices
- Show custom template for rescinded notices
- Add default filter keeping rescinded notices out of search entirely
