### PR TITLE
Fix rails_admin notice sub-class labels

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -12,6 +12,11 @@ guard 'spork', :rspec_env => { 'RAILS_ENV' => 'test' } do
   watch('spec/spec_helper.rb') { :rspec }
   watch('spec/factories.rb')
   watch(%r{^lib/.+\.rb$})
+
+  # These models are mentioned in initializers which prevents rails from
+  # marking them for hot-reloading in development and test.
+  watch('app/models/ability.rb')
+  watch('app/models/notice.rb')
   watch('app/models/search_results_proxy.rb')
   watch('app/models/user.rb')
 end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -48,6 +48,17 @@ class Notice < ActiveRecord::Base
 
   VALID_ACTIONS = %w( Yes No Partial )
 
+  TYPES = {
+    'Dmca' => 'DMCA',
+    'Trademark' => 'Trademark',
+    'Defamation' => 'Defamation',
+    'International' => 'International',
+    'CourtOrder' => 'Court Order',
+    'LawEnforcementRequest' => 'Law Enforcement Request',
+    'PrivateInformation' => 'Private Information',
+    'Other' => 'Other',
+  }
+
   belongs_to :reviewer, class_name: 'User'
 
   has_many :categorizations, dependent: :destroy

--- a/app/views/notices/select_type.html.erb
+++ b/app/views/notices/select_type.html.erb
@@ -1,12 +1,7 @@
 <% title 'Report Notice' %>
 
 <ul>
-  <li><%= link_to("DMCA", new_notice_path(type: :dmca)) %></li>
-  <li><%= link_to("Trademark", new_notice_path(type: :trademark)) %></li>
-  <li><%= link_to("Defamation", new_notice_path(type: :defamation)) %></li>
-  <li><%= link_to("International", new_notice_path(type: :international)) %></li>
-  <li><%= link_to("Court Order", new_notice_path(type: :court_order)) %></li>
-  <li><%= link_to("Law Enforcement Request", new_notice_path(type: :law_enforcement_request)) %></li>
-  <li><%= link_to("Private Information", new_notice_path(type: :private_information)) %></li>
-  <li><%= link_to("Other", new_notice_path(type: :other)) %></li>
+  <% Notice::TYPES.each do |notice_type, type_label| %>
+    <li><%= link_to(type_label, new_notice_path(type: notice_type)) %></li>
+  <% end %>
 </ul>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -53,6 +53,12 @@ RailsAdmin.config do |config|
     end
   end
 
+  Notice::TYPES.each do |notice_type, type_label|
+    config.model notice_type do
+      label type_label
+    end
+  end
+
   config.model 'Category' do
     edit do
       configure(:ancestry) { hide }

--- a/spec/integration/rails_admin_dashboard_spec.rb
+++ b/spec/integration/rails_admin_dashboard_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+feature "Rails admin dashboard" do
+  before do
+    AdminOnPage.new(create(:user)).tap do |user|
+      user.sign_in
+      user.visit_admin
+    end
+  end
+
+  scenario "It displays proper labels for Notice subclasses in the sidebar" do
+    within('.sidebar-nav') do
+      expect(page).to have_css('a:contains(Notice)', 1)
+
+      Notice::TYPES.each do |_, type_label|
+        expect(page).to have_css("a:contains('#{type_label}')")
+      end
+    end
+  end
+
+  scenario "It displays proper labels for Notice subclasses in the main list" do
+    within('.content') do
+      expect(page).to have_css('a:contains(Notice)', 1)
+
+      Notice::TYPES.each do |_, type_label|
+        expect(page).to have_css("a:contains('#{type_label}')")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This lead to the creation of Notice::TYPES which is a hash of subclass 
(as string) to human readable label.
