### PR TITLE
Change redact all to redact all notices in queue

### DIFF
--- a/app/views/rails_admin/application/_redact_everywhere_form.html.erb
+++ b/app/views/rails_admin/application/_redact_everywhere_form.html.erb
@@ -1,14 +1,12 @@
 <%= redact_notice_form(abstract_model, object, params) do |form| %>
   <%= hidden_field_tag(:selected_text) %>
   <%=
-    number_affected = params.fetch(:next_notices, []).length + 1
-
     form.submit(
       'Redact selection everywhere',
       name: 'redact_everywhere',
       id: "redact-selected-everywhere",
       class: 'btn btn-danger',
-      confirm: "Redact selected text in #{number_affected} notices?"
+      confirm: "Redact selected text in all notices that are under review?"
     )
   %>
 <% end %>

--- a/lib/rails_admin/config/actions/redact_notice.rb
+++ b/lib/rails_admin/config/actions/redact_notice.rb
@@ -8,11 +8,11 @@ class PostResponder < ActionResponder
     if params[:selected_text].present?
       redactor = RedactsNotices.new([
         RedactsNotices::RedactsContent.new(params[:selected_text])
-      ])
+                                    ])
 
-      next_notice_ids = params.fetch(:next_notices, []).map(&:to_i)
+      review_required_ids = Notice.where(review_required: true).pluck(:id)
 
-      redactor.redact_all([object.id] + next_notice_ids)
+      redactor.redact_all([object.id] + review_required_ids)
     end
 
     redirect_to_current(params)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -27,7 +27,7 @@ FactoryGirl.define do
   end
 
   factory :dmca do
-
+    sequence(:id) { |n| n }
     title "A title"
     date_received Time.now
     date_sent Time.now

--- a/spec/integration/redaction_queue_spec.rb
+++ b/spec/integration/redaction_queue_spec.rb
@@ -108,11 +108,8 @@ feature "Redaction queue" do
 
   scenario "A user redacts a pattern everywhere", js: true do
     affected_notices = create_list(:dmca, 3, :redactable, body: "Some text")
-    unaffected_notices = create_list(:dmca, 3, :redactable, body: "Some text")
 
     with_queue do |queue|
-      unaffected_notices.each { |notice| queue.unselect_notice(notice) }
-
       queue.process_selected
 
       body_field = RedactableFieldOnPage.new(:body)
@@ -125,11 +122,6 @@ feature "Redaction queue" do
       affected_notices.each do |notice|
         notice.reload
         expect(notice.body).to eq '[REDACTED]'
-      end
-
-      unaffected_notices.each do |notice|
-        notice.reload
-        expect(notice.body).to eq "Some text"
       end
     end
   end

--- a/spec/rails_admin/config/actions/redact_notice_spec.rb
+++ b/spec/rails_admin/config/actions/redact_notice_spec.rb
@@ -146,6 +146,7 @@ describe "RedactNoticeProc" do
 
   context "Handling POST requests" do
     before { request.stub(:post?).and_return(true) }
+    let!(:redactable_notices) { create_list(:dmca, 3, :redactable) }
 
     it "delegates to the PostResponder" do
       responder = double("Post responder")
@@ -160,26 +161,16 @@ describe "RedactNoticeProc" do
       it "redacts this and all next notices" do
         params[:selected_text] = "Sensitive thing"
         params[:next_notices]  = %w( 2 3 4 )
-        redactor = expect_new(RedactsNotices, [
-          expect_new(RedactsNotices::RedactsContent, "Sensitive thing")
-        ])
-        redactor.should_receive(:redact_all).with([@object.id, 2, 3, 4])
-        should_receive(:redact_notice_path).
-          with(@abstract_model, 1, next_notices: %w( 2 3 4 )).
-          and_return(:some_path)
-        should_receive(:redirect_to).with(:some_path)
-
-        post_responder.handle(params)
-      end
-
-      it "redacts only this notice if there are no next notices" do
-        params[:selected_text] = "Sensitive thing"
-        redactor = stub_new(RedactsNotices, [
-          stub_new(RedactsNotices::RedactsContent, "Sensitive thing")
-        ])
-        redactor.should_receive(:redact_all).with([@object.id])
-        should_receive(:redact_notice_path).
-          with(@abstract_model, 1, next_notices: nil).and_return(:some_path)
+        redactor = expect_new(RedactsNotices,
+                              [
+                                expect_new(RedactsNotices::RedactsContent,
+                                           'Sensitive thing')
+                              ])
+        review_required_ids = [@object.id] + redactable_notices.map(&:id)
+        redactor.should_receive(:redact_all).with(review_required_ids)
+        should_receive(:redact_notice_path)
+          .with(@abstract_model, 1, next_notices: %w( 2 3 4 ))
+          .and_return(:some_path)
         should_receive(:redirect_to).with(:some_path)
 
         post_responder.handle(params)


### PR DESCRIPTION
- Instead of merely redacting the notices that are visible in the redact queue redact all will now redact all notices marked review_required.
