### PR TITLE
Edit Ruby version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Development
 
 Requirements:
 
-* ruby 2.0
+* ruby 2.1.9
 * modern postgres
 * A jre (openjdk works fine)
 


### PR DESCRIPTION
Bumped the Ruby version in the README file. Gem install on Ruby 2.1.9 have been successful on me El Capitan. I need to know if my PRs can now be merged. Testing waters.