### PR TITLE
Do not redact stopwords

### DIFF
--- a/app/models/redacts_notices.rb
+++ b/app/models/redacts_notices.rb
@@ -33,12 +33,32 @@ class RedactsNotices
   end
 
   class RedactsContent
+    STOP_WORDS = %w(
+      a about above across after again against all almost alone along already also although always among an and another any anybody anyone anything
+      anywhere are area areas around as ask asked asking asks at away b back backed backing backs be became because become becomes been before began
+      behind being beings best better between big both but by c came can cannot case cases certain certainly clear clearly come could d did differ 
+      different differently do does done down down downed downing downs during e each early either end ended ending ends enough even evenly ever 
+      every everybody everyone everything everywhere f face faces fact facts far felt few find finds first for four from full fully further furthered 
+      furthering furthers g gave general generally get gets give given gives go going good goods got great greater greatest group grouped grouping 
+      groups h had has have having he her here herself high high high higher highest him himself his how however i if important in interest interested
+      nteresting interests into is it its itself j just k keep keeps kind knew know known knows l large largely last later latest least less let lets
+      like likely long longer longest m made make making man many may me member members men might more most mostly mr mrs much must my myself n necessary
+      need needed needing needs never new new newer newest next no nobody non noone not nothing now nowhere number numbers o of off often old older
+      oldest on once one only open opened opening opens or order ordered ordering orders other others our out over p part parted parting parts per
+      perhaps place places point pointed pointing points possible present presented presenting presents problem problems put puts q quite r rather
+      really right right room rooms s said same saw say says second seconds see seem seemed seeming seems sees several shall she should show showed
+      showing shows side sides since small smaller smallest so some somebody someone something somewhere state states still still such sure t take
+      taken than that the their them then there therefore these they thing things think thinks this those though thought thoughts three through thus
+      to today together too took toward turn turned turning turns two u under until up upon us use used uses v very w want wanted wanting wants was
+      way ways we well wells went were what when where whether which while who whole whose why will with within without work worked working works
+      would x y year years yet you young younger youngest your yours z
+    )
     def initialize(string_or_regex)
       @string_or_regex = string_or_regex
     end
 
     def redact(content)
-      content.gsub(@string_or_regex, mask)
+      content.gsub(@string_or_regex) { |s| STOP_WORDS.include?(s) ? s : mask }
     end
 
     def mask

--- a/spec/models/redacts_notices_spec.rb
+++ b/spec/models/redacts_notices_spec.rb
@@ -122,6 +122,17 @@ describe RedactsNotices do
       expect(notice.body).to eq "Some [REDACTED] text"
       expect(notice.body_original).to eq "Some sensitive text"
     end
+
+    it "ignores stopwords" do
+      notice = build(
+        :dmca,
+        body: "Text with the stopwords")
+      redactor = RedactsNotices.new([RedactsNotices::RedactsContent.new('the')])
+
+      redactor.redact(notice, :body)
+
+      expect(notice.body).to eq "Text with the stopwords"
+    end
   end
 
   context "#redact_all" do


### PR DESCRIPTION
* This feature causes the content redactor to not redact stopwords that might be part of a company name or other text portion that it wants to redact.