### PR TITLE
Add index to Notice.created_at

### DIFF
--- a/db/migrate/20180815162606_add_index_to_notices.rb
+++ b/db/migrate/20180815162606_add_index_to_notices.rb
@@ -1,0 +1,5 @@
+class AddIndexToNotices < ActiveRecord::Migration
+  def change
+    add_index :notices, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170908160728) do
+ActiveRecord::Schema.define(version: 20180815162606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 20170908160728) do
     t.integer  "counternotice_for_sid"
   end
 
+  add_index "notices", ["created_at"], name: "index_notices_on_created_at", using: :btree
   add_index "notices", ["original_notice_id"], name: "index_notices_on_original_notice_id", using: :btree
   add_index "notices", ["reviewer_id"], name: "index_notices_on_reviewer_id", using: :btree
   add_index "notices", ["submission_id"], name: "index_notices_on_submission_id", using: :btree


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Adds an index to `Notice.created_at`.

#### Helpful background context (if appropriate)
In Skylight we see that the home page can take an excessively long time to load, and nearly the entirety of this time is spent in SQL (see e.g. https://www.skylight.io/app/applications/utm46ElcSDtw/1534327080/1h27m/endpoints/HomeController%23index?responseType=html).

The SQL query includes an `ORDER_BY` on `Notice.created_at`. This column is not indexed, so it needs to sort on the fly, which is slow.

I did some performance tests on localhost in psql as follows. As you can see, the planning and execution time increase quite markedly as the number of records increases, but the indexed version is dramatically faster.

\c lumen_dev

explain (analyze) SELECT  "notices".* FROM "notices" WHERE "notices"."spam" = false AND "notices"."hidden" = false AND "notices"."published" = true AND "notices"."rescinded" = false  ORDER BY created_at;


----> With 500 notices
--------------------------------------------------------------------------------------------------------------
 Sort  (cost=43.41..44.66 rows=500 width=317) (actual time=0.825..1.054 rows=500 loops=1)
   Sort Key: created_at
   Sort Method: quicksort  Memory: 157kB
   ->  Seq Scan on notices  (cost=0.00..21.00 rows=500 width=317) (actual time=0.029..0.463 rows=500 loops=1)
         Filter: ((NOT spam) AND (NOT hidden) AND published AND (NOT rescinded))
 Planning time: 1.182 ms
 Execution time: 1.210 ms
(7 rows)


----> With 1000 notices
----------------------------------------------------------------------------------------------------------------
 Sort  (cost=88.83..91.33 rows=1000 width=318) (actual time=1.712..1.861 rows=1000 loops=1)
   Sort Key: created_at
   Sort Method: quicksort  Memory: 290kB
   ->  Seq Scan on notices  (cost=0.00..39.00 rows=1000 width=318) (actual time=0.030..1.008 rows=1000 loops=1)
         Filter: ((NOT spam) AND (NOT hidden) AND published AND (NOT rescinded))
 Planning time: 2.074 ms
 Execution time: 2.031 ms
(7 rows)

----> With 1000 notices after adding an index
----------------------------------------------------------------------------------------------------------------------------------------------
 Index Scan using index_notices_on_created_at on notices  (cost=0.28..79.24 rows=1000 width=317) (actual time=0.108..1.517 rows=1000 loops=1)
   Filter: ((NOT spam) AND (NOT hidden) AND published AND (NOT rescinded))
 Planning time: 0.248 ms
 Execution time: 1.653 ms
(4 rows)

#### How can a reviewer manually see the effects of these changes?

You can run similar tests on localhost (`rake db:setup NOTICE_COUNT=X` to set up the db with different numbers of notices). We should be able to run the same psql commands on prod pre- and post-deploy to measure success. We should also see a difference in Skylight for `HomeController#index`.

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
YES

#### Includes new or updated dependencies?
NO
