### PR TITLE
Fix advanced searches of multiple fields

### DIFF
--- a/app/models/date_range_filter.rb
+++ b/app/models/date_range_filter.rb
@@ -15,7 +15,7 @@ class DateRangeFilter
   def apply_to_search(searcher, param, value)
     if handles?(param)
       date_range_filter = filter_for(value)
-      searcher.filter *date_range_filter
+      searcher.filter(*date_range_filter)
     end
   end
 
@@ -32,10 +32,12 @@ class DateRangeFilter
 
   def filter_for(value)
     filter_values = FilterRangeValues.new(value)
-    [
-      :range,
-      @indexed_attribute => { from: filter_values.from, to: filter_values.to }
-    ]
+
+    [:range, @indexed_attribute => filter_values.to_attribute]
+  end
+
+
+  def apply_to_query(*)
   end
 
   private
@@ -55,12 +57,14 @@ class DateRangeFilter
   end
 
   class FilterRangeValues
-    attr_reader :from, :to
-
     def initialize(time_value)
       @from, @to = time_value.split(Notice::RANGE_SEPARATOR, 2).map do |str|
         Time.at(str.to_i / 1000)
       end
+    end
+
+    def to_attribute
+      { from: @from, to: @to }
     end
   end
 

--- a/app/models/term_filter.rb
+++ b/app/models/term_filter.rb
@@ -19,7 +19,7 @@ class TermFilter
   def apply_to_search(searcher, param, value)
     if handles?(param)
       term_filter = filter_for(value)
-      searcher.filter *term_filter
+      searcher.filter(*term_filter)
     end
   end
 
@@ -31,6 +31,9 @@ class TermFilter
     searcher.facet local_parameter do
       terms local_indexed_attribute
     end
+  end
+
+  def apply_to_query(*)
   end
 
   private

--- a/app/models/term_search.rb
+++ b/app/models/term_search.rb
@@ -19,16 +19,17 @@ class TermSearch
     end
   end
 
-  def apply_to_search(searcher, param, value)
+  def apply_to_search(*)
+  end
+
+  def apply_to_query(query, param, value)
     if handles?(param)
-      searcher.query do |q|
-        term_query = query_for(value)
-        q.boolean &term_query
-      end
+      term_query = query_for(value)
+      query.boolean(&term_query)
     end
   end
 
-  def register_filter(noop)
+  def register_filter(*)
   end
 
   private

--- a/spec/integration/api_notice_search_spec.rb
+++ b/spec/integration/api_notice_search_spec.rb
@@ -85,7 +85,7 @@ feature "Searching for Notices via the API" do
 
   context Defamation do
     scenario "has model-specific metadata", js: true, search: true do
-      notice = create(
+      create(
         :defamation,
         title: "The Lion King on Youtube",
         body: "A test body"

--- a/spec/integration/fielded_notice_search_spec.rb
+++ b/spec/integration/fielded_notice_search_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-feature "Fielded searches of Notices", search: true do
+feature "Fielded searches of Notices" do
   include SearchHelpers
 
   context "via parameters only" do
-    Notice::SEARCHABLE_FIELDS.reject{|f| f.parameter == :term}.each do |field|
-      it %Q|within #{field.title}|, search: true do
+    Notice::SEARCHABLE_FIELDS.reject { |f| f.parameter == :term }.each do |field|
+      scenario %Q|within #{field.title}|, search: true do
         in_field, outside_field = FieldedSearchNoticeGenerator.generate(field)
 
         search_on_page = FieldedSearchOnPage.new
@@ -21,8 +21,8 @@ feature "Fielded searches of Notices", search: true do
   end
 
   context "via the web UI" do
-    Notice::SEARCHABLE_FIELDS.reject{|f| f.parameter == :term}.each do |field|
-      it "within #{field.title}", search: true, js: true do
+    Notice::SEARCHABLE_FIELDS.reject { |f| f.parameter == :term }.each do |field|
+      scenario "within #{field.title}", search: true, js: true do
         in_field, outside_field = FieldedSearchNoticeGenerator.generate(field)
         search_on_page = FieldedSearchOnPage.new
         search_on_page.visit_search_page
@@ -39,7 +39,7 @@ feature "Fielded searches of Notices", search: true do
   end
 
   context "advanced search" do
-    it "copies search parameters to the facet form.", js: true do
+    scenario "copies search parameters to the facet form.", search: true, js: true do
       notice = create(:dmca, :with_facet_data, title: "Lion King two")
       sleep 1
 
@@ -58,7 +58,7 @@ feature "Fielded searches of Notices", search: true do
     end
 
     context "not active" do
-      it "dropdown not displayed by default", js: true do
+      scenario "dropdown not displayed by default", search: true, js: true do
         search_on_page = FieldedSearchOnPage.new
         search_on_page.visit_search_page
 
@@ -72,7 +72,7 @@ feature "Fielded searches of Notices", search: true do
         search_on_page.open_advanced_search
       end
 
-      it "dropdown retains visibility between page views", js: true do
+      scenario "dropdown retains visibility between page views", search: true, js: true do
         pending 'Javascript set cookies do not appear to work in capybara-webkit'
 
         expect(page).to have_visible_advanced_search_controls
@@ -81,7 +81,7 @@ feature "Fielded searches of Notices", search: true do
         expect(page).to have_visible_advanced_search_controls
       end
 
-      it "retains query parameters", js: true do
+      scenario "retains query parameters", search: true, js: true do
         search_on_page.add_fielded_search_for('Title', 'lion')
 
         search_on_page.run_search
@@ -93,7 +93,7 @@ feature "Fielded searches of Notices", search: true do
         end
       end
 
-      it "allows you to remove a fielded search", js: true do
+      scenario "allows you to remove a fielded search", search: true, js: true do
         search_on_page.add_fielded_search_for('Title', 'lion')
 
         search_on_page.remove_fielded_search_for(:title)
@@ -103,7 +103,7 @@ feature "Fielded searches of Notices", search: true do
         end
       end
 
-      it "allows you to change a fielded search", js: true do
+      scenario "allows you to change a fielded search", search: true, js: true do
         search_on_page.add_fielded_search_for('Title', 'lion')
         search_on_page.change_field(:title, 'Tags')
 
@@ -120,7 +120,7 @@ feature "Fielded searches of Notices", search: true do
         end
       end
 
-      it "removes the option from other drop-downs for a search that's been added", js: true do
+      scenario "removes the option from other drop-downs for a search that's been added", search: true, js: true do
         search_on_page.add_fielded_search_for('Title', 'lion')
 
         search_on_page.within_fielded_searches do
@@ -130,7 +130,7 @@ feature "Fielded searches of Notices", search: true do
         end
       end
 
-      it "removes the options for a search from a previous page", js: true do
+      scenario "removes the options for a search from a previous page", search: true, js: true do
         search_on_page.add_fielded_search_for('Title', 'lion')
         search_on_page.run_search
 
@@ -141,7 +141,7 @@ feature "Fielded searches of Notices", search: true do
         end
       end
 
-      it "allows you to select a search after you delete it", js: true do
+      scenario "allows you to select a search after you delete it", search: true, js: true do
         search_on_page.add_fielded_search_for('Title', 'lion')
         search_on_page.remove_fielded_search_for(:title)
 
@@ -154,7 +154,7 @@ feature "Fielded searches of Notices", search: true do
         end
       end
 
-      it "does not allow you to select the same search twice", js: true do
+      scenario "does not allow you to select the same search twice", search: true, js: true do
         search_on_page.add_fielded_search_for('Title', 'lion')
 
         search_on_page.within_template_row do
@@ -169,7 +169,7 @@ feature "Fielded searches of Notices", search: true do
         end
       end
 
-      it "removes the add query link after all searches have been added", js: true do
+      scenario "removes the add query link after all searches have been added", search: true, js: true do
         Notice::SEARCHABLE_FIELDS.each do |field|
           search_on_page.add_fielded_search_for(field.title, 'test')
         end
@@ -180,7 +180,7 @@ feature "Fielded searches of Notices", search: true do
         end
       end
 
-      it "activates the add query link when they are available", js: true do
+      scenario "activates the add query link when they are available", search: true, js: true do
         Notice::SEARCHABLE_FIELDS.each do |field|
           search_on_page.add_fielded_search_for(field.title, 'test')
         end
@@ -196,7 +196,6 @@ feature "Fielded searches of Notices", search: true do
           )
         end
       end
-
 
     end
   end

--- a/spec/models/term_search_spec.rb
+++ b/spec/models/term_search_spec.rb
@@ -4,17 +4,17 @@ describe TermSearch do
 
   before do
     @term_search = described_class.new(:term, :_all)
-    @searcher = double("SearchesModels Instance")
+    @query = double("SearchesModels query object")
   end
 
   it "queries the searcher given a param it handles" do
-    @searcher.should_receive(:query)
-    @term_search.apply_to_search(@searcher, :term, 'foo')
+    @query.should_receive(:boolean)
+    @term_search.apply_to_query(@query, :term, 'foo')
   end
 
   it "does not query with a parameter it is not bound to" do
-    @searcher.should_not_receive(:query)
-    @term_search.apply_to_search(@searcher, :unknown_term, 'foo')
+    @query.should_not_receive(:boolean)
+    @term_search.apply_to_query(@query, :unknown_term, 'foo')
   end
 
 end

--- a/spec/support/live_searching.rb
+++ b/spec/support/live_searching.rb
@@ -1,14 +1,15 @@
 RSpec.configure do |config|
-  config.before(:each, search: false) do
-    # Mock Elasticsearch for non-search scenarios
-    FakeWeb.register_uri(:any, %r|\Ahttp://localhost:9200|, :body => "{}")
-  end
+  config.before(:each) do
+    if example.options[:search]
+      FakeWeb.clean_registry
 
-  config.before(:each, search: true) do
-    Notice.index.delete
-    Notice.create_elasticsearch_index
+      Notice.index.delete
+      Notice.create_elasticsearch_index
 
-    Entity.index.delete
-    Entity.create_elasticsearch_index
+      Entity.index.delete
+      Entity.create_elasticsearch_index
+    else
+      FakeWeb.register_uri(:any, %r|\Ahttp://localhost:9200|, :body => "{}")
+    end
   end
 end

--- a/spec/support/search_helpers.rb
+++ b/spec/support/search_helpers.rb
@@ -9,6 +9,14 @@ module SearchHelpers
     click_on 'submit'
   end
 
+  def search_for(searches)
+    sleep 1 # required for indexing to complete
+
+    query = searches.map { |k,v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
+
+    visit "/notices/search?#{query}"
+  end
+
   def within_search_results_for(term)
     submit_search(term)
     within('.search-results') do


### PR DESCRIPTION
Commit message for ee572c7 explains it fairly thoroughly:

> Prevent multiple calls to #query
> 
> Iterating over multiple TermSearch objects and separately applying them to
> a search causes multiple calls to #query, of which only the last will make
> it to elastic search.
> 
> This change re-structures things so a single #query is called and each
> TermSearch adds a must-match clause to it.
