### PR TITLE
Rails admin edit error fix

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -161,9 +161,9 @@ RailsAdmin.config do |config|
     object_label_method { :custom_work_label }
     
     edit do
-      configure(:notice) { hide }
+      configure(:notices) { hide }
     end
-    
+
     list do
       configure(:copyrighted_urls) { hide }
       configure(:infringing_urls) { hide }

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -159,11 +159,11 @@ RailsAdmin.config do |config|
 
   config.model 'Work' do
     object_label_method { :custom_work_label }
-    configure :notices do
-      visible do
-        bindings[:object].notices.count < 100
-      end
+    
+    edit do
+      configure(:notice) { hide }
     end
+    
     list do
       configure(:copyrighted_urls) { hide }
       configure(:infringing_urls) { hide }


### PR DESCRIPTION
This should fix the error that we were getting when trying to edit notices in Rails Admin.