### PR TITLE
Modify Advanced Search UI

### DIFF
--- a/app/assets/javascripts/advanced_search_rows.js.coffee
+++ b/app/assets/javascripts/advanced_search_rows.js.coffee
@@ -1,47 +1,96 @@
 class @AdvancedSearchRows
-  constructor: (@field, @value) ->
+  constructor: ->
+    @_taken = []
+    @_fields = $('.search-field-data').map (_, elem) -> $(elem).data()
+    @_addMore = $('#duplicate-field')
 
-  activeRows: ->
-    $('.field-group:not(.hidden)')
+  displayActiveFields: ->
+    noParameters = true
 
-  enableRowsWithValues: ->
-    this.activeRows().find('input,select').attr('disabled',null)
+    for field in @_fields
+      if field.value
+        noParameters = false
 
-  removeOptionsforActiveRows: ->
-    activeFields = []
-    $(this.activeRows()).each (index, element) ->
-      if $(element).find('.remove-group').length > 0
-        field = $(element).find('input').attr('name')
-        $(".field-group:not('.#{field}')").find(
-          "option[value='#{field}']"
-        ).remove()
+        @_insertFieldGroup(field)
+        @_disableLastFieldGroup()
+        @_taken.push(field.parameter)
 
-  templateRow: ->
-    $('.field-group:last')
+    if noParameters
+      @_insertFieldGroup({})
 
-  resetTemplateRow: ->
-    $(this.templateRow()).find('input[type="text"]').val('')
-    $(this.templateRow()).find('select').val('')
+    @_resetAddMore()
 
-  activatedField: ->
-    $('.advanced-search').find('.field-group.' + @field)
+  addField: ->
+    @_disableLastFieldGroup()
+    @_insertFieldGroup({})
+    @_resetAddMore()
 
-  ensureFieldOptionsExist: ->
-    if $(this.activatedField()).find("option[value='#{@field}']").length == 0
-      option = $(this.templateRow()).find("option[value='#{@field}']")
-      $(this.activatedField()).find('select').prepend(option)
+  removeField: (fieldGroup) ->
+    name = fieldGroup.find('input[type="text"]').attr('name')
 
-  setActivatedFieldValue: ->
-    $(this.activatedField())
-      .find('input[type="text"]')
-      .attr('disabled', null).val(@value)
+    fieldGroup.remove()
 
-  removeFieldOptionsFromOtherDropdowns: ->
-    $(".field-group:not('.#{@field}')").find(
-      "option[value='#{@field}']"
-    ).remove()
+    @_release(name)
+    @_resetAddMore(true)
 
-    if $(this.templateRow()).find('option').length == 0
-      $('#duplicate-field').hide()
-      $(this.templateRow()).hide()
+  fieldChanged: (fieldGroup) ->
+    input = fieldGroup.find('input[type="text"]')
+    select = fieldGroup.find('select')
 
+    if oldName = input.attr('name')
+      fieldGroup.removeClass(oldName)
+      @_release(oldName)
+
+    newName = select.val()
+
+    if newName == ''
+      input.attr('name', null)
+    else
+      input.attr('name', newName)
+      fieldGroup.addClass(newName)
+      @_taken.push(newName)
+
+  _disableLastFieldGroup: ->
+    $('.field-group select').last().attr('disabled', 'disabled')
+
+  _insertFieldGroup: (field) ->
+    $('<div>')
+      .addClass("field-group")
+      .addClass(field.parameter)
+      .append($('<div>').addClass('remove-group'))
+      .append(@_buildSelect(field.parameter))
+      .append(@_buildInput(field))
+      .insertBefore(@_addMore)
+
+  _buildSelect: (selected) ->
+    select = $('<select>').attr('name', 'search-field')
+      .append(@_buildOption({}))
+
+    for field in @_fields
+      if field.parameter not in @_taken
+        option = @_buildOption(field)
+
+        if field.parameter == selected
+          option.attr('selected', true)
+
+        select.append(option)
+
+    $('<div>').addClass('input select').append(select)
+
+  _buildOption: (field) ->
+    $('<option>').val(field.parameter).text(field.title)
+
+  _buildInput: (field) ->
+    $('<input>').attr(type: 'text', name: field.parameter, value: field.value)
+
+  _release: (name) ->
+    index = @_taken.indexOf(name)
+    @_taken.splice(index, 1)
+
+  _resetAddMore: (forceShow) ->
+    available = @_fields.length - @_taken.length
+
+    if !forceShow && available <= 1
+      @_addMore.hide()
+    else
+      @_addMore.show()

--- a/app/assets/javascripts/faceted_search_form.js.coffee
+++ b/app/assets/javascripts/faceted_search_form.js.coffee
@@ -21,7 +21,7 @@ $('li.facet').on 'click', 'a', ->
         $(this).removeClass('active')
 
 clearEmptyParameters = ->
-  $('form#facets-form').find('input[type="hidden"]').each (index, element) ->
+  $('form#facets-form').find('input[type="hidden"]').each (_, element) ->
     if $(element).val() == ''
       $(element).remove()
 
@@ -35,13 +35,11 @@ cloneGlobalSearch = (context) ->
   $(context).append(term_input)
 
 cloneAdvancedSearch = (context) ->
-  $rows = new AdvancedSearchRows
-  $rows.activeRows().find('input:not([name="search-term"])')
-    .each (index, element) ->
-      name = $(element).attr('name')
-      value = $(element).val()
-      term_input = createHiddenTermInput(name, value)
-      $(context).append(term_input)
+  $('.field-group input').each (_, element) ->
+    name = $(element).attr('name')
+    value = $(element).val()
+    term_input = createHiddenTermInput(name, value)
+    $(context).append(term_input)
 
 $('form#facets-form').on 'submit', ->
   clearEmptyParameters()

--- a/app/assets/javascripts/search.js.coffee
+++ b/app/assets/javascripts/search.js.coffee
@@ -1,54 +1,20 @@
+$rows = new AdvancedSearchRows()
+
 $('form[action="/notices/search"]:not("#facets-form")').on 'submit', ->
   $(this)
     .find('[name="search-field"],[name="search-term"]')
     .attr('disabled','disabled')
 
-updateRows = (field, value) ->
-  $rows = new AdvancedSearchRows field, value
-  activatedFieldGroup = $rows.activatedField()
-  $rows.setActivatedFieldValue()
-  $rows.ensureFieldOptionsExist()
-  $rows.removeFieldOptionsFromOtherDropdowns()
-  $(activatedFieldGroup).removeClass('hidden')
-  $rows.resetTemplateRow()
-  $rows.enableRowsWithValues()
-
 $('#duplicate-field').on 'click', ->
-  field = $(this).prev().find('select').val()
-  value = $(this).prev().find('input[type="text"]').val()
+  $rows.addField()
 
-  updateRows(field, value)
-
-$('.field-group:not(.template-row) select').on 'change', ->
-  newInputName = $(this).val()
+$('.advanced-search').on 'change', '.field-group select', (event) ->
   fieldGroup = $(this).closest('.field-group')
-  oldInputName = $(fieldGroup).find('input').attr('name')
-  value = $(fieldGroup).find('input').val()
-  optionClone = $('.advanced-search')
-    .find("option[value='#{oldInputName}']").first().clone()
-
-  $(fieldGroup).removeClass(oldInputName).addClass(newInputName)
-  $(fieldGroup).find('input').attr('name', newInputName)
-
-  $rows = new AdvancedSearchRows newInputName, value
-  $rows.ensureFieldOptionsExist()
-  $rows.removeFieldOptionsFromOtherDropdowns()
-  $rows.enableRowsWithValues()
-  $rows.templateRow().find('select').prepend(optionClone)
+  $rows.fieldChanged(fieldGroup)
 
 $('.advanced-search').on 'click', '.remove-group', (event) ->
-  $fieldGroup = $((event || window.event).target).parent()
-  field = $fieldGroup.find('input[type="text"]').attr('name')
-  option = $fieldGroup.find("option[value='#{field}']")
-  $('.field-group:last select').prepend(option)
-  $fieldGroup.find('input,select').attr('disabled','disabled')
-  $fieldGroup.addClass('hidden')
-  $('.field-group.template-row,#duplicate-field').show()
-
-correctAdvancedSearchDropdowns = ->
-  $rows = new AdvancedSearchRows()
-  $rows.enableRowsWithValues()
-  $rows.removeOptionsforActiveRows()
+  fieldGroup = $(this).closest('.field-group')
+  $rows.removeField(fieldGroup)
 
 $ ->
-  correctAdvancedSearchDropdowns()
+  $rows.displayActiveFields()

--- a/app/controllers/notices/search_controller.rb
+++ b/app/controllers/notices/search_controller.rb
@@ -23,8 +23,6 @@ class Notices::SearchController < ApplicationController
   private
 
   def notice_searcher
-    now = Time.now.beginning_of_day
-
     SearchesModels.new(params).tap do |searcher|
       Notice::SEARCHABLE_FIELDS.each do |searched_field|
         searcher.register searched_field

--- a/app/views/notices/search/_term_search.html.erb
+++ b/app/views/notices/search/_term_search.html.erb
@@ -1,20 +1,12 @@
-<%
-  extra_class = " #{term_search.parameter}"
-  if params[term_search.parameter].blank?
-    extra_class += ' hidden'
-  end
+<%=
+  content_tag(
+    :div, '',
+    class: 'search-field-data',
+    style: 'display:none;',
+    data: {
+      title: term_search.title,
+      parameter: term_search.parameter,
+      value: params[term_search.parameter]
+    }
+  )
 %>
-<div class="field-group<%= extra_class %>">
-  <div class="remove-group <%= term_search.parameter %>"></div>
-  <div class="input select">
-    <%=
-      select_tag(
-        'search-field',
-        options_for_select(
-          Notice::SEARCHABLE_FIELDS.collect{|f| [f.title, f.parameter]},
-          term_search.parameter
-        )
-    ) %>
-  </div>
-  <%= text_field_tag term_search.parameter, params[term_search.parameter], id: nil, disabled: 'disabled' %>
-</div>

--- a/app/views/shared/_header_search.html.erb
+++ b/app/views/shared/_header_search.html.erb
@@ -16,17 +16,6 @@
           <% Notice::SEARCHABLE_FIELDS.each do |field| %>
             <%= render field %>
           <% end %>
-          <div class="field-group template-row">
-            <div class="input select">
-              <%= select_tag(
-                'search-field',
-                options_for_select(
-                  Notice::SEARCHABLE_FIELDS.collect{|f| [f.title, f.parameter]}
-              )
-              ) %>
-            </div>
-            <input type="text" name="search-term">
-          </div>
           <a id="duplicate-field" href="#" class="add-group">Add more</a>
           <div class="resubmit">
             <button class="button">Advanced Search</button>

--- a/spec/support/page_objects/fielded_search_on_page.rb
+++ b/spec/support/page_objects/fielded_search_on_page.rb
@@ -7,23 +7,32 @@ class FieldedSearchOnPage < PageObject
     end
   end
 
-  def within_template_row(&block)
-    open_advanced_search
-    within('.template-row', &block)
+  def add_more
+    find('#duplicate-field').click
   end
 
   def within_fielded_searches(&block)
     open_advanced_search
+
     within('.advanced-search', &block)
+  end
+
+  def within_last_field(&block)
+    # note: :last-of-type in the selector does not work.
+    field_group = all('.field-group').last
+
+    within(field_group, &block)
   end
 
   def add_fielded_search_for(field, term)
     open_advanced_search
-    within('.template-row') do
-      fill_in("search-term", with: term)
-      select(field, from: 'search-field')
+
+    add_more
+
+    within_last_field do
+      select(field.title, from: 'search-field')
+      fill_in(field.parameter, with: term)
     end
-    find('#duplicate-field').click
   end
 
   def set_sort_order(sort_order)
@@ -45,7 +54,10 @@ class FieldedSearchOnPage < PageObject
 
   def remove_fielded_search_for(field)
     open_advanced_search
-    find(".remove-group.#{field}").click
+
+    within(".field-group.#{field}") do
+      find(".remove-group").click
+    end
   end
 
   def run_search(wait_for_index = true)


### PR DESCRIPTION
The form no longer always displays an unusable blank field group. It was 
creating user confusion. However, a (usable) blank field group is 
displayed if no existing parameters were present on initial page load.

In the process, much of AdvancedSearchRows was re-written. Reviewing the 
change may be easiest by reading the as-currently-is file rather than 
trying to grok the diff.

There was one incidental behavior change: upon adding another field, any 
existing field is frozen at its current type. This prevents a user from 
getting into a scenario where two fields of the same type are present.
