### PR TITLE
Import Body and BodyOriginal, set review_required more intelligently

### DIFF
--- a/lib/ingestor/importer/base.rb
+++ b/lib/ingestor/importer/base.rb
@@ -90,6 +90,10 @@ module Ingestor
         'Yes'
       end
 
+      def require_review_if_works_empty?
+        true
+      end
+
       private
 
       def fix_paths(file_paths)

--- a/lib/ingestor/importer/unknown_importer.rb
+++ b/lib/ingestor/importer/unknown_importer.rb
@@ -12,6 +12,10 @@ module Ingestor
         []
       end
 
+      def require_review_if_works_empty?
+        false
+      end
+
     end
   end
 end

--- a/lib/ingestor/legacy_csv/attribute_mapper.rb
+++ b/lib/ingestor/legacy_csv/attribute_mapper.rb
@@ -29,12 +29,14 @@ module Ingestor
 
       def mapped
         works = importer.works
-        body = nil
 
         if works.empty?
           works = [Work.unknown]
-          review_required = true
+
+          review_required = importer.require_review_if_works_empty?
+
           body = hash['Body']
+          body_original = hash['BodyOriginal']
         else
           review_required = false
         end
@@ -58,6 +60,7 @@ module Ingestor
           submission_id: hash['SubmissionID'],
           entity_notice_roles: entity_notice_roles,
           body: body,
+          body_original: body_original,
         }
       end
 

--- a/spec/lib/ingestor/importer/base_spec.rb
+++ b/spec/lib/ingestor/importer/base_spec.rb
@@ -9,4 +9,12 @@ describe Ingestor::Importer::Base do
       expect(content).to include  '廣記商行」と検索する際の'
     end
   end
+
+  context "#require_review_if_works_empty?" do
+    it "should be true by default" do
+      importer = described_class.new('')
+
+      expect(importer.require_review_if_works_empty?).to be_true
+    end
+  end
 end

--- a/spec/lib/ingestor/importer/unknown_importer_spec.rb
+++ b/spec/lib/ingestor/importer/unknown_importer_spec.rb
@@ -23,6 +23,14 @@ describe Ingestor::Importer::UnknownImporter do
     )
   end
 
+  context "#require_review_if_works_empty?" do
+    it "should be false" do
+      importer = described_class.new('')
+
+      expect(importer.require_review_if_works_empty?).to be_false
+    end
+  end
+
   private
 
   def touch(path)


### PR DESCRIPTION
If a notice is imported via the UnknownImporter, then we don't set 
review_required. This notice didn't match one of our known formats and we
weren't expecting it to have works we could parse.

If we attempted to import via known format (say, twitter or one of the google
formats) then we set review_required when we couldn't find works because
something bad happened and we couldn't recover works information.
