### PR TITLE
Implement marking a notice as spam

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -13,10 +13,11 @@ guard 'spork', :rspec_env => { 'RAILS_ENV' => 'test' } do
   watch('spec/factories.rb')
   watch(%r{^lib/.+\.rb$})
 
-  # These models are mentioned in initializers which prevents rails from
-  # marking them for hot-reloading in development and test.
+  # These models do not have edits picked up and therefore require a
+  # restart of guard when changed.
   watch('app/models/ability.rb')
   watch('app/models/notice.rb')
+  watch('app/models/searchability.rb')
   watch('app/models/search_results_proxy.rb')
   watch('app/models/user.rb')
 end

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -40,7 +40,7 @@ class NoticesController < ApplicationController
   end
 
   def show
-    @notice = Notice.find(params[:id])
+    @notice = Notice.find_visible(params[:id])
 
     respond_to do |format|
       format.html do

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -116,8 +116,14 @@ class Notice < ActiveRecord::Base
   end
 
   def self.add_default_filter(search)
-    filter = TermFilter.new(:rescinded)
-    filter.apply_to_search(search, :rescinded, false)
+    { rescinded: false, spam: false }.each do |field, value|
+      filter = TermFilter.new(field)
+      filter.apply_to_search(search, field, value)
+    end
+  end
+
+  def self.find_visible(notice_id)
+    where(spam: false).find(notice_id)
   end
 
   def active_model_serializer

--- a/app/models/redaction/queue.rb
+++ b/app/models/redaction/queue.rb
@@ -19,6 +19,11 @@ module Redaction
       Notice.in_review(user).where(id: notice_ids).update_all(reviewer_id: nil)
     end
 
+    def mark_as_spam(notice_ids)
+      Notice.in_review(user).where(id: notice_ids).
+        update_all(spam: true, reviewer_id: nil)
+    end
+
     def available_space
       self.class.queue_max - notices.count
     end

--- a/app/models/searchability.rb
+++ b/app/models/searchability.rb
@@ -13,6 +13,7 @@ module Searchability
         indexes :title
         indexes :date_received, type: 'date', include_in_all: false
         indexes :rescinded, type: 'boolean', include_in_all: false
+        indexes :spam, type: 'boolean', include_in_all: false
         indexes :tag_list, as: 'tag_list'
         indexes :jurisdiction_list, as: 'jurisdiction_list'
         indexes :action_taken, analyzer: 'keyword'

--- a/app/views/rails_admin/application/redact_queue.html.erb
+++ b/app/views/rails_admin/application/redact_queue.html.erb
@@ -51,5 +51,6 @@
   <div class="form-actions">
     <%= submit_tag 'Process selected', class: 'btn btn-primary' %>
     <%= submit_tag 'Release selected', name: 'release_selected', class: 'btn btn-secondary' %>
+    <%= submit_tag 'Mark selected as spam', name: 'mark_selected_as_spam', class: 'btn btn-secondary' %>
   </div>
 <% end %>

--- a/db/migrate/20130827152223_add_spam_to_notices.rb
+++ b/db/migrate/20130827152223_add_spam_to_notices.rb
@@ -1,0 +1,5 @@
+class AddSpamToNotices < ActiveRecord::Migration
+  def change
+    add_column :notices, :spam, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130827142648) do
+ActiveRecord::Schema.define(:version => 20130827152223) do
 
   create_table "blog_entries", :force => true do |t|
     t.integer  "user_id"
@@ -172,6 +172,7 @@ ActiveRecord::Schema.define(:version => 20130827142648) do
     t.boolean  "rescinded",       :default => false, :null => false
     t.string   "action_taken",    :default => "No",  :null => false
     t.string   "type"
+    t.boolean  "spam",            :default => false
   end
 
   add_index "notices", ["reviewer_id"], :name => "index_notices_on_reviewer_id"

--- a/lib/rails_admin/config/actions/redact_queue.rb
+++ b/lib/rails_admin/config/actions/redact_queue.rb
@@ -12,6 +12,9 @@ RedactQueueProc = Proc.new do
     elsif params[:release_selected].present?
       queue.release(params[:selected])
       redirect_to redact_queue_path(@abstract_model)
+    elsif params[:mark_selected_as_spam].present?
+      queue.mark_as_spam(params[:selected])
+      redirect_to redact_queue_path(@abstract_model)
     elsif params[:selected].present?
       notice_id, *next_notices = params[:selected]
       redact_path = redact_notice_path(

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -4,7 +4,7 @@ describe NoticesController do
   context "#show" do
     it "finds the notice by ID" do
       notice = Notice.new
-      Notice.should_receive(:find).with('42').and_return(notice)
+      Notice.should_receive(:find_visible).with('42').and_return(notice)
 
       get :show, id: 42
 
@@ -67,7 +67,7 @@ describe NoticesController do
 
     def stub_find_notice(notice = nil)
       notice ||= Notice.new
-      notice.tap { |n| Notice.stub(:find).and_return(n) }
+      notice.tap { |n| Notice.stub(:find_visible).and_return(n) }
     end
   end
 

--- a/spec/integration/notice_search_spec.rb
+++ b/spec/integration/notice_search_spec.rb
@@ -59,6 +59,12 @@ feature "Searching Notices" do
     expect_search_to_not_find("arbitrary", notice)
   end
 
+  scenario "it does not include spam notices", search: true do
+    notice = create(:dmca, title: "arbitrary", spam: true)
+
+    expect_search_to_not_find("arbitrary", notice)
+  end
+
   context "within associated models" do
     scenario "for category names", search: true do
       category = create(:category, name: "Lion King")

--- a/spec/models/dmca_spec.rb
+++ b/spec/models/dmca_spec.rb
@@ -320,4 +320,17 @@ describe Dmca do
       expect(notice.supporting_documents).to be_all { |d| d.kind == 'supporting' }
     end
   end
+
+  context ".find_visible" do
+    it "finds notices which are not spam" do
+      notice = create(:dmca, spam: false)
+      spam_notice = create(:dmca, spam: true)
+
+      expect(Notice.find_visible(notice.id)).to eq notice
+      expect { Notice.find_visible(spam_notice.id) }.to raise_error(
+        ActiveRecord::RecordNotFound
+      )
+    end
+  end
+
 end

--- a/spec/rails_admin/config/actions/redact_queue_spec.rb
+++ b/spec/rails_admin/config/actions/redact_queue_spec.rb
@@ -56,9 +56,7 @@ describe RedactQueueProc do
       queue = stub_new(Redaction::Queue, current_user)
       refill = stub_new(Redaction::RefillQueue, params)
       refill.should_receive(:fill).with(queue)
-      should_receive(:redact_queue_path).with(@abstract_model).and_return(:path)
-      should_receive(:redirect_to).with(:path)
-      should_not_receive(:respond_to)
+      should_redirect_back
 
       instance_eval(&RedactQueueProc)
     end
@@ -68,9 +66,17 @@ describe RedactQueueProc do
       params[:release_selected] = true
       queue = stub_new(Redaction::Queue, current_user)
       queue.should_receive(:release).with(%w( 1 3 5 9 ))
-      should_receive(:redact_queue_path).with(@abstract_model).and_return(:path)
-      should_receive(:redirect_to).with(:path)
-      should_not_receive(:respond_to)
+      should_redirect_back
+
+      instance_eval(&RedactQueueProc)
+    end
+
+    it "marks notices as spam and redirects if required" do
+      params[:selected] = %w( 1 3 5 9 )
+      params[:mark_selected_as_spam] = true
+      queue = stub_new(Redaction::Queue, current_user)
+      queue.should_receive(:mark_as_spam).with(%w( 1 3 5 9 ))
+      should_redirect_back
 
       instance_eval(&RedactQueueProc)
     end
@@ -91,5 +97,11 @@ describe RedactQueueProc do
     klass.new(*args).tap do |instance|
       klass.stub(:new).and_return(instance)
     end
+  end
+
+  def should_redirect_back
+    should_receive(:redact_queue_path).with(@abstract_model).and_return(:path)
+    should_receive(:redirect_to).with(:path)
+    should_not_receive(:respond_to)
   end
 end

--- a/spec/support/page_objects/redaction_queue_on_page.rb
+++ b/spec/support/page_objects/redaction_queue_on_page.rb
@@ -41,6 +41,10 @@ class RedactionQueueOnPage < PageObject
     click_on 'Release selected'
   end
 
+  def mark_selected_as_spam
+    click_on 'Mark selected as spam'
+  end
+
   def redact_everywhere
     page.execute_script 'window.original_confirm = window.confirm'
     page.execute_script 'window.confirm = function(msg) { return true; }'


### PR DESCRIPTION
- Add Notice#spam?
- Add spam=false default filter to searches
- Add Notice.find_visible which only returns non-spam (and eventually 
  non-deleted)
- Add button to Redact Queue to mark selected as spam
