### PR TITLE
Redact Turkish phone numbers with spaces in them

### DIFF
--- a/app/models/redacts_notices.rb
+++ b/app/models/redacts_notices.rb
@@ -50,7 +50,8 @@ class RedactsNotices
     def redact(text)
       redactor = RedactsContent.new(
         /(\(?\d{3}\)?.?)? # optional area code
-         \d{3}[^\d]?\d{4} # phone number, optional single-char separator
+         (\d{3}[^\d]?\d{4})| # phone number, optional single-char separator
+         (\d+[\d ]{10,16}\d+) # turkish phone number
         /x
       )
 

--- a/spec/models/redacts_notices_spec.rb
+++ b/spec/models/redacts_notices_spec.rb
@@ -27,6 +27,7 @@ describe RedactsNotices::RedactsPhoneNumbers do
     456-7890
     456.7890
     456\ 7890
+    90\ 212\ 326\ 06\ 15
   )
 
   PHONE_NUMBERS.each do |phone_number|


### PR DESCRIPTION
Fixes an edge case where long Turkish phone numbers with spaces in them were not being redacted.