### PR TITLE
Add notes field to notices model

### DIFF
--- a/db/migrate/20160222192409_add_notes_to_notices.rb
+++ b/db/migrate/20160222192409_add_notes_to_notices.rb
@@ -1,0 +1,5 @@
+class AddNotesToNotices < ActiveRecord::Migration
+  def change
+    add_column :notices, :notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160114162401) do
+ActiveRecord::Schema.define(:version => 20160222192409) do
 
   create_table "blog_entries", :force => true do |t|
     t.integer  "user_id"
@@ -161,6 +161,7 @@ ActiveRecord::Schema.define(:version => 20160114162401) do
     t.boolean  "published",                :default => true,  :null => false
     t.integer  "url_count"
     t.boolean  "webform",                  :default => false
+    t.text     "notes"
   end
 
   add_index "notices", ["original_notice_id"], :name => "index_notices_on_original_notice_id"


### PR DESCRIPTION
This adds a field to the notices model for admins to take notes in.
This field will be visible to everyone that has access to RailsAdmin.