### PR TITLE
Download supporting documents

### DIFF
--- a/app/models/file_upload.rb
+++ b/app/models/file_upload.rb
@@ -6,4 +6,15 @@ class FileUpload < ActiveRecord::Base
   belongs_to :notice
 
   has_attached_file :file
+
+  delegate :url, to: :file
+
+  def file_type
+    case file_content_type
+    when 'application/pdf' then 'PDF'
+    when /\Aimage\// then 'Image'
+    else 'Document'
+    end
+  end
+
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -158,6 +158,10 @@ class Notice < ActiveRecord::Base
     super(tag_list_value)
   end
 
+  def supporting_documents
+    file_uploads.where(kind: 'supporting')
+  end
+
   private
 
   def entities_that_have_submitted

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -18,29 +18,12 @@
       <section class="attachments">
         <h5 class="title">Supporting Documents</h5>
         <ol class="attachments">
-          <% 3.times do %>
-            <li class="pdf">
-            <a href="#">
-              <span>Supporting PDF</span>
-              <span class="download">Download</span>
-            </a>
-            </li>
-          <% end %>
-
-          <% 3.times do %>
-            <li class="image">
-            <a href="#">
-              <span>Supporting Image</span>
-              <span class="download">Download</span>
-            </a>
-            </li>
-          <% end %>
-          <% 3.times do %>
-            <li class="">
-            <a href="#">
-              <span>Supporting Document</span>
-              <span class="download">Download</span>
-            </a>
+          <% @notice.supporting_documents.each do |document| %>
+            <li class="<%= document.file_type.downcase %>">
+              <%= link_to(document.url) do %>
+                <span>Supporting <%= document.file_type %></span>
+                <span class="download">Download</span>
+              <% end %>
             </li>
           <% end %>
         </ol>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -74,6 +74,34 @@ FactoryGirl.define do
       review_required true
     end
 
+    trait :with_original do
+      before(:create) do |notice|
+        notice.file_uploads << build(:file_upload, kind: 'original')
+      end
+    end
+
+    trait :with_document do
+      before(:create) do |notice|
+        notice.file_uploads << build(:file_upload, kind: 'supporting')
+      end
+    end
+
+    trait :with_pdf do
+      before(:create) do |notice|
+        notice.file_uploads << build(
+          :file_upload, kind: 'supporting', file_content_type: 'application/pdf'
+        )
+      end
+    end
+
+    trait :with_image do
+      before(:create) do |notice|
+        notice.file_uploads << build(
+          :file_upload, kind: 'supporting', file_content_type: 'image/jpeg'
+        )
+      end
+    end
+
     factory :trademark, class: 'Trademark'
     factory :defamation, class: 'Defamation'
     factory :international, class: 'International'

--- a/spec/models/dmca_spec.rb
+++ b/spec/models/dmca_spec.rb
@@ -305,4 +305,19 @@ describe Dmca do
       expect(notices).to match_array(expected_notices)
     end
   end
+
+  context "#supporting_documents" do
+    it "returns file uploads of kind 'supporting'" do
+      file_uploads = [
+        build(:file_upload, kind: 'original'),
+        build(:file_upload, kind: 'supporting'),
+        build(:file_upload, kind: 'supporting'),
+      ]
+
+      notice = create(:dmca, file_uploads: file_uploads)
+
+      expect(notice).to have(2).supporting_documents
+      expect(notice.supporting_documents).to be_all { |d| d.kind == 'supporting' }
+    end
+  end
 end

--- a/spec/models/file_upload_spec.rb
+++ b/spec/models/file_upload_spec.rb
@@ -4,7 +4,42 @@ describe FileUpload do
   it { should have_attached_file(:file) }
   it { should belong_to :notice }
   it { should have_db_index :notice_id }
+
   context 'automatic validations' do
     it { should ensure_length_of(:kind).is_at_most(255) }
+  end
+
+  context "file_type" do
+    it "returns PDF for PDFs" do
+      for_each_mime_type(['application/pdf']) do |file_upload|
+        expect(file_upload.file_type).to eq 'PDF'
+      end
+    end
+
+    it "returns Image for mime types that begin with image/" do
+      mime_types = %w( image/jpeg image/png image/anything )
+
+      for_each_mime_type(mime_types) do |file_upload|
+        expect(file_upload.file_type).to eq 'Image'
+      end
+    end
+
+    it "returns Document for anything else" do
+      mime_types = %w( video/mp4 application/octet-stream not-image/flim-flam )
+
+      for_each_mime_type(mime_types) do |file_upload|
+        expect(file_upload.file_type).to eq 'Document'
+      end
+    end
+  end
+
+  private
+
+  def for_each_mime_type(mime_types, &block)
+    mime_types.each do |mime|
+      file_upload = FileUpload.new(file_content_type: mime)
+
+      yield file_upload
+    end
   end
 end

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -161,6 +161,33 @@ describe 'notices/show.html.erb' do
     end
   end
 
+  it "does not link to the notices original" do
+    notice = create(:dmca, :with_original)
+    original = notice.file_uploads.first
+    assign(:notice, notice)
+
+    render
+
+    within('ol.attachments') do
+      expect(page).not_to contain_link(original.url)
+    end
+  end
+
+  it "shows links to supporting documents" do
+    notice = create(:dmca, :with_pdf, :with_image, :with_document)
+    assign(:notice, notice)
+
+    render
+
+    notice.file_uploads.each do |file_upload|
+      within("ol.attachments .#{file_upload.file_type.downcase}") do
+        expect(page).to contain_link(file_upload.url)
+      end
+    end
+  end
+
+  private
+
   def have_facet_link(facet, value)
     have_css(
       "a[href='#{faceted_search_path(facet => value)}']",


### PR DESCRIPTION
This change assumes the functionality of the other PR (for uploading), 
so there is no real way to test other then set something up in admin.

I'd like to merge this first, then rebase the other so I can un-pend the 
integration specs now that we can get the uploaded documents back out 
again.
