### PR TITLE
Exclude spam notices from import

### DIFF
--- a/spec/lib/ingestor/legacy_csv_spec.rb
+++ b/spec/lib/ingestor/legacy_csv_spec.rb
@@ -4,22 +4,29 @@ require 'ingestor'
 describe Ingestor::LegacyCsv do
 
   before do
-    described_class::ErrorHandler.stub(:new).
-      and_return(double.as_null_object)
+    @error_handler = double.as_null_object
+    described_class::ErrorHandler.stub(:new).and_return(@error_handler)
+
+    @attribute_mapper = double("AttributeMapper")
+    @attribute_mapper.stub(:exclude?).and_return(false)
+    @attribute_mapper.stub(:notice_type).and_return(Dmca)
+    @attribute_mapper.stub(:mapped).and_return({})
+    described_class::AttributeMapper.stub(:new).and_return(@attribute_mapper)
   end
 
   it "instantiates the correct notice type based on AttributeMapper" do
-    attribute_mapper = double("AttributeMapper")
-    attribute_mapper.stub(:notice_type).and_return(Trademark)
-    attribute_mapper.stub(:mapped).and_return({})
-    described_class::AttributeMapper.stub(:new).and_return(attribute_mapper)
+    @attribute_mapper.stub(:notice_type).and_return(Trademark)
     Trademark.should_receive(:create!).at_least(:once).and_return(Trademark.new)
-    importer = described_class.new(
-      "spec/support/example_files/example_notice_export.csv"
-    )
-    importer.logger.level = ::Logger::FATAL
 
-    importer.import
+    new_importer.import
+  end
+
+  def new_importer
+    sample_file = "spec/support/example_files/example_notice_export.csv"
+
+    described_class.new(sample_file).tap do |importer|
+      importer.logger.level = ::Logger::FATAL
+    end
   end
 
 end


### PR DESCRIPTION
- Readlevel == 9
- Recipient is Google and Sender is in a blacklist regex
- Kicks the excluded notices out as an error so they're preserved for
  later inspection/use
