### PR TITLE
Pass through "Body" value from CSV when no works found

### DIFF
--- a/lib/ingestor/legacy_csv/attribute_mapper.rb
+++ b/lib/ingestor/legacy_csv/attribute_mapper.rb
@@ -29,10 +29,12 @@ module Ingestor
 
       def mapped
         works = importer.works
+        body = nil
 
         if works.empty?
           works = [Work.unknown]
           review_required = true
+          body = hash['Body']
         else
           review_required = false
         end
@@ -55,6 +57,7 @@ module Ingestor
           hidden: hidden?,
           submission_id: hash['SubmissionID'],
           entity_notice_roles: entity_notice_roles,
+          body: body,
         }
       end
 


### PR DESCRIPTION
Our new notice source parsing re-creates most of the content that was included
in "Body" in the original notices.  When we can't recover any works, pass
through "Body" directly to ensure there's some notice content to display
and/or redact.
