### PR TITLE
Use Readlevel to set rescinded and hidden states

### DIFF
--- a/lib/ingestor/legacy_csv/attribute_mapper.rb
+++ b/lib/ingestor/legacy_csv/attribute_mapper.rb
@@ -2,6 +2,12 @@ module Ingestor
   class LegacyCsv
     class AttributeMapper
 
+      READLEVELS = {
+        '3' => :hidden,
+        '8' => :hidden,
+        '10' => :rescinded
+      }
+
       delegate :notice_type, to: :importer
 
       def initialize(hash)
@@ -36,6 +42,8 @@ module Ingestor
           works: works,
           review_required: review_required,
           topics: topics(hash['CategoryName']),
+          rescinded: rescinded?,
+          hidden: hidden?,
           entity_notice_roles: [
             EntityNoticeRole.new(
               name: 'sender',
@@ -90,6 +98,19 @@ module Ingestor
           'USA' => 'US',
         }
       end
+
+      def rescinded?
+        READLEVELS[readlevel] == :rescinded
+      end
+
+      def hidden?
+        READLEVELS[readlevel] == :hidden
+      end
+
+      def readlevel
+        hash['Readlevel'].to_s
+      end
+
     end
   end
 end


### PR DESCRIPTION
I'm going to check for Readlevel 9 (spam) in another card where we're
excluding spam for other rules as well.
