### PR TITLE
Modify how Notice subclasses define their label

### DIFF
--- a/app/models/dmca.rb
+++ b/app/models/dmca.rb
@@ -6,6 +6,10 @@ class Dmca < Notice
     Notice.model_name
   end
 
+  def self.label
+    'DMCA'
+  end
+
   def to_partial_path
     'notices/notice'
   end

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -55,15 +55,15 @@ class Notice < ActiveRecord::Base
 
   VALID_ACTIONS = %w( Yes No Partial )
 
-  TYPES = {
-    'Dmca' => 'DMCA',
-    'Trademark' => 'Trademark',
-    'Defamation' => 'Defamation',
-    'CourtOrder' => 'Court Order',
-    'LawEnforcementRequest' => 'Law Enforcement Request',
-    'PrivateInformation' => 'Private Information',
-    'Other' => 'Other',
-  }
+  TYPES = %w(
+    Dmca
+    Trademark
+    Defamation
+    CourtOrder
+    LawEnforcementRequest
+    PrivateInformation
+    Other
+  )
 
   belongs_to :reviewer, class_name: 'User'
 
@@ -102,10 +102,12 @@ class Notice < ActiveRecord::Base
 
   define_elasticsearch_mapping
 
+  def self.label
+    name.titleize
+  end
+
   def self.type_models
-    TYPES.keys.collect do |model_name|
-      model_name.constantize
-    end
+    TYPES.map(&:constantize)
   end
 
   def self.available_for_review

--- a/app/views/notices/select_type.html.erb
+++ b/app/views/notices/select_type.html.erb
@@ -4,18 +4,18 @@
   <h1>Which type of notice would you like to report?</h1>
   <section class="notices-list">
     <ul>
-      <% Notice::TYPES.each do |notice_type, type_label| %>
-        <li data-id="<%= notice_type %>"><%= type_label %></li>
+      <% Notice.type_models.each do |model| %>
+        <li data-id="<%= model.name %>"><%= model.label %></li>
       <% end %>
     </ul>
   </section>
 
   <section class="info-panel wip">
-    <% Notice::TYPES.each do |notice_type, type_label| %>
-      <div data-id="<%= notice_type %>">
-        <article><b><%= type_label %>:</b> Has someone asked your ISP, or the host of an online discussion you participate in, to give them your identity or other information about you?</article>
+    <% Notice.type_models.each do |model| %>
+      <div data-id="<%= model.name %>">
+        <article><b><%= model.label %>:</b> Has someone asked your ISP, or the host of an online discussion you participate in, to give them your identity or other information about you?</article>
         <div class="button-wrapper">
-          <a class="button" href="<%= new_notice_path(type: notice_type) %>">Report <%= type_label %> notice</a>
+          <a class="button" href="<%= new_notice_path(type: model.name) %>">Report <%= model.label %> notice</a>
         </div>
       </div>
     <% end %>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -57,10 +57,10 @@ RailsAdmin.config do |config|
     end
   end
 
-  Notice::TYPES.each do |notice_type, type_label|
+  Notice::TYPES.each do |notice_type|
     config.audit_with :history, notice_type
     config.model notice_type do
-      label type_label
+      label { abstract_model.model.label }
     end
   end
 

--- a/spec/integration/rails_admin_dashboard_spec.rb
+++ b/spec/integration/rails_admin_dashboard_spec.rb
@@ -12,8 +12,8 @@ feature "Rails admin dashboard" do
     within('.sidebar-nav') do
       expect(page).to have_css('a:contains(Notice)', 1)
 
-      Notice::TYPES.each do |_, type_label|
-        expect(page).to have_css("a:contains('#{type_label}')")
+      Notice.type_models.each do |model|
+        expect(page).to have_css("a:contains('#{model.label}')")
       end
     end
   end
@@ -22,8 +22,8 @@ feature "Rails admin dashboard" do
     within('.content') do
       expect(page).to have_css('a:contains(Notice)', 1)
 
-      Notice::TYPES.each do |_, type_label|
-        expect(page).to have_css("a:contains('#{type_label}')")
+      Notice.type_models.each do |model|
+        expect(page).to have_css("a:contains('#{model.label}')")
       end
     end
   end

--- a/spec/views/notices/new.html.erb_spec.rb
+++ b/spec/views/notices/new.html.erb_spec.rb
@@ -9,10 +9,10 @@ describe 'notices/new.html.erb' do
     expect(rendered).to have_css 'form'
   end
 
-  Notice::TYPES.each do |notice_class, notice_title|
-    context "country selectors in \"#{notice_title}\" notices" do
+  Notice.type_models.each do |model|
+    context "country selectors in \"#{model.label}\" notices" do
       it "use ISO country codes" do
-        factory_name = notice_class.tableize.singularize
+        factory_name = model.name.tableize.singularize
         assign(
           :notice, build(factory_name, role_names: %w( sender recipient ))
         )


### PR DESCRIPTION
Notice::TYPES becomes a list of strings. This list is still useful in
initializers where we don't want to load and reference the actual class.

Notice.type_models becomes the way we reference the types at runtime and
we can call the class method .label to get the human readable form.

The default is to titleize it, the only override being DMCA.
