### PR TITLE
15224 faq perf

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -209,14 +209,6 @@ class Notice < ActiveRecord::Base
     end
   end
 
-  def all_relevant_questions(limit = 15)
-    (relevant_questions | topic_relevant_questions).sample(limit)
-  end
-
-  def related_blog_entries(limit = 5)
-    super.published.limit(limit)
-  end
-
   def other_entity_notice_roles
     other_roles = self.class::DEFAULT_ENTITY_NOTICE_ROLES - Notice::DEFAULT_ENTITY_NOTICE_ROLES
     entity_notice_roles.find_all do |entity_notice_role|

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -134,18 +134,6 @@
           %>
         <% end %>
       </section>
-
-      <section id="relevant-questions">
-        <h4 class="title"><span>Related FAQs</span></h3>
-        <div class="wrapper">
-          <%= render @notice.all_relevant_questions %>
-        </div>
-      </section>
-
-      <section id="related-blog-entries">
-        <h4 class="title"><span>Related Blog Entries</span></h3>
-        <%= render partial: 'blog_entry', collection: @notice.related_blog_entries %>
-      </section>
     </aside>
 
     <footer>

--- a/spec/models/dmca_spec.rb
+++ b/spec/models/dmca_spec.rb
@@ -65,127 +65,6 @@ describe DMCA, type: :model do
     end
   end
 
-  context "#all_relevant_questions" do
-    it "returns questions related to it and its topics" do
-      topic1_questions = [create(:relevant_question, question: "Q1")]
-      topic2_questions = [
-        create(:relevant_question, question: "Q2"),
-        create(:relevant_question, question: "Q3")
-      ]
-      notice_questions = [create(:relevant_question, question: "Q4")]
-      notice = create(
-        :dmca,
-        topics: [
-          create(:topic, relevant_questions: topic1_questions),
-          create(:topic, relevant_questions: topic2_questions)
-        ],
-        relevant_questions: notice_questions
-      )
-
-      questions = notice.all_relevant_questions.map(&:question)
-
-      expect(questions).to match_array %w( Q1 Q2 Q3 Q4 )
-    end
-
-    it "does not duplicate questions" do
-      shared_question = create(:relevant_question, question: "Q1")
-      topic_questions = [
-        shared_question,
-        create(:relevant_question, question: "Q2")
-      ]
-      notice = create(
-        :dmca,
-        topics: [create(:topic, relevant_questions: topic_questions)],
-        relevant_questions: [shared_question]
-      )
-
-      questions = notice.all_relevant_questions.map(&:question)
-
-      expect(questions).to match_array %w( Q1 Q2 )
-    end
-
-    it "can be limited" do
-      notice = create(
-        :dmca, relevant_questions: create_list(:relevant_question, 10)
-      )
-
-      questions_1 = notice.all_relevant_questions(3)
-      questions_2 = notice.all_relevant_questions(3)
-
-      expect(questions_1.length).to eq 3
-      expect(questions_2.length).to eq 3
-    end
-  end
-
-  context "#related_blog_entries" do
-    it "returns blog_entries that share topics with itself" do
-      notice = create(:dmca, :with_topics)
-      expected_blog_entries = [
-        create(:blog_entry, :published, topics: [notice.topics.sample]),
-        create(:blog_entry, :published, topics: [notice.topics.sample]),
-        create(:blog_entry, :published, topics: [notice.topics.sample])
-      ]
-
-      related_blog_entries = notice.related_blog_entries
-
-      expect(related_blog_entries).to match_array(expected_blog_entries)
-    end
-
-    it "does not return blog entries with different topics" do
-      notice = create(:dmca, :with_topics)
-      create(:blog_entry, :published, topics: [create(:topic)])
-
-      related_blog_entries = notice.related_blog_entries
-
-      expect(related_blog_entries).to be_empty
-    end
-
-    it "does not duplicate blog entries" do
-      notice = create(:dmca, :with_topics)
-      blog_entry = create(
-        :blog_entry, :published, topics: notice.topics
-      )
-
-      related_blog_entries = notice.related_blog_entries
-
-      expect(related_blog_entries).to eq [blog_entry]
-    end
-
-    it "returns a limited set of related blog entries" do
-      notice = create(:dmca, :with_topics)
-      create(:blog_entry, :published, topics: [notice.topics.sample])
-      create(:blog_entry, :published, topics: [notice.topics.sample])
-      create(:blog_entry, :published, topics: [notice.topics.sample])
-
-      blog_entries = notice.related_blog_entries(2)
-
-      expect(blog_entries.length).to eq 2
-    end
-
-    it "returns only published blog entries" do
-      notice = create(:dmca, :with_topics)
-      expected_blog_entries = [
-        create(:blog_entry, :published, topics: [notice.topics.first]),
-        create(:blog_entry, :published, topics: [notice.topics.first]),
-      ]
-      create(:blog_entry, topics: [notice.topics.first])
-      create(
-        :blog_entry,
-        topics: [notice.topics.first],
-        published_at: 1.day.from_now
-      )
-      create(
-        :blog_entry,
-        topics: [notice.topics.first],
-        published_at: 1.hour.from_now
-      )
-
-      blog_entries = notice.related_blog_entries
-
-      expect(blog_entries).to match_array(expected_blog_entries)
-    end
-  end
-
   context "#redacted" do
     it "returns '#{DMCA::UNDER_REVIEW_VALUE}' when review is required" do
       notice = DMCA.new(review_required: true, body: "A value")
@@ -360,7 +239,7 @@ describe DMCA, type: :model do
       notice = create(:dmca, file_uploads: file_uploads)
 
       expect(notice).to have(2).original_documents
-      
+
       expect(notice.original_documents).to be_all { |d| d.kind == 'original' }
     end
   end
@@ -406,14 +285,14 @@ describe DMCA, type: :model do
       expect(notice).not_to be_on_behalf_of_principal
     end
   end
-  
+
   context "#publication_delay" do
     it "returns 0 if submitter doesn't respond" do
       notice = create(:dmca)
 
       expect(notice.publication_delay).to eq(0)
     end
-    
+
     it "returns the submitter's value" do
       notice = create(:dmca)
       user = create(:user, :submitter, :with_entity, publication_delay: 60)

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe 'notices/show.html.erb' do
     allow(view.controller).to receive(:current_ability) { @ability }
   end
 
-  it "displays a metadata from a notice" do
+  it 'displays a metadata from a notice' do
     notice = build(:dmca)
     assign(:notice, notice)
 
@@ -16,40 +16,40 @@ describe 'notices/show.html.erb' do
     expect(rendered).to include notice.title
   end
 
-  it "displays the date sent in the proper format" do
+  it 'displays the date sent in the proper format' do
     notice = build(:dmca, date_sent: Time.zone.local(2013, 5, 4))
     allow(notice).to receive(:sender).and_return(build(:entity))
     assign(:notice, notice)
 
     render
 
-    expect(rendered).to include "May 04, 2013"
+    expect(rendered).to include 'May 04, 2013'
   end
 
-  it "displays the date received in the proper format" do
+  it 'displays the date received in the proper format' do
     notice = build(:dmca, date_received: Time.zone.local(2013, 6, 5))
     allow(notice).to receive(:recipient).and_return(build(:entity))
     assign(:notice, notice)
 
     render
 
-    expect(rendered).to include "June 05, 2013"
+    expect(rendered).to include 'June 05, 2013'
   end
 
-  it "displays a notice with tags" do
+  it 'displays a notice with tags' do
     notice = create(:dmca, :with_tags)
     assign(:notice, notice)
 
     render
 
-    expect(rendered).to have_css( '#tags', text: 'a_tag' )
+    expect(rendered).to have_css('#tags', text: 'a_tag')
     expect(rendered).to have_facet_link(:tags, 'a_tag')
   end
 
-  it "displays a notice with default entities" do
-    notice = create(:dmca, role_names: ['sender', 'recipient'])
-    sender = notice.sender
-    recipient = notice.recipient
+  it 'displays a notice with default entities' do
+    notice = create(:dmca, role_names: %w[sender recipient])
+    _sender = notice.sender
+    _recipient = notice.recipient
 
     assign(:notice, notice)
 
@@ -61,15 +61,18 @@ describe 'notices/show.html.erb' do
       expect(rendered).to have_css('#entities span', text: entity.state)
       expect(rendered).to have_css('#entities span', text: entity.country_code)
       expect(rendered).to have_css('#entities span.private', text: '[Private]')
-      expect(rendered).not_to have_css('#entities span', text: entity.address_line_1)
-      expect(rendered).not_to have_css('#entities span', text: entity.address_line_2)
+      expect(rendered).not_to have_css('#entities span',
+                                       text: entity.address_line_1)
+      expect(rendered).not_to have_css('#entities span',
+                                       text: entity.address_line_2)
     end
   end
 
-  it "displays non-default entities" do
+  it 'displays non-default entities' do
     notice = create(
       :court_order,
-      role_names: %w|recipient sender principal issuing_court plaintiff defendant|
+      role_names: %w[recipient sender principal issuing_court plaintiff
+                     defendant]
     )
 
     assign(:notice, notice)
@@ -77,13 +80,14 @@ describe 'notices/show.html.erb' do
     render
 
     notice.other_entity_notice_roles.each do |role|
-      expect(rendered).to have_css( '.secondary.hide a', text: role.entity.name )
-      expect(rendered).to have_css( '.other-entities li', text: role.name.titleize )
+      expect(rendered).to have_css('.secondary.hide a', text: role.entity.name)
+      expect(rendered).to have_css('.other-entities li',
+                                   text: role.name.titleize)
     end
   end
 
-  it "displays sender_names such that they are clickable" do
-    notice = create(:dmca, role_names: %w( sender principal recipient ))
+  it 'displays sender_names such that they are clickable' do
+    notice = create(:dmca, role_names: %w[sender principal recipient])
 
     assign(:notice, notice)
 
@@ -94,78 +98,78 @@ describe 'notices/show.html.erb' do
     expect(rendered).to have_facet_link(:recipient_name, notice.recipient_name)
   end
 
-  context "showing Principal" do
+  context 'showing Principal' do
     it "displays the name as 'on behalf of principal' when differing" do
-      notice = create(:dmca, role_names: %w( sender principal ))
+      notice = create(:dmca, role_names: %w[sender principal])
       allow(notice).to receive(:on_behalf_of_principal?).and_return(true)
       assign(:notice, notice)
 
       render
 
-      expect(rendered).to have_css( '.sender a', text: notice.sender_name )
-      expect(rendered).to have_css( '.sender span', text: 'on behalf of' )
-      expect(rendered).to have_css( '.sender a', text: notice.principal_name )
+      expect(rendered).to have_css('.sender a', text: notice.sender_name)
+      expect(rendered).to have_css('.sender span', text: 'on behalf of')
+      expect(rendered).to have_css('.sender a', text: notice.principal_name)
     end
 
-    it "does not display if not different" do
-      notice = create(:dmca, role_names: %w( sender principal ))
+    it 'does not display if not different' do
+      notice = create(:dmca, role_names: %w[sender principal])
       allow(notice).to receive(:on_behalf_of_principal?).and_return(false)
       assign(:notice, notice)
 
       render
 
-      expect(rendered).to have_css( '.sender a', text: notice.sender_name )
-      expect(rendered).not_to have_css( '.sender span', text: 'on behalf of' )
-      expect(rendered).not_to have_css( '.sender a', text: notice.principal_name )
+      expect(rendered).to have_css('.sender a', text: notice.sender_name)
+      expect(rendered).not_to have_css('.sender span', text: 'on behalf of')
+      expect(rendered).not_to have_css('.sender a', text: notice.principal_name)
     end
   end
 
   it "displays a notice's works and infringing urls" do
     params = {
       notice: {
-        title: "A title",
-        type: "DMCA",
-        subject: "Infringement Notfication via Blogger Complaint",
-        date_sent: "2013-05-22",
-        date_received: "2013-05-23",
+        title: 'A title',
+        type: 'DMCA',
+        subject: 'Infringement Notfication via Blogger Complaint',
+        date_sent: '2013-05-22',
+        date_received: '2013-05-23',
         works_attributes: [
           {
-            description: "The Avengers",
+            description: 'The Avengers',
             copyrighted_urls_attributes: [
-              { url: "http://example.com/test_url_1" },
-              { url: "http://example.com/test_url_2" },
-              { url: "http://example.com/test_url_3" }
+              { url: 'http://example.com/test_url_1' },
+              { url: 'http://example.com/test_url_2' },
+              { url: 'http://example.com/test_url_3' }
             ],
             infringing_urls_attributes: [
-              { url: "http://youtube.com/bad_url_1" },
-              { url: "http://youtube.com/bad_url_2" },
-              { url: "http://youtube.com/bad_url_3" }
+              { url: 'http://youtube.com/bad_url_1' },
+              { url: 'http://youtube.com/bad_url_2' },
+              { url: 'http://youtube.com/bad_url_3' }
             ]
           }
         ],
         entity_notice_roles_attributes: [
           {
-            name: "recipient",
+            name: 'recipient',
             entity_attributes: {
-              name: "Google",
-              kind: "organization",
-              address_line_1: "1600 Amphitheatre Parkway",
-              city: "Mountain View",
-              state: "CA",
-              zip: "94043",
-              country_code: "US"
+              name: 'Google',
+              kind: 'organization',
+              address_line_1: '1600 Amphitheatre Parkway',
+              city: 'Mountain View',
+              state: 'CA',
+              zip: '94043',
+              country_code: 'US'
             }
           },
           {
-            name: "sender",
+            name: 'sender',
             entity_attributes: {
-              name: "Joe Lawyer",
-              kind: "individual",
-              address_line_1: "1234 Anystreet St.",
-              city: "Anytown",
-              state: "CA",
-              zip: "94044",
-              country_code: "US"
+              name: 'Joe Lawyer',
+              kind: 'individual',
+              address_line_1: '1234 Anystreet St.',
+              city: 'Anytown',
+              state: 'CA',
+              zip: '94044',
+              country_code: 'US'
             }
           }
         ]
@@ -180,24 +184,27 @@ describe 'notices/show.html.erb' do
     render
 
     notice.works.each do |work|
-      expect(rendered).to have_css( "#work_#{work.id} .description", text: work.description )
+      expect(rendered).to have_css("#work_#{work.id} .description",
+                                   text: work.description)
 
       work.copyrighted_urls.each do |url|
-        expect(rendered).to have_css( "#work_#{work.id} li.copyrighted_url", text: url.url )
+        expect(rendered).to have_css("#work_#{work.id} li.copyrighted_url",
+                                     text: url.url)
       end
 
       work.infringing_urls.each do |url|
-        expect(rendered).to have_css( "#work_#{work.id} li.infringing_url", text: url.url )
+        expect(rendered).to have_css("#work_#{work.id} li.infringing_url",
+                                     text: url.url)
       end
     end
   end
 
-  it "displays the notice source" do
-    assign(:notice, build(:dmca, source: "Arbitrary source"))
+  it 'displays the notice source' do
+    assign(:notice, build(:dmca, source: 'Arbitrary source'))
 
     render
 
-    expect(rendered).to have_content("Sent via: Arbitrary source")
+    expect(rendered).to have_content('Sent via: Arbitrary source')
   end
 
   Notice::VALID_ACTIONS.each do |action|
@@ -210,23 +217,23 @@ describe 'notices/show.html.erb' do
     end
   end
 
-  it "displays correctly for a notice of unknown source" do
+  it 'displays correctly for a notice of unknown source' do
     assign(:notice, build(:dmca, source: nil))
 
     render
 
-    expect(rendered).to have_content("Sent via: Unknown")
+    expect(rendered).to have_content('Sent via: Unknown')
   end
 
   it "displays the notice's subject" do
-    assign(:notice, build(:dmca, subject: "Some subject"))
+    assign(:notice, build(:dmca, subject: 'Some subject'))
 
     render
 
-    expect(rendered).to have_content("Re: Some subject")
+    expect(rendered).to have_content('Re: Some subject')
   end
 
-  it "does not link to the notices original" do
+  it 'does not link to the notices original' do
     notice = create(:dmca, :with_original, :with_pdf)
     original = notice.file_uploads.first
     assign(:notice, notice)
@@ -236,19 +243,21 @@ describe 'notices/show.html.erb' do
     expect(rendered).not_to have_link(original.url)
   end
 
-  it "shows links to supporting documents" do
+  it 'shows links to supporting documents' do
     notice = create(:dmca, :with_pdf, :with_image, :with_document)
     assign(:notice, notice)
 
     render
 
     notice.file_uploads.each do |file_upload|
-      expect(rendered).to have_css( "ol.attachments .#{file_upload.file_type.downcase}" )
-      expect(rendered).to have_css( "ol.attachments a[href=\"#{file_upload.url}\"]" )
+      expect(rendered).to have_css(
+        "ol.attachments .#{file_upload.file_type.downcase}")
+      expect(rendered).to have_css(
+        "ol.attachments a[href=\"#{file_upload.url}\"]")
     end
   end
 
-  it "does not show supporting documents list when empty" do
+  it 'does not show supporting documents list when empty' do
     assign(:notice, build(:dmca))
 
     render
@@ -257,7 +266,7 @@ describe 'notices/show.html.erb' do
     expect(rendered).not_to have_css('.attachments')
   end
 
-  it "shows a link to the admin page for admins" do
+  it 'shows a link to the admin page for admins' do
     notice = build_stubbed(:dmca)
     assign(:notice, notice)
     @ability.can :access, :rails_admin
@@ -269,7 +278,7 @@ describe 'notices/show.html.erb' do
     )
   end
 
-  it "does not show a link to admin normally" do
+  it 'does not show a link to admin normally' do
     notice = build_stubbed(:dmca)
     assign(:notice, notice)
 
@@ -288,5 +297,4 @@ describe 'notices/show.html.erb' do
       text: value
     )
   end
-
 end

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -120,22 +120,6 @@ describe 'notices/show.html.erb' do
     end
   end
 
-  it "displays a notice with all relevant questions" do
-    topic_question = create(:relevant_question, question: "Q 1", answer: "A 1")
-    notice_question = create(:relevant_question, question: "Q 2", answer: "A 2")
-    assign(:notice, create(:dmca,
-      topics: [create(:topic, relevant_questions: [topic_question])],
-      relevant_questions: [notice_question]
-    ))
-
-    render
-
-    [topic_question, notice_question].each do |question|
-      expect(rendered).to have_css("#relevant_question_#{question.id} .question", text: question.question)
-      expect(rendered).to have_css("#relevant_question_#{question.id} .answer", text: question.answer)
-    end
-  end
-
   it "displays a notice's works and infringing urls" do
     params = {
       notice: {
@@ -167,7 +151,7 @@ describe 'notices/show.html.erb' do
               kind: "organization",
               address_line_1: "1600 Amphitheatre Parkway",
               city: "Mountain View",
-              state: "CA", 
+              state: "CA",
               zip: "94043",
               country_code: "US"
             }
@@ -240,19 +224,6 @@ describe 'notices/show.html.erb' do
     render
 
     expect(rendered).to have_content("Re: Some subject")
-  end
-
-  it "displays limited related blog entries" do
-    blog_entries = build_stubbed_list(:blog_entry, 3)
-    notice = build(:dmca)
-    allow(notice).to receive(:related_blog_entries).and_return(blog_entries)
-    assign(:notice, notice)
-
-    render
-
-    blog_entries.each do |blog_entry|
-      expect(rendered).to have_link( blog_entry.title, href: blog_entry_path(blog_entry) )
-    end
   end
 
   it "does not link to the notices original" do


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Removes the related FAQs and blogs from Notices - they were very resource-intensive to construct.

If we decide we want some amount of FAQ content to be here, an alternative would be:
* select one random related topic
* pull some of its related content
* cache that template fragment, using the topic ID in the key

That should be more performant than the status quo, but less performant than just removing the feature entirely.

#### Helpful background context (if appropriate)
Constructing four inner joins when some of the tables have millions of entries is slow, even if you indexed things.

#### How can a reviewer manually see the effects of these changes?
Compare, e.g., https://lumendatabase.org/notices/1 and http://flutie.law.harvard.edu:8000/notices/300073651 (scroll down).

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15224

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- ~~[ ] Documentation~~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
