### PR TITLE
Add visible checks to SearchesModels queries to limit facet results.

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -184,7 +184,11 @@ class Notice < ActiveRecord::Base
   end
 
   def self.visible
-    where(spam: false, hidden: false, published: true, rescinded: false)
+    where(visible_qualifiers)
+  end
+
+  def self.visible_qualifiers
+    { spam: false, hidden: false, published: true, rescinded: false }
   end
   
   def self.find_unpublished(notice_id)

--- a/spec/models/searches_models_spec.rb
+++ b/spec/models/searches_models_spec.rb
@@ -1,6 +1,22 @@
 require 'spec_helper'
 
 describe SearchesModels do
+  context 'visible_qualifiers' do
+    it "delegates to the @model_class" do
+      expected = { expected_key: :expected_value }
+      FakeModel.stub(:visible_qualifiers).and_return(expected)
+      expect(described_class.new({}, FakeModel).visible_qualifiers).to eq(expected)
+    end
+
+    it "fills in if @model_class does not support it" do
+      expect(described_class.new({}, FakeModel).visible_qualifiers).to eq({})
+    end
+
+    it "has a real value calling with all defaults" do
+      expected = { spam: false, hidden: false, published: true, rescinded: false }
+      expect(described_class.new.visible_qualifiers).to eq(expected)
+    end
+  end
 
   it "returns an elasticsearch search instance" do
     expect(subject.search).to be_instance_of(Tire::Search::Search)


### PR DESCRIPTION
Keeps facet results from leaking hidden, spam, rescinded, or unpublished data.