### PR TITLE
Allow removal of nested entity notice roles

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -127,7 +127,7 @@ class Notice < ActiveRecord::Base
   accepts_nested_attributes_for :file_uploads,
     reject_if: ->(attributes) { [attributes['file'], attributes[:pdf_request_fulfilled]].all?(&:blank?) }
 
-  accepts_nested_attributes_for :entity_notice_roles
+  accepts_nested_attributes_for :entity_notice_roles, :allow_destroy => true
 
   accepts_nested_attributes_for :works, :allow_destroy => true
 


### PR DESCRIPTION
Rails admin was not allowing users to delete an entity notice role. This would cause a problem if an entity was associated in multiple roles for a notice and a user wanted to change the name/assocation for one entity but not the other one. This change allows the admin user to sever the relationship and then create a new entity to make this kind of change.
