### PR TITLE
Add tasks for updating Google notices

### DIFF
--- a/lib/tasks/chillingeffects.rake
+++ b/lib/tasks/chillingeffects.rake
@@ -579,7 +579,7 @@ where works.id in (
     }
   end
 
-  desc 'Fix Google Defamation notices in Redact Queue'
+  desc 'Fix Google defamation notices in redact queue'
   task fix_google_redact_queue_notices: :environment do
     notices = Notice.where(title: 'Legal Complaint to Google',
                            type: 'Other',
@@ -590,7 +590,14 @@ where works.id in (
       notice.save!
     end
     notices.update_all(review_required: false)
-    notices.update_all(hidden: false)
+  end
+
+  desc 'Unhide hidden Google defamation notices'
+  task unhide_google_defamation_notices: :environment do
+    Notice.where(title: 'Legal Complaint to Google',
+                 type: 'Other',
+                 hidden: true)
+          .update_all(hidden: false)
   end
 
   desc 'Remove Google API Defamation complaints from Redact Queue'

--- a/lib/tasks/chillingeffects.rake
+++ b/lib/tasks/chillingeffects.rake
@@ -578,4 +578,24 @@ where works.id in (
 )
     }
   end
+
+  desc 'Fix Google Defamation notices in Redact Queue'
+  task fix_google_redact_queue_notices: :environment do
+    notices = Notice.where(title: 'Legal Complaint to Google',
+                           type: 'Other',
+                           hidden: true)
+    notices.each do |notice|
+      notice.body = notice.body_original[/(?:country\.)(.+)/, 1]
+      notice.auto_redact
+      notice.save!
+    end
+    notices.update_all(review_required: false)
+    notices.update_all(hidden: false)
+  end
+
+  desc 'Remove Google API Defamation complaints from Redact Queue'
+  task remove_google_api_redact_queue_notices: :environment do
+    Notice.where(title: 'Defamation Complaint to Google', review_required: true)
+          .update_all(review_required: false)
+  end
 end


### PR DESCRIPTION
- Will fix google notices in redact queue so they do not include unneeded text in the body field
- Removes the Google API defamation complaints from the redact queue
