### PR TITLE
Ingestor Improvements

### DIFF
--- a/lib/ingestor.rb
+++ b/lib/ingestor.rb
@@ -5,6 +5,8 @@ end
 module Ingestor
   ImportDispatcher.register(Importer::Google)
   ImportDispatcher.register(Importer::GoogleSecondary::DmcaParser)
+  ImportDispatcher.register(Importer::GoogleSecondary::EbDmcaParser)
+  ImportDispatcher.register(Importer::GoogleSecondary::BloggerParser)
   ImportDispatcher.register(Importer::GoogleSecondary::OtherParser)
   ImportDispatcher.register(Importer::Twitter)
   ImportDispatcher.register(Importer::NullImporter)

--- a/lib/ingestor/importer/google_secondary/blogger_parser.rb
+++ b/lib/ingestor/importer/google_secondary/blogger_parser.rb
@@ -1,0 +1,51 @@
+require 'ingestor/importer/base'
+
+module Ingestor
+  module Importer
+    module GoogleSecondary
+      class BloggerParser < Base
+
+        handles_content(/IssueType:\s?blogger_dmca_infringment/m)
+
+        def parse_works(file_path)
+          content = self.class.read_file(file_path)
+
+          [Work.new(
+            description: parse_description(content),
+            infringing_urls: parse_urls(content)
+          )]
+        end
+
+        private
+
+        def parse_description(content)
+          parse_key(content, 'a06_copyrighted_work')
+        end
+
+        def parse_urls(content)
+          urls = []
+
+          %w( a07_infringing_URL a08_infringing_URL ).each do |key|
+            if urls_string = parse_key(content, key)
+              lines = urls_string.split(/\s+/)
+              urls += lines.map { |line| line.sub(/<.*>$/, '') }
+            end
+          end
+
+          urls.map { |url| InfringingUrl.new(url: url) }
+        end
+
+        def parse_key(content, key)
+          next_number = key.sub(/a(\d{2})_/, '\1').to_i + 1
+          next_key = "a#{"%02d" % next_number}_"
+
+          if content.match(/^#{key}:\s*(.*)^#{next_key}/m)
+            $1.strip
+          end
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/ingestor/importer/google_secondary/eb_dmca_parser.rb
+++ b/lib/ingestor/importer/google_secondary/eb_dmca_parser.rb
@@ -1,0 +1,21 @@
+require 'ingestor/importer/base'
+
+module Ingestor
+  module Importer
+    module GoogleSecondary
+      class EbDmcaParser < Base
+
+        handles_content(/IssueType:\s?eb_dmca/m)
+
+        def parse_works(file_path)
+          content = EbIssueContent.new(
+            file_path, 'description_of_copyrighted_work', 'dmca_company_name'
+          )
+
+          [content.to_work]
+        end
+
+      end
+    end
+  end
+end

--- a/lib/ingestor/importer/google_secondary/eb_issue_content.rb
+++ b/lib/ingestor/importer/google_secondary/eb_issue_content.rb
@@ -1,0 +1,16 @@
+require 'ingestor/importer/google_secondary/issue_content'
+
+module Ingestor
+  module Importer
+    module GoogleSecondary
+      class EbIssueContent < IssueContent
+
+        def infringing_urls
+          content.match(/url_of_infringing_material:\s*(.*)/m)
+          extract_urls($1)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/ingestor/importer/google_secondary/issue_content.rb
+++ b/lib/ingestor/importer/google_secondary/issue_content.rb
@@ -4,10 +4,7 @@ module Ingestor
       class IssueContent
 
         def initialize(file_path, description_start, description_end)
-          @content = IO.read(file_path).
-            force_encoding("ISO-8859-1").
-            encode("utf-8", replace: nil)
-
+          @content = Base.read_file(file_path)
           @description_start = description_start
           @description_end = description_end
         end

--- a/lib/ingestor/importer/google_secondary/other_parser.rb
+++ b/lib/ingestor/importer/google_secondary/other_parser.rb
@@ -5,7 +5,7 @@ module Ingestor
     module GoogleSecondary
       class OtherParser < Base
 
-        handles_content(/IssueType:\s?lr_legalother2/m)
+        handles_content(/IssueType:\s?lr_legalother/m)
 
         def parse_works(file_path)
           content = IssueContent.new(

--- a/lib/ingestor/legacy_csv/error_handler.rb
+++ b/lib/ingestor/legacy_csv/error_handler.rb
@@ -22,16 +22,17 @@ module Ingestor
       end
 
       def handle(csv_row, ex)
+        file_paths  = (csv_row['OriginalFilePath'] || '').split(',')
+        file_paths += (csv_row['SupportingFilePath'] || '').split(',')
         error_message = "(#{ex.class}) #{ex.message}: #{ex.backtrace.first}"
-        original_files = csv_row.fetch('OriginalFilePath', '').split(',')
 
         logger.error "Error importing Notice #{csv_row['NoticeID']}"
         logger.error "  Error: #{error_message}"
-        logger.error "  Files: #{original_files.join(', ')}"
+        logger.error "  Files: #{file_paths.join(', ')}"
 
         csv << (csv_row.to_hash.values + [error_message])
 
-        original_files.each { |file_path| store_file(file_path) }
+        file_paths.each { |file_path| store_file(file_path) }
 
       rescue => ex
         logger.error "Failure handling failure: #{ex}"

--- a/spec/lib/ingestor/importer/google_secondary/blogger_parser_spec.rb
+++ b/spec/lib/ingestor/importer/google_secondary/blogger_parser_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'ingestor'
+
+describe Ingestor::Importer::GoogleSecondary::BloggerParser do
+
+  it "handles the correct files" do
+    expect(described_class).to handle(sample_file)
+  end
+
+  it "gets work descriptions" do
+    work = described_class.new(sample_file).works.first
+
+    expect(work.description).to eq(
+      "Malgré les signalements le site est toujours en  \r
+ligne, nous demandons la suppréssion immédiate du site web ! (sons, albums  \r
+& clips en téléchargements illégaux)"
+    )
+  end
+
+  it "gets infringing_urls" do
+    work = described_class.new(sample_file).works.first
+
+    expect(work.infringing_urls.map(&:url)).to match_array([
+      'http://www.example.com/infringing_1.html',
+      'http://www.example.com/infringing_2.html',
+      'http://www.example.com/infringing_3.html',
+      'http://www.example.com/infringing_4.html',
+      'http://www.example.com/infringing_5.html',
+      'http://www.example.com/infringing_6.html',
+    ])
+  end
+
+  private
+
+  def sample_file
+    'spec/support/example_files/blogger_dmca_source.txt'
+  end
+
+  def handle(file)
+    be_handles(file)
+  end
+end

--- a/spec/lib/ingestor/importer/google_secondary/eb_dmca_parser_spec.rb
+++ b/spec/lib/ingestor/importer/google_secondary/eb_dmca_parser_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'ingestor'
+
+describe Ingestor::Importer::GoogleSecondary::EbDmcaParser do
+
+  it "gets work descriptions" do
+    work = described_class.new(sample_file).works.first
+
+    expect(work.description).to eq(
+      "êîíòðîëüíûå, <a  \r
+href=\"http://example.com/copyrighted_1\">free amateur   \r
+movies</a>, [url=\"http://example.com/copyrighted_2\"]free  \r
+amateur  movies[/url], http://example.com/copyrighted_3 sybille  \r
+some work,  pplei,"
+    )
+  end
+
+  it "gets copyrighted_urls" do
+    work = described_class.new(sample_file).works.first
+
+    expect(work.copyrighted_urls.map(&:url)).to match_array([
+      'http://example.com/copyrighted_1',
+      'http://example.com/copyrighted_2',
+      'http://example.com/copyrighted_3'
+    ])
+  end
+
+  it "gets infringing_urls" do
+    work = described_class.new(sample_file).works.first
+
+    expect(work.infringing_urls.map(&:url)).to match_array([
+      'http://example.com/infringing_1',
+      'http://example.com/infringing_2',
+      'http://example.com/infringing_3'
+    ])
+  end
+
+  private
+
+  def sample_file
+    'spec/support/example_files/eb_dmca_source.txt'
+  end
+end

--- a/spec/support/example_files/blogger_dmca_source.txt
+++ b/spec/support/example_files/blogger_dmca_source.txt
@@ -1,0 +1,25 @@
+
+
+AutoDetectedBrowser: Firefox 3
+AutoDetectedOS: Windows XP
+IssueType: blogger_dmca_infringment
+Language: fr
+a01_first_name: Sébastien
+a02_last_name: Forte
+a03_company_name: No Time Records / MERCURY
+a04_copyright_holder: No Time Records / MERCURY
+a05_copyrighted_location: Sur le site même!
+a06_copyrighted_work: Malgré les signalements le site est toujours en  
+ligne, nous demandons la suppréssion immédiate du site web ! (sons, albums  
+& clips en téléchargements illégaux)
+a07_infringing_URL: http://www.example.com/infringing_1.html
+http://www.example.com/infringing_2.html
+http://www.example.com/infringing_3.html
+a08_infringing_URL: http://www.example.com/infringing_4.html
+http://www.example.com/infringing_5.html
+http://www.example.com/infringing_6.html
+a09_confirm1_goodfaith_notauthorized: checked
+a10_confirm2_swear_accurate_copyrightowner: checked
+a11_signed_date: 29/01/11
+a12_signature: Forte Sébastien
+country: FR

--- a/spec/support/example_files/eb_dmca_source.txt
+++ b/spec/support/example_files/eb_dmca_source.txt
@@ -1,0 +1,28 @@
+
+
+AutoDetectedBrowser: Internet Explorer 6
+AutoDetectedOS: Windows XP
+IssueType: eb_dmca
+Language: en
+agree1: yes
+agree: yes
+country: RU
+description_of_copyrighted_work: контрольные, <a  
+href="http://example.com/copyrighted_1">free amateur   
+movies</a>, [url="http://example.com/copyrighted_2"]free  
+amateur  movies[/url], http://example.com/copyrighted_3 sybille  
+some work,  pplei,
+dmca_company_name: Vsjrh32e8v13Mor
+dmca_signature: 234524980nckPDwnrvZwq
+dmca_signature_date: KbAA02934gmVSEuAB
+first_name: first name
+last_name: last name
+location_of_copyrighted_work: контрольные, <a  
+href="http://example.com/location_1">free amateu  
+represented_copyright_holder: MfNRnTmWaLMVu
+url_of_infringing_material: контрольные, <a  
+href="http://example.com/infringing_1">free amateur 
+movies</a>, [url="http://example.com/infringing_2"]free  
+amateur movies[/url],  
+example[/url], http://example.com/infringing_3 sybille  
+rauch example,  pplei,


### PR DESCRIPTION
- Ensure OtherParser is used more often

I saw some IssueType notices with "legalother" as the key, not the
expected "legalother2" so I just loosened the regex there.
- Add Blogger and EbDmca parsers, sample files, etc

I might've liked to refactor the GoogleSecondary stuff a bit at this
point, but I restrained myself given the one-off nature of these things.
- Ensure error handler copies supporting files over too

This caused re-imports of failed CSVs to fail when trying to open the
referenced but missing files.
- Ensure files exist before opening them

I made this fix before I found the bug in the error handler. In reality,
all referenced files will always exist, but I decided to just leave the
existence checks anyway, since it makes it more robust and I see little
downside.
