### PR TITLE
Change title-handling and related things

### DIFF
--- a/app/models/entity_notice_role.rb
+++ b/app/models/entity_notice_role.rb
@@ -45,5 +45,6 @@ class EntityNoticeRole < ActiveRecord::Base
 
   validates_inclusion_of :name, in: ROLES
   validates_presence_of :entity, :notice
+  validates_associated :entity
 
 end

--- a/app/models/submit_notice.rb
+++ b/app/models/submit_notice.rb
@@ -13,6 +13,10 @@ class SubmitNotice
       entity_present?('recipient') or set_entity('recipient', entity)
     end
 
+    unless notice.title.present?
+      notice.title = generic_title
+    end
+
     notice.auto_redact
 
     if notice.save
@@ -37,9 +41,55 @@ class SubmitNotice
     }
   end
 
+  def recipient_name
+    entity_name('recipient')
+  end
+
+  def generic_title
+    if recipient_name.present?
+      "#{model_class.label} notice to #{recipient_name}"
+    else
+      "#{model_class.label} notice"
+    end
+  end
+
+  def entity_name(role_name)
+    role = entity_notice_role(role_name)
+
+    if role.present?
+      if role.has_key?(:entity_attributes)
+        role[:entity_attributes][:name]
+      elsif role.has_key?(:entity_id)
+        Entity.find(role[:entity_id]).name
+      end
+    end
+  end
+
   def entity_present?(role_name)
-    roles = parameters.fetch(:entity_notice_roles_attributes, [])
-    roles.any? { |role| role[:name] == role_name }
+    entity_notice_role(role_name).present?
+  end
+
+  def entity_notice_role(role_name)
+    roles = flatten_param(parameters[:entity_notice_roles_attributes])
+    roles.detect { |role| role[:name] == role_name }
+  end
+
+  # JSON API submissions:
+  #
+  #   [{ ... }, { ... }, { ... }]
+  #
+  # Rails form submissions:
+  #
+  #   { '0' => { ... }, '1' => { ... }, '3' => { ... } }
+  #
+  # This flattens the second style to the first, IFF it's not that way
+  # already. Curse you, Rails for making me type-check.
+  def flatten_param(param)
+    case param
+    when Hash  then param.values
+    when Array then param
+    else []
+    end
   end
 
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -8,6 +8,7 @@ class Work < ActiveRecord::Base
   has_and_belongs_to_many :copyrighted_urls
 
   accepts_nested_attributes_for :infringing_urls, :copyrighted_urls
+  validates_associated :infringing_urls, :copyrighted_urls
 
   # Similar to the hack in EntityNoticeRole, because all validations are
   # run before all inserts, we have to save to ensure we don't have the

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -3,7 +3,7 @@
 <article class="notice-show">
   <section class="body">
     <header id="entities">
-      <h1><%= @notice.type.titleize %> - <%= @notice.title %></h1>
+      <h1><%= @notice.title %></h1>
       <div class="entities-wrapper">
         <% if @notice.sender %>
           <%= render @notice.sender, notice: @notice, role: :sender %>

--- a/db/migrate/20130923143531_remove_title_validation_on_notices.rb
+++ b/db/migrate/20130923143531_remove_title_validation_on_notices.rb
@@ -1,0 +1,5 @@
+class RemoveTitleValidationOnNotices < ActiveRecord::Migration
+  def change
+    change_column :notices, :title, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130920011650) do
+ActiveRecord::Schema.define(:version => 20130923143531) do
 
   create_table "blog_entries", :force => true do |t|
     t.integer  "user_id"
@@ -163,7 +163,7 @@ ActiveRecord::Schema.define(:version => 20130920011650) do
   add_index "infringing_urls_works", ["work_id"], :name => "index_infringing_urls_works_on_work_id"
 
   create_table "notices", :force => true do |t|
-    t.string   "title",                                 :null => false
+    t.string   "title"
     t.text     "body"
     t.datetime "date_received"
     t.datetime "created_at",                            :null => false

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -16,8 +16,6 @@ feature "notice submission" do
       select "en - English", from: "Language"
     end
 
-    open_recent_notice
-
     notice = Notice.last
     expect(notice.language).to eq 'en'
   end
@@ -36,8 +34,6 @@ feature "notice submission" do
     submit_recent_notice do
       fill_in "Jurisdiction", with: 'US, foobar'
     end
-
-    open_recent_notice
 
     notice = Notice.last
     expect(notice.jurisdiction_list).to match_array ['US', 'foobar']
@@ -63,9 +59,8 @@ feature "notice submission" do
   scenario "submitting a notice with an original attached" do
     submit_recent_notice { attach_notice }
 
-    open_recent_notice
-
-    pending "We don't display originals yet"
+    notice = Notice.last
+    expect(notice).to have(1).original_document
   end
 
   scenario "submitting a notice with a supporting document", js: true do
@@ -236,7 +231,7 @@ feature "notice submission" do
     visit "/notices/new?type=Dmca"
 
     within('form#new_notice') do
-      expect(page).to have_css('input#notice_title.required')
+      expect(page).to have_css("input##{works_copyrighted_url_id}.required")
       expect(page).to have_css('input#notice_date_received:not(.required)')
     end
   end
@@ -246,9 +241,19 @@ feature "notice submission" do
 
     click_on "Submit"
 
-    within('form .notice_title') do
-      expect(page).to have_css('.error')
+    all("form .#{entity_name_class}").each do |elem|
+      within(elem) { expect(page).to have_css('.error') }
     end
+  end
+
+  private
+
+  def works_copyrighted_url_id
+    'notice_works_attributes_0_copyrighted_urls_attributes_0_url'
+  end
+
+  def entity_name_class
+    'notice_entity_notice_roles_entity_name'
   end
 
 end

--- a/spec/integration/user_submits_typed_notices_spec.rb
+++ b/spec/integration/user_submits_typed_notices_spec.rb
@@ -6,7 +6,6 @@ feature "typed notice submissions" do
     submission.open_submission_form
 
     submission.fill_in_form_with({
-      "Title" => "A title",
       "Mark" => "My trademark (TM)",
       "Infringing URL" => "http://example.com/infringing_url1",
       "Alleged Infringment" => "They used my thing",
@@ -23,7 +22,7 @@ feature "typed notice submissions" do
 
     open_recent_notice
 
-    expect(page).to have_content("Trademark - A title")
+    expect(page).to have_content("Trademark notice to Recipient")
 
     within("#works") do
       expect(page).to have_content('Mark')
@@ -41,7 +40,6 @@ feature "typed notice submissions" do
     submission.open_submission_form
 
     submission.fill_in_form_with({
-      "Title" => "A title",
       "Legal Complaint" => "They impuned upon my good character",
       "Defamatory URL" => "http://example.com/defamatory_url1",
     })
@@ -57,7 +55,7 @@ feature "typed notice submissions" do
 
     open_recent_notice
 
-    expect(page).to have_content("Defamation - A title")
+    expect(page).to have_content("Defamation notice to Recipient")
 
     within("#works") do
       expect(page).to have_content('Locations of Defamatory Material')
@@ -75,8 +73,6 @@ feature "typed notice submissions" do
     submission.open_submission_form
 
     submission.fill_in_form_with({
-      "Title" => "A title",
-
       "Subject of Court Order" => "My sweet website", # works.description
       "Targetted URL" => "http://example.com/targetted_url", # infringing_urls
 
@@ -86,7 +82,7 @@ feature "typed notice submissions" do
 
     %i|recipient sender principal issuing_court plaintiff defendant|.each do |role|
       submission.fill_in_entity_form_with(role, {
-        'Name' => "#{role} entity",
+        'Name' => role.capitalize
       })
     end
 
@@ -94,7 +90,7 @@ feature "typed notice submissions" do
 
     open_recent_notice
 
-    expect(page).to have_content("Court Order - A title")
+    expect(page).to have_content("Court Order notice to Recipient")
 
     within("#works") do
       expect(page).to have_content('Targetted URLs')
@@ -113,8 +109,6 @@ feature "typed notice submissions" do
     submission.open_submission_form
 
     submission.fill_in_form_with({
-      "Title" => "A title",
-
       "Subject of Enforcement Request" => "My Tiny Tim fansite", # works.description
       "URL of original work" => "http://example.com/original_object1", # copyrighted_urls
       "URL mentioned in request" => "http://example.com/offending_url1", # infringing_urls
@@ -139,7 +133,7 @@ feature "typed notice submissions" do
 
     open_recent_notice
 
-    expect(page).to have_content("Law Enforcement Request - A title")
+    expect(page).to have_content("Law Enforcement Request notice to Recipient")
 
     within("#works") do
       expect(page).to have_content('URLs mentioned in request')
@@ -166,8 +160,6 @@ feature "typed notice submissions" do
     submission.open_submission_form
 
     submission.fill_in_form_with({
-      "Title" => "A title",
-
       "Complaint" => "These URLs disclose my existence", # works.description
       "Original Work URL" => "http://example.com/original_object1", # copyrighted_urls
       "URL with private information" => "http://example.com/offending_url1", # infringing_urls
@@ -186,7 +178,7 @@ feature "typed notice submissions" do
 
     open_recent_notice
 
-    expect(page).to have_content("Private Information - A title")
+    expect(page).to have_content("Private Information notice to Recipient")
 
     within("#works") do
       expect(page).to have_content('URLs with private information')
@@ -207,8 +199,6 @@ feature "typed notice submissions" do
     submission.open_submission_form
 
     submission.fill_in_form_with({
-      "Title" => "A title",
-
       "Complaint" => "These URLs are a serious problem", # works.description
       "Original Work URL" => "http://example.com/original_object1", # copyrighted_urls
       "Problematic URL" => "http://example.com/offending_url1", # infringing_urls
@@ -227,7 +217,7 @@ feature "typed notice submissions" do
 
     open_recent_notice
 
-    expect(page).to have_content("Other - A title")
+    expect(page).to have_content("Other notice to Recipient")
 
     within("#works") do
       expect(page).to have_content('Problematic URLs')

--- a/spec/models/dmca_spec.rb
+++ b/spec/models/dmca_spec.rb
@@ -7,7 +7,6 @@ describe Dmca do
   it { should ensure_inclusion_of(:action_taken).in_array(Dmca::VALID_ACTIONS).allow_nil }
 
   context 'automatic validations' do
-    it { should validate_presence_of :title }
     it { should ensure_length_of(:title).is_at_most(255) }
   end
 

--- a/spec/models/entity_notice_role_spec.rb
+++ b/spec/models/entity_notice_role_spec.rb
@@ -45,9 +45,28 @@ describe EntityNoticeRole do
 
       expect(entity_notice_role.entity).to eq existing_entity
     end
+
+    it "validates entities corrently when multiple are used at once" do
+      notice = notice_with_roles_attributes([
+        { name: 'recipient', entity_attributes: { name: "" } },
+        { name: 'submitter', entity_attributes: { name: "" } }
+      ])
+
+      expect(notice).not_to be_valid
+      expect(notice.errors.messages).to eq(
+        { :"entity_notice_roles.entity" => ["is invalid"] }
+      )
+    end
   end
 
   private
+
+  def notice_with_roles_attributes(attributes)
+    Dmca.new(
+      entity_notice_roles_attributes: attributes,
+      works: build_list(:work, 2) # to make it valid otherwise
+    )
+  end
 
   def entity_attributes
     {

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -75,4 +75,40 @@ describe Work do
       work.save
     end
   end
+
+  it "validates infringing urls correctly when multiple are used at once" do
+    notice = notice_with_works_attributes([
+      { infringing_urls_attributes: [{ url: "" }] },
+      { infringing_urls_attributes: [{ url: "" }] }
+    ])
+
+    expect(notice).not_to be_valid
+    expect(notice.errors.messages).to eq(
+      { :"works.infringing_urls" => ["is invalid"] }
+    )
+  end
+
+  it "validates infringing urls correctly when multiple are used at once" do
+    notice = notice_with_works_attributes([
+      { copyrighted_urls_attributes: [{ url: "" }] },
+      { copyrighted_urls_attributes: [{ url: "" }] }
+    ])
+
+    expect(notice).not_to be_valid
+    expect(notice.errors.messages).to eq(
+      { :"works.copyrighted_urls" => ["is invalid"] }
+    )
+  end
+
+  private
+
+  def notice_with_works_attributes(attributes)
+    Dmca.new(
+      works_attributes: attributes,
+      entity_notice_roles_attributes: [{
+        name: 'recipient',
+        entity_attributes: { name: 'Recipient' }
+      }]
+    )
+  end
 end

--- a/spec/support/notice_actions.rb
+++ b/spec/support/notice_actions.rb
@@ -22,8 +22,8 @@ module NoticeActions
     click_on "Submit"
   end
 
-  def open_recent_notice(title = "A title")
-    within('#recent-notices') { click_on title }
+  def open_recent_notice
+    within('#recent-notices li:nth-child(1)') { find('a').click }
   end
 
   def attach_notice(content = "Some content")


### PR DESCRIPTION
The main feature was to remove the title validation and compute
something generic based on type and recipient. That was a relatively
easy and small patch visible as the migration and
SubmitNotice#generic_title.

That exposed a number of things:
1. The parameters have a different structure depending on if they came
   in from the web form or a direct JSON POST. See details in
   SubmitNotice#flatten_param
2. EntityNoticeRoles was, in some cases, saving nested Entities even
   when they were invalid. We never saw this bug until now because those
   scenarios were hidden by the Notice being invalid for other reasons
   (no Title).
3. Works had the same bug w.r.t Infringing/Copyrighted URLs.
4. The view didn't work as is ("<type> - <title>") since the requirement
   is that an empty title leads to "<type> notice for <recipient>".
   Changing this just meant updating the submit_typed_notice specs to
   rely on the generated title to verify that the right type was
   created.
