### PR TITLE
Add Notice#action_taken

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -59,6 +59,7 @@ class NoticesController < ApplicationController
       :tag_list,
       :jurisdiction_list,
       :language,
+      :action_taken,
       category_ids: [],
       file_uploads_attributes: [:file],
       entity_notice_roles_attributes: [

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -20,6 +20,8 @@ class Notice < ActiveRecord::Base
   UNDER_REVIEW_VALUE = 'Under review'
   RANGE_SEPARATOR = '..'
 
+  VALID_ACTIONS = %w( Yes No Partial )
+
   belongs_to :reviewer, class_name: 'User'
 
   has_many :categorizations, dependent: :destroy
@@ -37,6 +39,7 @@ class Notice < ActiveRecord::Base
 
   has_and_belongs_to_many :works
 
+  validates_inclusion_of :action_taken, in: VALID_ACTIONS
   validates_inclusion_of :language, in: Language.codes, allow_blank: true
   validates_presence_of :works, :entity_notice_roles
 
@@ -48,6 +51,8 @@ class Notice < ActiveRecord::Base
   accepts_nested_attributes_for :entity_notice_roles
 
   accepts_nested_attributes_for :works
+
+  after_initialize :set_default_action_taken
 
   after_touch { tire.update_index }
 
@@ -182,6 +187,12 @@ class Notice < ActiveRecord::Base
   end
 
   private
+
+  def set_default_action_taken
+    if action_taken.blank?
+      self.action_taken = 'No'
+    end
+  end
 
   def entities_that_have_submitted
     entity_notice_roles.submitters.map(&:entity)

--- a/app/views/notices/new.html.erb
+++ b/app/views/notices/new.html.erb
@@ -23,6 +23,7 @@
         %>
         <%= form.input :language, collection: Language.codes %>
         <%= form.input :jurisdiction_list, label: "Jurisdiction", placeholder: 'a list of countries - US, CA, etc.' %>
+        <%= form.input :action_taken, collection: Notice::VALID_ACTIONS %>
       </div>
       <div class="body-wrapper right attach">
         <%= form.input :body, label: "Notice Body" %>

--- a/db/migrate/20130730153030_add_action_taken_to_notices.rb
+++ b/db/migrate/20130730153030_add_action_taken_to_notices.rb
@@ -1,0 +1,5 @@
+class AddActionTakenToNotices < ActiveRecord::Migration
+  def change
+    add_column(:notices, :action_taken, :string, null: false, default: 'No')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130725180215) do
+ActiveRecord::Schema.define(:version => 20130730153030) do
 
   create_table "blog_entries", :force => true do |t|
     t.integer  "user_id"
@@ -172,6 +172,7 @@ ActiveRecord::Schema.define(:version => 20130725180215) do
     t.integer  "reviewer_id"
     t.string   "language"
     t.boolean  "rescinded",            :default => false, :null => false
+    t.string   "action_taken",         :default => "No",  :null => false
   end
 
   add_index "notices", ["reviewer_id"], :name => "index_notices_on_reviewer_id"

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -24,6 +24,19 @@ feature "notice submission" do
     pending "We don't display language yet"
   end
 
+  scenario "submitting a notice with action taken" do
+    submit_recent_notice do
+      select "Yes", from: "Action taken"
+    end
+
+    open_recent_notice
+
+    notice = Notice.last
+    expect(notice.action_taken).to eq 'Yes'
+
+    pending "We don't display action taken yet"
+  end
+
   scenario "submitting a notice with a jurisdiction" do
     submit_recent_notice do
       fill_in "Jurisdiction", with: 'US, foobar'

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -4,6 +4,7 @@ describe Notice do
   it { should validate_presence_of :works }
   it { should validate_presence_of :entity_notice_roles }
   it { should ensure_inclusion_of(:language).in_array(Language.codes) }
+  it { should ensure_inclusion_of(:action_taken).in_array(Notice::VALID_ACTIONS) }
 
   context 'automatic validations' do
     it { should validate_presence_of :title }
@@ -22,6 +23,12 @@ describe Notice do
   it_behaves_like "an object with a recent scope"
   it_behaves_like "an object tagged in the context of", "tag", case_insensitive: true
   it_behaves_like "an object tagged in the context of", "jurisdiction"
+
+  it "defaults to no action taken" do
+    notice = Notice.new
+
+    expect(notice.action_taken).to eq 'No'
+  end
 
   context "entity notice roles" do
     context 'with entities' do


### PR DESCRIPTION
I've held off on adding this field to search or the view, only put it in 
the DB and added an input to the submission form (like I did with 
language).

I suspect we'll be reevaluating all fields in light of the notice-types 
work, so I'm just getting the new ones in place for now.
