### PR TITLE
Route recipient and category short urls

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,5 +26,9 @@ Chill::Application.routes.draw do
 
   match :faceted_search, controller: 'notices/search', action: 'index'
 
+  # N.B. no constraints on categories, that would require a db call
+  match '/:recipient_name(/:categories)' => 'notices/search#index',
+    constraints: { recipient_name: /Twitter|Google/i }
+
   root to: 'home#index'
 end

--- a/spec/routing/short_urls_spec.rb
+++ b/spec/routing/short_urls_spec.rb
@@ -10,5 +10,31 @@ describe "Notices" do
     )
     end
   end
-
 end
+
+describe "Submitters" do
+  %w( Twitter Google twitter google ).each do |submitter|
+    it "routes /#{submitter} to a search on that recipient name" do
+      expect(get: "/#{submitter}").to route_to(
+        controller: "notices/search",
+        action: "index",
+        recipient_name: submitter
+      )
+    end
+
+    it "routes /#{submitter}/Category to a search on that recipient/category" do
+      expect(get: "/#{submitter}/Defamation").to route_to(
+        controller: "notices/search",
+        action: "index",
+        recipient_name: submitter,
+        categories: "Defamation"
+      )
+    end
+  end
+
+  it "only supports Twitter and Google" do
+    expect(get: "/Other").not_to be_routable
+    expect(get: "/Other/Whatever").not_to be_routable
+  end
+end
+


### PR DESCRIPTION
Visiting /:recipient_name(/:categories) presents the search page with results
for the given recipient and category. Recipient is constrained to Twitter or
Google.

Examples: /Twitter/DMCA, /Google/Antitrust
