### PR TITLE
Naively count rows for large tables to speed UI significantly

### DIFF
--- a/config/initializers/kaminari.rb
+++ b/config/initializers/kaminari.rb
@@ -1,5 +1,10 @@
+require './lib/kaminari/active_record_relation_methods'
+
 # Prevents conflicts between Kaminari (used by rails_admin) and
 # will_paginate.
 Kaminari.configure do |config|
   config.page_method_name = :per_page_kaminari
 end
+
+Chill::Application.config.tables_using_naive_counts =
+  (ENV['TABLES_USING_NAIVE_COUNTS'] || 'infringing_urls').split(',')

--- a/lib/kaminari/active_record_relation_methods.rb
+++ b/lib/kaminari/active_record_relation_methods.rb
@@ -1,0 +1,40 @@
+module Kaminari
+  module ActiveRecordRelationMethods
+    def total_count
+      @total_count ||= begin
+       if Chill::Application.config.tables_using_naive_counts.include?(table_name)
+         get_naive_total_count
+       else
+         get_actual_count
+       end
+      end
+    end
+
+    def get_actual_count
+      # This is extracted fairly directly from the original
+      # Kaminari::ActiveRecordRelationMethods class
+
+      c = except(:offset, :limit, :order)
+
+      # Remove includes only if they are irrelevant
+      c = c.except(:includes) unless references_eager_loaded_tables?
+
+      # a workaround to count the actual model instances on distinct query because count + distinct returns wrong value in some cases. see https://github.com/amatsuda/kaminari/pull/160
+      uses_distinct_sql_statement = c.to_sql =~ /DISTINCT/i
+      if uses_distinct_sql_statement
+        c.length
+      else
+        # .group returns an OrderdHash that responds to #count
+        c = c.count
+        c.respond_to?(:count) ? c.count : c
+      end
+    end
+
+    def get_naive_total_count
+      result = connection.execute(
+        "SELECT (reltuples)::integer FROM pg_class r WHERE relkind = 'r' AND relname ='#{table_name}'"
+      )
+      result.first["reltuples"].to_i
+    end
+  end
+end

--- a/spec/lib/kaminari/active_record_relation_methods_spec.rb
+++ b/spec/lib/kaminari/active_record_relation_methods_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'Customized kaminari counting' do
+  it 'counts for configured tables' do
+    table_name = 'a_table'
+    dummy = Dummy.new(table_name)
+    execute_double = stub_execute(dummy)
+
+    execute_double.should_receive(:execute)
+
+    with_configured_pagination_overrides([ table_name ]) do
+      dummy.total_count
+    end
+  end
+
+  it 'does not count for unconfigured tables' do
+    table_name = 'a_table'
+    different_table_name = 'some_other_table_name'
+
+    dummy = Dummy.new(table_name)
+    execute_double = stub_execute(dummy)
+
+    execute_double.should_not_receive(:execute)
+
+    with_configured_pagination_overrides([ different_table_name ]) do
+      begin
+        dummy.total_count
+      rescue
+      end
+    end
+  end
+
+  def stub_execute(dummy)
+    double('Execute double', execute: [{ 'reltuples' => 100 }]).tap do |execute_double|
+      dummy.stub(:connection).and_return(execute_double)
+    end
+  end
+
+  def with_configured_pagination_overrides(tables)
+    original_tables_with_naive_counts = Chill::Application.config.tables_using_naive_counts
+    begin
+      Chill::Application.config.tables_using_naive_counts = tables
+      yield
+    ensure
+      Chill::Application.config.tables_using_naive_counts = original_tables_with_naive_counts
+    end
+  end
+
+  class Dummy
+    include Kaminari::ActiveRecordRelationMethods
+    attr_reader :table_name
+    def initialize(table_name)
+      @table_name = table_name
+    end
+  end
+end
+


### PR DESCRIPTION
Monkeypatch Kaminari::ActiveRecordRelationMethods to naively count configured
tables via reltuples, which - while imprecise - returns almost instantly as
opposed to taking multiple minutes.

This feature defaults to only intercept counts on  `infringing_urls`, you can
configure it by modifying the following ENV with a comma-separated list:

```
TABLES_USING_NAIVE_COUNTS="infringing_urls,works"
```

See also:
- https://wiki.postgresql.org/wiki/Slow_Counting
