### PR TITLE
Record import errors into NoticeImportError model

### DIFF
--- a/IMPORTING.md
+++ b/IMPORTING.md
@@ -1,16 +1,16 @@
 Importing from Mysql
 ====================
 
-The ingestor can now import directly from the legacy MySQL chillingeffects datastore.
+The ingestor can now import directly from the legacy MySQL chillingeffects database.
 
 This presupposes a few conditions:
 
 1) The process can CD into a `BASE_DIRECTORY` that contains all the possible files, and
-2) The MySQL connection is correctly configured via environment variables
+2) The MySQL connection is correctly configured via environment variables.
 
-It also has the ability to write failures as CSV (including the relevant files)
-into a separate directory, configured, again, via ENV. Below is a list of
-relevant environment variables.
+It records errors into the NoticeImportError model, which allows for more
+flexible searching and viewing of errors. Below is a list of relevant
+environment variables.
 
 * `MYSQL_HOST`
 * `MYSQL_USERNAME`
@@ -18,7 +18,5 @@ relevant environment variables.
 * `MYSQL_PORT`
 * `MYSQL_DATABASE`
 * `BASE_DIRECTORY` - The directory that contains the original source files
-* `IMPORT_ERRORS_DIRECTORY` - The directory that will store the error CSV reports and source file copies. It needs to be writeable by the user the importer runs as.
 
-The importer can import from CSV and MySQL. See
-`lib/tasks/chillingeffects.rake` for examples.
+See `lib/tasks/chillingeffects.rake` for examples.

--- a/app/models/notice_import_error.rb
+++ b/app/models/notice_import_error.rb
@@ -1,0 +1,4 @@
+class NoticeImportError < ActiveRecord::Base
+  include ValidatesAutomatically
+
+end

--- a/db/migrate/20131209154641_create_notice_import_errors.rb
+++ b/db/migrate/20131209154641_create_notice_import_errors.rb
@@ -1,0 +1,12 @@
+class CreateNoticeImportErrors < ActiveRecord::Migration
+  def change
+    create_table(:notice_import_errors) do |t|
+      t.integer :original_notice_id
+      t.string :file_list, limit: 2.kilobytes
+      t.string :message, limit: 16.kilobytes
+      t.string :stacktrace, limit: 2.kilobytes
+      t.string :import_set_name, limit: 1.kilobyte
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20131008184042) do
+ActiveRecord::Schema.define(:version => 20131209154641) do
 
   create_table "blog_entries", :force => true do |t|
     t.integer  "user_id"
@@ -132,6 +132,16 @@ ActiveRecord::Schema.define(:version => 20131008184042) do
 
   add_index "infringing_urls_works", ["infringing_url_id"], :name => "index_infringing_urls_works_on_infringing_url_id"
   add_index "infringing_urls_works", ["work_id"], :name => "index_infringing_urls_works_on_work_id"
+
+  create_table "notice_import_errors", :force => true do |t|
+    t.integer  "original_notice_id"
+    t.string   "file_list",          :limit => 2048
+    t.string   "message",            :limit => 16384
+    t.string   "stacktrace",         :limit => 2048
+    t.string   "import_set_name",    :limit => 1024
+    t.datetime "created_at",                          :null => false
+    t.datetime "updated_at",                          :null => false
+  end
 
   create_table "notices", :force => true do |t|
     t.string   "title"

--- a/lib/ingestor/legacy.rb
+++ b/lib/ingestor/legacy.rb
@@ -18,10 +18,7 @@ module Ingestor
 
       @logger.debug { "Started at: #{@start_unixtime}, #{Time.now}" }
 
-      @error_handler = ErrorHandler.new(
-        ENV['IMPORT_ERRORS_DIRECTORY'] || record_source.base_directory, record_source.name
-      )
-      @error_handler.copy_headers(record_source.headers)
+      @error_handler = ErrorHandler.new(record_source.name)
 
       @succeeded = 0
       @failed = 0

--- a/lib/tasks/chillingeffects.rake
+++ b/lib/tasks/chillingeffects.rake
@@ -11,23 +11,14 @@ namespace :chillingeffects do
     sleep 5
   end
 
-  desc "Import legacy chillingeffects data from CSV"
-  task import_legacy_csv_data: :environment do
-    with_file_name do |file_name|
-      ingestor = Ingestor::Legacy.open_csv(file_name)
-      ingestor.import
-    end
-  end
-
   desc "Import chillingeffects data from Mysql"
   task import_notices_via_mysql: :environment do
     name = ENV['IMPORT_NAME']
     base_directory = ENV['BASE_DIRECTORY']
     where_fragment = ENV['WHERE']
-    import_errors = ENV['IMPORT_ERRORS_DIRECTORY']
 
-    unless name && base_directory && where_fragment && import_errors
-      puts "You need to give an IMPORT_NAME, BASE_DIRECTORY, WHERE fragment and IMPORT_ERRORS_DIRECTORY"
+    unless name && base_directory && where_fragment
+      puts "You need to give an IMPORT_NAME, BASE_DIRECTORY and WHERE fragment"
       puts "See IMPORTING.md for additional details about environment variables necessary to import via mysql"
       exit
     end

--- a/spec/lib/ingestor/legacy_spec.rb
+++ b/spec/lib/ingestor/legacy_spec.rb
@@ -14,20 +14,6 @@ describe Ingestor::Legacy do
     described_class::AttributeMapper.stub(:new).and_return(@attribute_mapper)
   end
 
-  it "can override the error handler storage location via ENV" do
-    described_class::ErrorHandler.should_receive(:new).with(
-      'foobar', 'example_notice_export.csv')
-
-    import_errors_directory = ENV['IMPORT_ERRORS_DIRECTORY']
-
-    begin
-      ENV['IMPORT_ERRORS_DIRECTORY'] = 'foobar'
-      importer
-    ensure
-      ENV['IMPORT_ERRORS_DIRECTORY'] = import_errors_directory
-    end
-  end
-
   it "instantiates the correct notice type based on AttributeMapper" do
     @attribute_mapper.stub(:notice_type).and_return(Trademark)
     Trademark.should_receive(:create!).at_least(:once).and_return(Trademark.new)

--- a/spec/models/notice_import_error_spec.rb
+++ b/spec/models/notice_import_error_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe NoticeImportError do
+  it { should ensure_length_of(:file_list).is_at_most(2.kilobytes) }
+  it { should ensure_length_of(:message).is_at_most(16.kilobytes) }
+  it { should ensure_length_of(:stacktrace).is_at_most(2.kilobytes) }
+  it { should ensure_length_of(:import_set_name).is_at_most(1.kilobyte) }
+end


### PR DESCRIPTION
This avoids writing CSV files for failed imports and allows for more flexible
and usable error reporting.
