### PR TITLE
Implement the "Attach another" button.

### DIFF
--- a/app/assets/javascripts/notices_new.js.coffee
+++ b/app/assets/javascripts/notices_new.js.coffee
@@ -1,3 +1,16 @@
+addFileUploadInput = (field, parent, updateContainer) ->
+  containers = parent.find(".notice_file_uploads_#{field}")
+
+  nextId = "notice_file_uploads_attributes_#{containers.length}_#{field}"
+  nextName =  "notice[file_uploads_attributes][#{containers.length}][#{field}]"
+
+  container = containers.last()
+  newContainer = container.clone()
+
+  updateContainer(newContainer, nextId, nextName)
+
+  newContainer.insertAfter(container)
+
 $('#new_notice select').each ->
   $(this).select2
     placeholder: ''
@@ -8,3 +21,13 @@ $('#notice_date_sent').datepicker
 
 $('#notice_date_received').datepicker
   format: 'yyyy-mm-dd'
+
+$('.attach #add-another').click ->
+  parent = $(this).parent()
+
+  addFileUploadInput 'file', parent, (newContainer, nextId, nextName) ->
+    newContainer.find('input').attr('id', nextId).attr('name', nextName)
+    newContainer.find('label').attr('for', nextId).html('Other Documents')
+
+  addFileUploadInput 'kind', parent, (newContainer, nextId, nextName) ->
+    newContainer.find('input').attr('id', nextId).attr('name', nextName).attr('value', 'supporting')

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -9,7 +9,7 @@ class NoticesController < ApplicationController
     model_class = get_notice_type(params)
 
     @notice = model_class.new
-    @notice.file_uploads.build
+    @notice.file_uploads.build(kind: 'original')
     model_class::DEFAULT_ENTITY_NOTICE_ROLES.each do |role|
       @notice.entity_notice_roles.build(name: role).build_entity
     end
@@ -79,7 +79,7 @@ class NoticesController < ApplicationController
       :language,
       :action_taken,
       category_ids: [],
-      file_uploads_attributes: [:file],
+      file_uploads_attributes: [:kind, :file],
       entity_notice_roles_attributes: [
         :entity_id,
         :name,

--- a/app/models/file_upload.rb
+++ b/app/models/file_upload.rb
@@ -3,6 +3,8 @@ require 'validates_automatically'
 class FileUpload < ActiveRecord::Base
   include ValidatesAutomatically
 
+  validates_inclusion_of :kind, in: %w( original supporting )
+
   belongs_to :notice
 
   has_attached_file :file

--- a/app/views/notices/_court_order_form.html.erb
+++ b/app/views/notices/_court_order_form.html.erb
@@ -30,7 +30,8 @@
       <%= form.input :legal_other, label: "Legal (Other)" %>
       <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
         <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="#" onclick="return false;" class="add wip">Attach another</a>
+        <a href="#" id="add-another">Attach another</a>
+        <%= file_uploads_form.input :kind, as: :hidden %>
       <% end %>
     </div>
   </section>

--- a/app/views/notices/_defamation_form.html.erb
+++ b/app/views/notices/_defamation_form.html.erb
@@ -30,7 +30,8 @@
       <%= form.input :legal_other, label: "Legal (Other)" %>
       <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
         <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="#" onclick="return false;" class="add wip">Attach another</a>
+        <a href="#" id="add-another">Attach another</a>
+        <%= file_uploads_form.input :kind, as: :hidden %>
       <% end %>
     </div>
   </section>

--- a/app/views/notices/_dmca_form.html.erb
+++ b/app/views/notices/_dmca_form.html.erb
@@ -30,7 +30,8 @@
       <%= form.input :legal_other, label: "Legal (Other)" %>
       <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
         <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="#" onclick="return false;" class="add wip">Attach another</a>
+        <a href="#" id="add-another">Attach another</a>
+        <%= file_uploads_form.input :kind, as: :hidden %>
       <% end %>
     </div>
   </section>

--- a/app/views/notices/_international_form.html.erb
+++ b/app/views/notices/_international_form.html.erb
@@ -30,7 +30,8 @@
       <%= form.input :legal_other, label: "Legal (Other)" %>
       <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
         <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="#" onclick="return false;" class="add wip">Attach another</a>
+        <a href="#" id="add-another">Attach another</a>
+        <%= file_uploads_form.input :kind, as: :hidden %>
       <% end %>
     </div>
   </section>

--- a/app/views/notices/_law_enforcement_request_form.html.erb
+++ b/app/views/notices/_law_enforcement_request_form.html.erb
@@ -30,7 +30,8 @@
       <%= form.input :legal_other, label: "Legal (Other)" %>
       <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
         <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="#" onclick="return false;" class="add wip">Attach another</a>
+        <a href="#" id="add-another">Attach another</a>
+        <%= file_uploads_form.input :kind, as: :hidden %>
       <% end %>
     </div>
   </section>

--- a/app/views/notices/_other_form.html.erb
+++ b/app/views/notices/_other_form.html.erb
@@ -30,7 +30,8 @@
       <%= form.input :legal_other, label: "Legal (Other)" %>
       <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
         <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="#" onclick="return false;" class="add wip">Attach another</a>
+        <a href="#" id="add-another">Attach another</a>
+        <%= file_uploads_form.input :kind, as: :hidden %>
       <% end %>
     </div>
   </section>

--- a/app/views/notices/_private_information_form.html.erb
+++ b/app/views/notices/_private_information_form.html.erb
@@ -30,7 +30,8 @@
       <%= form.input :legal_other, label: "Legal (Other)" %>
       <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
         <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="#" onclick="return false;" class="add wip">Attach another</a>
+        <a href="#" id="add-another">Attach another</a>
+        <%= file_uploads_form.input :kind, as: :hidden %>
       <% end %>
     </div>
   </section>

--- a/app/views/notices/_trademark_form.html.erb
+++ b/app/views/notices/_trademark_form.html.erb
@@ -30,7 +30,8 @@
       <%= form.input :legal_other, label: "Legal (Other)" %>
       <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
         <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="#" onclick="return false;" class="add wip">Attach another</a>
+        <a href="#" id="add-another">Attach another</a>
+        <%= file_uploads_form.input :kind, as: :hidden %>
       <% end %>
     </div>
   </section>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -116,6 +116,8 @@ FactoryGirl.define do
       content "Content"
     end
 
+    kind 'original'
+
     file do
       Tempfile.open('factory_file') do |fh|
         fh.write(content)

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -67,14 +67,41 @@ feature "notice submission" do
     end
   end
 
-  scenario "submitting a notice with an attached file" do
+  scenario "submitting a notice with an original attached" do
+    submit_recent_notice { attach_notice }
+
+    open_recent_notice
+
+    pending "We don't display originals yet"
+  end
+
+  scenario "submitting a notice with a supporting document", js: true do
     submit_recent_notice do
-      attach_notice_file("Some content")
+      add_supporting_document("Some supporting content")
     end
 
     open_recent_notice
 
-    pending "We don't use the attached file yet"
+    within('ol.attachments') do
+      click_on "Supporting Document"
+
+      # page.html is actually plain-text in this case
+      expect(page.html).to eq "Some supporting content"
+    end
+  end
+
+  scenario "submitting a notice with multiple supporting documents", js: true do
+    submit_recent_notice do
+      add_supporting_document
+      add_supporting_document
+      add_supporting_document
+    end
+
+    open_recent_notice
+
+    within('ol.attachments') do
+      expect(page).to have_css('li', 3)
+    end
   end
 
   scenario "submitting a notice with tags" do

--- a/spec/models/file_upload_spec.rb
+++ b/spec/models/file_upload_spec.rb
@@ -4,6 +4,7 @@ describe FileUpload do
   it { should have_attached_file(:file) }
   it { should belong_to :notice }
   it { should have_db_index :notice_id }
+  it { should ensure_inclusion_of(:kind).in_array %w( original supporting ) }
 
   context 'automatic validations' do
     it { should ensure_length_of(:kind).is_at_most(255) }

--- a/spec/support/notice_actions.rb
+++ b/spec/support/notice_actions.rb
@@ -26,12 +26,29 @@ module NoticeActions
     within('#recent-notices') { click_on title }
   end
 
-  def attach_notice_file(content)
-    Tempfile.open('notice_file') do |fh|
-      fh.write content
-      fh.flush
+  def attach_notice(content = "Some content")
+    with_file(content) { |file| attach_file "Attach Notice", file.path }
+  end
 
-      attach_file "Attach Notice", fh.path
+  def add_supporting_document(content = "Some content")
+    @field_index ||= 0
+    @field_index  += 1
+
+    click_on "Attach another"
+
+    field_name = "notice_file_uploads_attributes_#{@field_index}_file"
+
+    with_file(content) do |file|
+      attach_file field_name, file.path
+    end
+  end
+
+  def with_file(content)
+    Tempfile.open('file') do |file|
+      file.write content
+      file.flush
+
+      yield(file)
     end
   end
 end


### PR DESCRIPTION
The initial input says "Attach Notice" and adds a file upload of kind 
"original". Additional inputs say "Supporting Document" and add file 
uploads of kind "supporting".

"original"s are not available except to admins (or possibly by specific 
request to researchers). "supporting" documents will be added to the 
show-notice page for download.

For now the integration specs are pending since we can't see the 
documents anywhere. I'm going to start a new branch for that. I may 
merge that one first so that I can rebase and finalize the integration 
specs here before merging this.

Note: once the types branch is merged, only my addition of the hidden 
input for file_upload[kind] will need to be propagated to the 
type-specific partials.
