### PR TITLE
Fixes risk trigger no argument error

### DIFF
--- a/app/models/risk_trigger.rb
+++ b/app/models/risk_trigger.rb
@@ -1,7 +1,7 @@
 class RiskTrigger < ActiveRecord::Base
 
   def risky?(notice)
-    field_present?(notice) && condition_matches?(notice) unless notice.submitter.try(:email, "google@chillingeffects.org") && notice.try(:type, "Defamation")
+    field_present?(notice) && condition_matches?(notice) unless notice..try(:submitter).try(:email, "google@chillingeffects.org") && notice.try(:type, "Defamation")
 
   rescue NoMethodError => ex
     Rails.logger.warn "Invalid risk trigger (#{id}): #{ex}"


### PR DESCRIPTION
*When submitting a notice via web interface as a logged out user an error would say wrong number of arguments (1 for 0) on the submitter. This fixes that error.