### PR TITLE
Fix counter-notice radio buttons

### DIFF
--- a/app/views/counter_notices/_form.html.erb
+++ b/app/views/counter_notices/_form.html.erb
@@ -19,6 +19,7 @@
     
       <%= f.input :jurisdiction,
         as: :radio_buttons,
+        item_label_class: "collection_radio_buttons",
         collection: CounterNotice::JURISDICTIONS
     %>
     


### PR DESCRIPTION
The DMCA counter-notice generator radio buttons were not displaying properly because the simple-form update did not give them the class that styled them that the old version had. This manually gives the labels their class and thus fixes the styling.
