### PR TITLE
Fix setup instructions

### DIFF
--- a/ELASTICSEARCH_INDEXING.md
+++ b/ELASTICSEARCH_INDEXING.md
@@ -8,7 +8,7 @@ Elasticsearch indexing happens out-of-process, meaning you must keep the index
 up to date by periodically running `ReindexRun.index_changed_model_instances`.
 This method looks for models (currently Entity and Notice (and its subclasses))
 with an `updated_at` value greater than the last time we reindexed.  It will
-then retreive these model instances in batches (controlled by the value of
+then retrieve these model instances in batches (controlled by the value of
 ENV['BATCH_SIZE'], with a default of 100) and send each of them to
 elasticsearch.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Requirements:
 
 * ruby 2.3.3
 * PostgreSQL 9.6
-* Elasticsearch 1.7.6
+* Elasticsearch 5.6.x
 * Java Runtime Environment (OpenJDK works fine)
 * Piwik Tracking
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Requirements:
 * Elasticsearch 5.6.x
 * Java Runtime Environment (OpenJDK works fine)
 * Piwik Tracking
+* phantomjs (used only by test runner)
 
 Setup:
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,10 @@
-Notice.index.delete
-Notice.create_elasticsearch_index
+# The following four lines may spit out "Index does not
+# exist" errors, but they don't matter.
+Notice.__elasticsearch__.delete_index! force: true
+Notice.__elasticsearch__.create_index! force: true
 
-Entity.index.delete
-Entity.create_elasticsearch_index
+Entity.__elasticsearch__.delete_index! force: true
+Entity.__elasticsearch__.create_index! force: true
 
 # Execute seeds in a logical order
 seed_files = %w(


### PR DESCRIPTION
The current prod version of elasticsearch is 5.6, not 1.7.6. In
addition, db/seeds.rb was inconsistent with the current version of the
elasticsearch library. These updated instructions reduce yakshaving
for new users setting up a first instance.