### PR TITLE
Modify Faceted search UI/UX

### DIFF
--- a/app/assets/javascripts/faceted_search_form.js.coffee
+++ b/app/assets/javascripts/faceted_search_form.js.coffee
@@ -1,24 +1,13 @@
-$('li.facet').on 'click', 'a', ->
+$('li.facet').on 'click', 'a', (event) ->
+  event.preventDefault()
 
-  facet_hidden_input = $('input#' + $(this).attr('data-facet-name'))
-  $(facet_hidden_input).val($(this).attr('data-value'))
+  facet_name = $(this).attr('data-facet-name')
+  facet_value = $(this).attr('data-value')
+  facet_hidden_input = $("input##{facet_name}")
 
-  $parent = $(this).parent()
-  $grandparent = $(this).parents('.dropdown')
-
-  if $parent.hasClass('active')
-    $parent.removeClass('active')
-    $grandparent.removeClass('active')
-
-  else
-    $parent.addClass('active')
-    $grandparent.addClass('active')
-
-    ## Only allow one active child
-    ## Remove all other active siblings
-    $parent.siblings().each ->
-      if $(this).hasClass('active')
-        $(this).removeClass('active')
+  if facet_hidden_input.val() != facet_value
+    facet_hidden_input.val(facet_value)
+    $('form#facets-form').submit()
 
 clearEmptyParameters = ->
   $('form#facets-form').find('input[type="hidden"]').each (_, element) ->
@@ -51,7 +40,10 @@ $('form#facets-form').on 'submit', ->
 
 $('.sort-order ol.dropdown-menu a').click (event)->
   event.preventDefault()
-  $('.sort-order a.dropdown-toggle').text($(this).attr('data-label'))
-  $('.sort_by_field').val(
-    $(this).attr('data-value')
-  )
+
+  value = $(this).attr('data-value')
+  sort_by_field = $('.sort_by_field')
+
+  if sort_by_field.val() != value
+    sort_by_field.val(value)
+    $('form#facets-form').submit()

--- a/app/views/notices/search/index.html.erb
+++ b/app/views/notices/search/index.html.erb
@@ -9,7 +9,6 @@
             <% Notice::FILTERABLE_FIELDS.each do |filterable_field| %>
               <%= render filterable_field, results: @results %>
             <% end %>
-          <li class="button-wrapper"><button class="">Apply</button></li>
         </ol>
       <% end %>
       <%= hidden_field_tag(:sort_by, params[:sort_by], class: 'sort_by_field') %>

--- a/spec/integration/faceted_notice_search_spec.rb
+++ b/spec/integration/faceted_notice_search_spec.rb
@@ -132,6 +132,24 @@ feature "Faceted search of Notices", search: true do
     end
   end
 
+  context "facet auto-submission" do
+    scenario "a user selects a facet", js: true, search: true do
+      create(:dmca, title: "Lion King", date_received: 10.months.ago)
+      notice = create(:dmca, title: "King Leon", date_received: 1.day.ago)
+
+      within_search_results_for('king') do
+        expect(page).to have_n_results 2
+      end
+
+      click_on 'Date'
+      find('ol.date_received_facet li:nth-child(2) a').click
+
+      expect(page).to have_active_facet_dropdown(:date_received_facet)
+      expect(page).to have_n_results 1
+      expect(page).to have_content(notice.title)
+    end
+  end
+
   def with_a_faceted_search(facet_name, facet_attribute_name)
     sleep 1
     results = Notice.search do

--- a/spec/integration/fielded_notice_search_spec.rb
+++ b/spec/integration/fielded_notice_search_spec.rb
@@ -42,39 +42,31 @@ feature "Fielded searches of Notices" do
 
   context "sorting" do
     before do
-      search_on_page.visit_search_page
-      search_on_page.add_fielded_search_for(title_field, 'Foobar')
-    end
+      @notice = create(:dmca, title: "Lion King", date_received: 1.day.ago)
+      @old_notice = create(
+        :dmca, title: "King Leon", date_received: 10.days.ago
+      )
 
-    scenario "sort_order selection changes", search: true, js: true do
-      search_on_page.set_sort_order('date_received desc')
-      expect(page).to have_sort_order_selection_of('Newest')
+      submit_search('king')
     end
 
     scenario "by newest date_received", search: true, js: true do
-      notice, older_notice = create_dated_notices
       search_on_page.set_sort_order('date_received desc')
 
-      search_on_page.run_search
-
       expect(page).to have_sort_order_selection_of('Newest')
-
       search_on_page.within_results do
-        expect(page).to have_first_notice_of(notice)
-        expect(page).to have_last_notice_of(older_notice)
+        expect(page).to have_first_notice_of(@notice)
+        expect(page).to have_last_notice_of(@old_notice)
       end
     end
 
     scenario "by oldest date_received", search: true, js: true do
-      notice, older_notice = create_dated_notices
       search_on_page.set_sort_order('date_received asc')
-
-      search_on_page.run_search
 
       expect(page).to have_sort_order_selection_of('Oldest')
       search_on_page.within_results do
-        expect(page).to have_first_notice_of(older_notice)
-        expect(page).to have_last_notice_of(notice)
+        expect(page).to have_first_notice_of(@old_notice)
+        expect(page).to have_last_notice_of(@notice)
       end
     end
   end
@@ -89,7 +81,6 @@ feature "Fielded searches of Notices" do
       search_on_page.add_fielded_search_for(title_field, 'lion')
 
       open_and_select_facet(:sender_name_facet, notice.sender_name)
-      click_faceted_search_button
 
       expect(page).to have_active_facet(:sender_name_facet, notice.sender_name)
       expect(page).to have_n_results 1
@@ -257,15 +248,6 @@ feature "Fielded searches of Notices" do
 
   def have_last_notice_of(notice)
     have_css("ol.results-list li:last-child[id='notice_#{notice.id}']")
-  end
-
-  def create_dated_notices
-    [
-      create(:dmca, title: 'Foobar First', date_received: Time.now),
-      create(
-        :dmca, title: 'Foobar Last', date_received: Time.now - 10.days
-      )
-    ]
   end
 
   def have_sort_order_selection_of(sort_by)

--- a/spec/support/search_helpers.rb
+++ b/spec/support/search_helpers.rb
@@ -45,14 +45,6 @@ module SearchHelpers
     click_on 'submit'
 
     open_and_select_facet(facet, facet_value)
-
-    click_faceted_search_button
-  end
-
-  def click_faceted_search_button
-    within('.search-results') do
-      find('button').click
-    end
   end
 
   def within_faceted_search_results_for(term, facet, facet_value)


### PR DESCRIPTION
- Auto-submit form on selection
- Auto-submit form on sort
- Prevent un-selection (user must choose All)

Incidental changes:
- Removed the (now unused) Apply button
- Adjusted some spec helpers to assume the search is submitted upon
  facet-selection/sort
