### PR TITLE
Improve lr_dmca work description parsing

### DIFF
--- a/lib/ingestor/importer/google_secondary/dmca_parser.rb
+++ b/lib/ingestor/importer/google_secondary/dmca_parser.rb
@@ -9,7 +9,7 @@ module Ingestor
 
         def parse_works(file_path)
           content = IssueContent.new(
-            file_path, 'description_of_copyrighted_work', 'full_name'
+            file_path, 'description_of_copyrighted_work'
           )
 
           [content.to_work]

--- a/lib/ingestor/importer/google_secondary/eb_dmca_parser.rb
+++ b/lib/ingestor/importer/google_secondary/eb_dmca_parser.rb
@@ -9,7 +9,7 @@ module Ingestor
 
         def parse_works(file_path)
           content = EbIssueContent.new(
-            file_path, 'description_of_copyrighted_work', 'dmca_company_name'
+            file_path, 'description_of_copyrighted_work'
           )
 
           [content.to_work]

--- a/lib/ingestor/importer/google_secondary/issue_content.rb
+++ b/lib/ingestor/importer/google_secondary/issue_content.rb
@@ -3,10 +3,9 @@ module Ingestor
     module GoogleSecondary
       class IssueContent
 
-        def initialize(file_path, description_start, description_end)
+        def initialize(file_path, description_start)
           @content = Base.read_file(file_path)
           @description_start = description_start
-          @description_end = description_end
         end
 
         def to_work
@@ -18,7 +17,7 @@ module Ingestor
         end
 
         def description
-          if content.match(/#{description_start}[^:]*:(.*)\n#{description_end}[^:]*:/m)
+          if content.match(/#{description_start}[^:]*:(.+?)\n[a-z_]+:/m)
             $1.strip
           end
         end
@@ -34,7 +33,7 @@ module Ingestor
 
         private
 
-        attr_reader :content, :description_start, :description_end
+        attr_reader :content, :description_start
 
         def extract_urls(string)
           URI::extract(string || '').

--- a/lib/ingestor/importer/google_secondary/other_parser.rb
+++ b/lib/ingestor/importer/google_secondary/other_parser.rb
@@ -9,7 +9,7 @@ module Ingestor
 
         def parse_works(file_path)
           content = IssueContent.new(
-            file_path, 'legalother_explain', 'legalother_quote'
+            file_path, 'legalother_explain'
           )
 
           [content.to_work]

--- a/spec/lib/ingestor/importer/google_secondary/dmca_parser_spec.rb
+++ b/spec/lib/ingestor/importer/google_secondary/dmca_parser_spec.rb
@@ -3,15 +3,23 @@ require 'ingestor'
 
 describe Ingestor::Importer::GoogleSecondary::DmcaParser do
 
-  it "gets work descriptions" do
-    work = described_class.new(sample_file).works.first
+  context "work descriptions" do
+    it "from the first format" do
+      work = described_class.new(sample_file).works.first
 
-    expect(work.description).to eq(
-      'A computer generated image of a beach/pool
+      expect(work.description).to eq(
+        'A computer generated image of a beach/pool
 villa, the design of which is the copyright work of Bag of Holding
 Co. Ltd.
 It is located at http://www.example.com/photo.jpg'
-    )
+      )
+    end
+
+    it "from the second format" do
+      work = described_class.new(tertiary_sample_file).works.first
+
+      expect(work.description).to eq( 'Insanity� fitness DVD' )
+    end
   end
 
   it "gets copyrighted_urls" do
@@ -36,5 +44,9 @@ http://www.example.com/unstoppable_3.html|
 
   def sample_file
     'spec/support/example_files/secondary_dmca_notice_source.html'
+  end
+
+  def tertiary_sample_file
+    'spec/support/example_files/secondary_dmca_notice_source-3.html'
   end
 end

--- a/spec/support/example_files/secondary_dmca_notice_source-3.html
+++ b/spec/support/example_files/secondary_dmca_notice_source-3.html
@@ -1,0 +1,43 @@
+AutoDetectedBrowser: Firefox
+AutoDetectedOS: Windows XP
+IIILanguage: en
+IssueType: lr_dmca
+Language: en
+agree1: checked
+agree: checked
+companyname: Busybody, LLC
+country_residence: US
+description_of_copyrighted_work: Insanity� fitness DVD
+dmca_signature: Cheryl Schmoe
+dmca_signature_date_day: 21
+dmca_signature_date_month: 10
+dmca_signature_date_year: 2011
+full_name: Cheryl Schmoe
+hidden_dmca_category:
+hidden_product: productsearch
+location_of_copyrighted_work: The copyrighted work at issue is the product  
+that appears on http://www.example.com
+http://www.example.com/product/fitness_programs/insanity.do?t=san2c1
+
+represented_copyright_holder: Busybody, LLC
+url_box_1: The store Bargain Shop offers counterfeit versions of our  
+product under the search term: Shaun T Insanity -  
+http://www.example.com/index.aspx?pageid=410078&prodid=3970894&rw=1
+url_box_2: The store Cheap Nike Soccer Cleats offers counterfeit versions  
+of our product under the search term: Shaun T Insanity -  
+http://www.example.com/catalogsearch/result/?q=shaun+t+insanity+&x=0&y=0
+url_box_3: The store fitness paradise offers counterfeit versions of our  
+product under the search term: Shaun T Insanity -  
+http://www.example.net/insanity-workout-a-60-day-workout-with-shaun-t-p-7.html
+url_box_4: The store GM Tech offers counterfeit versions of our product  
+under the search term: Shaun T Insanity -  
+http://www.example.com/stores/GMTech/item?lid=19316903&source=Vendio:Google%20Product%20Search
+url_box_5: The store P90x DVD Outlet offers counterfeit versions of our  
+product under the search term: Shaun T Insanity -  
+http://www.example.com/shaun-ts-insanity-workout-deluxe-package-13dvd-p-3.html
+url_box_6: The store sellao.com offers counterfeit versions of our product  
+under the search term: Shaun T Insanity -  
+http://www.example.com/auction_details.php?auction_id=1000003480
+url_box_7: The store www.example.uk-sales4u.co.uk offers counterfeit versions of  
+our product under the search term: Shaun T Insanity -  
+http://www.example.co.uk/product473971_3208393.aspx


### PR DESCRIPTION
This now retrieves content only up to the next field, rather than a defined
string that may or may not define the next field.
