### PR TITLE
15439 submitter field

### DIFF
--- a/app/models/government_request.rb
+++ b/app/models/government_request.rb
@@ -1,6 +1,5 @@
 class GovernmentRequest < Notice
-
-  DEFAULT_ENTITY_NOTICE_ROLES = %w|recipient sender principal|
+  DEFAULT_ENTITY_NOTICE_ROLES = %w[recipient sender principal].freeze
   acts_as_taggable_on :regulations
 
   define_elasticsearch_mapping
@@ -11,11 +10,12 @@ class GovernmentRequest < Notice
     'Email',
     'Records Preservation',
     'Subpoena',
-    'Warrant',
-  ]
+    'Warrant'
+  ].freeze
 
   validates_inclusion_of :request_type,
-    in: VALID_REQUEST_TYPES, allow_blank: true
+                         in: VALID_REQUEST_TYPES,
+                         allow_blank: true
 
   def self.model_name
     Notice.model_name

--- a/app/models/government_request.rb
+++ b/app/models/government_request.rb
@@ -1,5 +1,5 @@
 class GovernmentRequest < Notice
-  DEFAULT_ENTITY_NOTICE_ROLES = %w[recipient sender principal].freeze
+  DEFAULT_ENTITY_NOTICE_ROLES = %w[recipient sender principal submitter].freeze
   acts_as_taggable_on :regulations
 
   define_elasticsearch_mapping

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe NoticesController do
-  context "#show" do
-    it "finds the notice by ID" do
+  context '#show' do
+    it 'finds the notice by ID' do
       notice = Notice.new
       expect(Notice).to receive(:find).with('42').and_return(notice)
 
@@ -11,8 +11,8 @@ describe NoticesController do
       expect(assigns(:notice)).to eq notice
     end
 
-    context "as HTML" do
-      it "renders the show template" do
+    context 'as HTML' do
+      it 'renders the show template' do
         stub_find_notice
 
         get :show, id: 1
@@ -21,7 +21,7 @@ describe NoticesController do
         expect(response).to render_template(:show)
       end
 
-      it "renders the rescinded template if the notice is rescinded" do
+      it 'renders the rescinded template if the notice is rescinded' do
         stub_find_notice(build(:dmca, rescinded: true))
 
         get :show, id: 1
@@ -31,14 +31,15 @@ describe NoticesController do
       end
     end
 
-    context "as JSON" do
+    context 'as JSON' do
       Notice.type_models.each do |model_class|
         it "returns a serialized notice for #{model_class}" do
           notice = stub_find_notice(model_class.new)
           serializer_class = model_class.active_model_serializer || NoticeSerializer
           serialized = serializer_class.new(notice)
-          expect(serializer_class).to receive(:new).
-            with(notice, anything).and_return(serialized)
+          expect(serializer_class).to receive(:new)
+            .with(notice, anything)
+            .and_return(serialized)
 
           get :show, id: 1, format: :json
 
@@ -55,54 +56,54 @@ describe NoticesController do
 
         get :show, id: 1, format: :json
 
-        json = JSON.parse(response.body)["dmca"]
+        json = JSON.parse(response.body)['dmca']
         expect(json).to have_key('id').with_value(notice.id)
         expect(json).to have_key('title').with_value(notice.title)
-        expect(json).to have_key('body').with_value("Notice Rescinded")
+        expect(json).to have_key('body').with_value('Notice Rescinded')
       end
 
-      it "returns original URLs for a Notice if you are a researcher" do
+      it 'returns original URLs for a Notice if you are a researcher' do
         user = create(:user, roles: [Role.researcher])
         params = {
           notice: {
-            title: "A title",
-            type: "DMCA",
-            subject: "Infringement Notfication via Blogger Complaint",
-            date_sent: "2013-05-22",
-            date_received: "2013-05-23",
+            title: 'A title',
+            type: 'DMCA',
+            subject: 'Infringement Notfication via Blogger Complaint',
+            date_sent: '2013-05-22',
+            date_received: '2013-05-23',
             works_attributes: [
               {
-                description: "The Avengers",
+                description: 'The Avengers',
                 infringing_urls_attributes: [
-                  { url: "http://youtube.com/bad_url_1" },
-                  { url: "http://youtube.com/bad_url_2" },
-                  { url: "http://youtube.com/bad_url_3" }
+                  { url: 'http://youtube.com/bad_url_1' },
+                  { url: 'http://youtube.com/bad_url_2' },
+                  { url: 'http://youtube.com/bad_url_3' }
                 ]
               }
             ],
             entity_notice_roles_attributes: [
               {
-                name: "recipient",
+                name: 'recipient',
                 entity_attributes: {
-                  name: "Google",
-                  kind: "organization",
-                  address_line_1: "1600 Amphitheatre Parkway",
-                  city: "Mountain View",
-                  state: "CA", 
-                  zip: "94043",
-                  country_code: "US"
+                  name: 'Google',
+                  kind: 'organization',
+                  address_line_1: '1600 Amphitheatre Parkway',
+                  city: 'Mountain View',
+                  state: 'CA',
+                  zip: '94043',
+                  country_code: 'US'
                 }
               },
               {
-                name: "sender",
+                name: 'sender',
                 entity_attributes: {
-                  name: "Joe Lawyer",
-                  kind: "individual",
-                  address_line_1: "1234 Anystreet St.",
-                  city: "Anytown",
-                  state: "CA",
-                  zip: "94044",
-                  country_code: "US"
+                  name: 'Joe Lawyer',
+                  kind: 'individual',
+                  address_line_1: '1234 Anystreet St.',
+                  city: 'Anytown',
+                  state: 'CA',
+                  zip: '94044',
+                  country_code: 'US'
                 }
               }
             ]
@@ -116,7 +117,7 @@ describe NoticesController do
         request.env['HTTP_AUTHENTICATION_TOKEN'] = user.authentication_token
         get :show, id: 1, format: :json
 
-        json = JSON.parse(response.body)["dmca"]["works"][0]["infringing_urls"][0]
+        json = JSON.parse(response.body)['dmca']['works'][0]['infringing_urls'][0]
         expect(json).to have_key('url_original')
       end
     end
@@ -127,36 +128,36 @@ describe NoticesController do
     end
   end
 
-  context "#create" do
-    context "format-independent logic" do
+  context '#create' do
+    context 'format-independent logic' do
       before do
-        @submit_notice = double("SubmitNotice").as_null_object
-        @notice_params = HashWithIndifferentAccess.new(title: "A title")
+        @submit_notice = double('SubmitNotice').as_null_object
+        @notice_params = HashWithIndifferentAccess.new(title: 'A title')
       end
 
-      it "initializes a DMCA by default from params" do
-        expect(SubmitNotice).to receive(:new).
-          with(DMCA, @notice_params).
-          and_return(@submit_notice)
+      it 'initializes a DMCA by default from params' do
+        expect(SubmitNotice).to receive(:new)
+          .with(DMCA, @notice_params)
+          .and_return(@submit_notice)
 
         post :create, notice: @notice_params
       end
 
-      it "uses the type param to instantiate the correct class" do
-        expect(SubmitNotice).to receive(:new).
-          with(Trademark, @notice_params).
-          and_return(@submit_notice)
+      it 'uses the type param to instantiate the correct class' do
+        expect(SubmitNotice).to receive(:new)
+          .with(Trademark, @notice_params)
+          .and_return(@submit_notice)
 
         post :create, notice: @notice_params.merge(type: 'trademark')
       end
 
-      it "defaults to DMCA if the type is missing or invalid" do
+      it 'defaults to DMCA if the type is missing or invalid' do
         invalid_types = ['', 'FlimFlam', 'Object', 'User', 'Hash']
 
-        expect(SubmitNotice).to receive(:new).
-          exactly(5).times.
-          with(DMCA, @notice_params).
-          and_return(@submit_notice)
+        expect(SubmitNotice).to receive(:new)
+          .exactly(5).times
+          .with(DMCA, @notice_params)
+          .and_return(@submit_notice)
 
         invalid_types.each do |invalid_type|
           post :create, notice: @notice_params.merge(type: invalid_type)
@@ -164,8 +165,8 @@ describe NoticesController do
       end
     end
 
-    context "as HTML" do
-      it "redirects when saved successfully" do
+    context 'as HTML' do
+      it 'redirects when saved successfully' do
         stub_submit_notice
 
         post_create
@@ -173,7 +174,7 @@ describe NoticesController do
         expect(response).to redirect_to(:root)
       end
 
-      it "renders the new template when unsuccessful" do
+      it 'renders the new template when unsuccessful' do
         submit_notice = stub_submit_notice
         allow(submit_notice).to receive(:submit).and_return(false)
 
@@ -184,7 +185,7 @@ describe NoticesController do
       end
     end
 
-    context "as JSON" do
+    context 'as JSON' do
       before do
         @ability = Object.new
         @ability.extend(CanCan::Ability)
@@ -192,7 +193,7 @@ describe NoticesController do
         allow(controller).to receive(:current_ability) { @ability }
       end
 
-      it "returns unauthorized if one cannot submit" do
+      it 'returns unauthorized if one cannot submit' do
         stub_submit_notice
         @ability.cannot(:submit, Notice)
 
@@ -201,7 +202,7 @@ describe NoticesController do
         expect(response.status).to eq 401
       end
 
-      it "returns a proper Location header when saved successfully" do
+      it 'returns a proper Location header when saved successfully' do
         notice = build_stubbed(:dmca)
         submit_notice = stub_submit_notice
         allow(submit_notice).to receive(:notice).and_return(notice)
@@ -212,7 +213,7 @@ describe NoticesController do
         expect(response.headers['Location']).to eq notice_url(notice)
       end
 
-      it "returns a useful status code when there are errors" do
+      it 'returns a useful status code when there are errors' do
         submit_notice = stub_submit_notice
         allow(submit_notice).to receive(:submit).and_return(false)
 
@@ -221,7 +222,7 @@ describe NoticesController do
         expect(response).to be_unprocessable
       end
 
-      it "includes any errors in the response" do
+      it 'includes any errors in the response' do
         submit_notice = stub_submit_notice
         allow(submit_notice).to receive(:submit).and_return(false)
         allow(submit_notice).to receive(:errors).and_return(
@@ -245,7 +246,7 @@ describe NoticesController do
     end
 
     def post_create(format = :html)
-      post :create, notice: { title: "A title" }, format: format
+      post :create, notice: { title: 'A title' }, format: format
     end
 
     def mock_errors(model, field_errors = {})

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -1,88 +1,88 @@
 require 'rails_helper'
 require 'support/sign_in'
 
-feature "notice submission" do
+feature 'notice submission' do
   include NoticeActions
 
-  scenario "non signed-in user cannot submit notices" do
-    visit "/notices/new?type=DMCA"
+  scenario 'non signed-in user cannot submit notices' do
+    visit '/notices/new?type=DMCA'
 
     expect(page).to have_content('Direct submission to Lumen is no longer available. If you are interested in sharing with Lumen copies of takedown notices you have sent or received, please contact Lumen.')
   end
 
-  scenario "submitting a notice with title" do
-    submit_recent_notice("A title")
+  scenario 'submitting a notice with title' do
+    submit_recent_notice('A title')
 
     expect(page).to have_css('#flash_notice')
 
-    expect(page).to have_css( '#recent-notices li', text: 'A title' )
+    expect(page).to have_css('#recent-notices li', text: 'A title')
   end
 
-  scenario "submitting a notice with language" do
+  scenario 'submitting a notice with language' do
     submit_recent_notice do
-      select "en - English", from: "Language"
+      select 'en - English', from: 'Language'
     end
 
     notice = Notice.last
     expect(notice.language).to eq 'en'
   end
 
-  scenario "submitting a notice with action taken" do
+  scenario 'submitting a notice with action taken' do
     submit_recent_notice do
-      select "Yes", from: "Action taken"
+      select 'Yes', from: 'Action taken'
     end
 
     open_recent_notice
 
-    expect(page).to have_content("Action taken: Yes")
+    expect(page).to have_content('Action taken: Yes')
   end
 
-  scenario "submitting a notice with a jurisdiction" do
+  scenario 'submitting a notice with a jurisdiction' do
     submit_recent_notice do
-      fill_in "Jurisdiction", with: 'US, foobar'
+      fill_in 'Jurisdiction', with: 'US, foobar'
     end
 
     notice = Notice.last
-    expect(notice.jurisdiction_list).to match_array ['US', 'foobar']
+    expect(notice.jurisdiction_list).to match_array %w[US foobar]
   end
 
-  scenario "submitting a notice with dates" do
+  scenario 'submitting a notice with dates' do
     submit_recent_notice do
-      fill_in "Date sent", with: Time.zone.local(2013, 5, 4)
-      fill_in "Date received", with: Time.zone.local(2013, 5, 5)
+      fill_in 'Date sent', with: Time.zone.local(2013, 5, 4)
+      fill_in 'Date received', with: Time.zone.local(2013, 5, 5)
     end
 
     open_recent_notice
 
     within('.recipient .date') do
-      expect(page).to have_content("May 05, 2013")
+      expect(page).to have_content('May 05, 2013')
     end
 
     within('.sender .date') do
-      expect(page).to have_content("May 04, 2013")
+      expect(page).to have_content('May 04, 2013')
     end
   end
 
-  scenario "submitting a notice with an original attached" do
+  scenario 'submitting a notice with an original attached' do
     submit_recent_notice { attach_notice }
 
     notice = Notice.last
     expect(notice).to have(1).original_document
   end
 
-  scenario "submitting a notice with a supporting document", js: true do
+  scenario 'submitting a notice with a supporting document', js: true do
     submit_recent_notice do
-      add_supporting_document("Some supporting content")
+      add_supporting_document('Some supporting content')
     end
 
     open_recent_notice
 
     within('ol.attachments') do
-      expect(page).to have_link("Supporting Document")
+      expect(page).to have_link('Supporting Document')
     end
   end
 
-  scenario "submitting a notice with multiple supporting documents", js: true do
+  scenario 'submitting a notice with multiple supporting documents', js: true do
     submit_recent_notice do
       add_supporting_document
       add_supporting_document
@@ -96,93 +96,93 @@ feature "notice submission" do
     end
   end
 
-  scenario "submitting a notice with tags" do
+  scenario 'submitting a notice with tags' do
     submit_recent_notice do
-      fill_in "Tag list", with: "tag_1, tag_2"
+      fill_in 'Tag list', with: 'tag_1, tag_2'
     end
 
     open_recent_notice
 
     within('#tags') do
-      expect(page).to have_content "tag_1"
+      expect(page).to have_content 'tag_1'
     end
   end
 
-  scenario "submitting a notice with topics" do
-    create(:topic, name: "Topic 1")
-    create(:topic, name: "Topic 2")
-    create(:topic, name: "Topic 3")
+  scenario 'submitting a notice with topics' do
+    create(:topic, name: 'Topic 1')
+    create(:topic, name: 'Topic 2')
+    create(:topic, name: 'Topic 3')
 
     submit_recent_notice do
-      select "Topic 1", from: "Topics"
-      select "Topic 3", from: "Topics"
+      select 'Topic 1', from: 'Topics'
+      select 'Topic 3', from: 'Topics'
     end
 
     open_recent_notice
 
     within('#topics') do
-      expect(page).to have_content "Topic 1"
-      expect(page).to have_content "Topic 3"
+      expect(page).to have_content 'Topic 1'
+      expect(page).to have_content 'Topic 3'
     end
   end
 
-  scenario "submitting a notice with entities" do
+  scenario 'submitting a notice with entities' do
     submit_recent_notice do
       within('section.recipient') do
-        fill_in "Name", with: "Recipient the first"
-        fill_in "Address Line 1", with: "Recipient Line 1"
-        fill_in "Address Line 2", with: "Recipient Line 2"
-        fill_in "City", with: "Recipient City"
-        fill_in "State", with: "MA"
-        select "United States", from: "Country"
+        fill_in 'Name', with: 'Recipient the first'
+        fill_in 'Address Line 1', with: 'Recipient Line 1'
+        fill_in 'Address Line 2', with: 'Recipient Line 2'
+        fill_in 'City', with: 'Recipient City'
+        fill_in 'State', with: 'MA'
+        select 'United States', from: 'Country'
       end
 
       within('section.sender') do
-        fill_in "Name", with: "Sender the first"
+        fill_in 'Name', with: 'Sender the first'
       end
     end
 
     open_recent_notice
 
     within('#entities') do
-      expect(page).to have_content "Recipient the first"
-      expect(page).to have_content "[Private]"
-      expect(page).to have_content "Recipient City"
-      expect(page).to have_content "MA"
-      expect(page).to have_content "US"
+      expect(page).to have_content 'Recipient the first'
+      expect(page).to have_content '[Private]'
+      expect(page).to have_content 'Recipient City'
+      expect(page).to have_content 'MA'
+      expect(page).to have_content 'US'
 
-      expect(page).to have_content "Sender the first"
+      expect(page).to have_content 'Sender the first'
     end
   end
 
-  scenario "entity addresses are partially private" do
+  scenario 'entity addresses are partially private' do
     submit_recent_notice do
       within('section.recipient') do
-        fill_in "Name", with: "Recipient the first"
-        fill_in "Address Line 1", with: "Recipient Line 1"
-        fill_in "Address Line 2", with: "Recipient Line 2"
-        select "organization", from: "Recipient Type"
+        fill_in 'Name', with: 'Recipient the first'
+        fill_in 'Address Line 1', with: 'Recipient Line 1'
+        fill_in 'Address Line 2', with: 'Recipient Line 2'
+        select 'organization', from: 'Recipient Type'
       end
 
       within('section.sender') do
-        fill_in "Name", with: "Sender the first"
-        fill_in "Address Line 1", with: "Sender Line 1"
-        fill_in "Address Line 2", with: "Sender Line 2"
+        fill_in 'Name', with: 'Sender the first'
+        fill_in 'Address Line 1', with: 'Sender Line 1'
+        fill_in 'Address Line 2', with: 'Sender Line 2'
       end
     end
 
     open_recent_notice
 
     within('#entities') do
-      expect(page).to have_no_content "Recipient Line 1"
-      expect(page).to have_no_content "Recipient Line 2"
-      expect(page).to have_no_content "Sender Line 1"
-      expect(page).to have_no_content "Sender Line 2"
-      expect(page).to have_no_content "organization"
+      expect(page).to have_no_content 'Recipient Line 1'
+      expect(page).to have_no_content 'Recipient Line 2'
+      expect(page).to have_no_content 'Sender Line 1'
+      expect(page).to have_no_content 'Sender Line 2'
+      expect(page).to have_no_content 'organization'
     end
   end
 
-  scenario "submitting notices with duplicate items" do
+  scenario 'submitting notices with duplicate items' do
     submit_recent_notice
     submit_recent_notice
 
@@ -192,11 +192,11 @@ feature "notice submission" do
     expect(InfringingUrl.count).to eq 1
   end
 
-  scenario "submitting a notice with works" do
+  scenario 'submitting a notice with works' do
     submit_recent_notice do
       fill_in 'Work URL', with: 'http://www.example.com/original_work.pdf'
       fill_in 'Description', with: 'A series of videos and still images'
-      fill_in 'Infringing URL', with: "http://example.com/infringing_url1"
+      fill_in 'Infringing URL', with: 'http://example.com/infringing_url1'
     end
 
     open_recent_notice
@@ -211,30 +211,30 @@ feature "notice submission" do
     end
   end
 
-  scenario "submitting a notice with a source" do
+  scenario 'submitting a notice with a source' do
     submit_recent_notice do
-      fill_in "Sent via", with: "Arbitrary source"
+      fill_in 'Sent via', with: 'Arbitrary source'
     end
 
     open_recent_notice
 
-    expect(page).to have_content "Sent via: Arbitrary source"
+    expect(page).to have_content 'Sent via: Arbitrary source'
   end
 
-  scenario "submitting a notice with a subject" do
+  scenario 'submitting a notice with a subject' do
     submit_recent_notice do
-      fill_in "Subject", with: "Some subject"
+      fill_in 'Subject', with: 'Some subject'
     end
 
     open_recent_notice
 
-    expect(page).to have_content "Re: Some subject"
+    expect(page).to have_content 'Re: Some subject'
   end
 
-  scenario "a form articulates its required fields correctly" do
-    sign_in( create(:user, :submitter) )
+  scenario 'a form articulates its required fields correctly' do
+    sign_in(create(:user, :submitter))
 
-    visit "/notices/new?type=DMCA"
+    visit '/notices/new?type=DMCA'
 
     within('form#new_notice') do
       expect(page).to have_css("input##{works_copyrighted_url_id}:not(.required)")
@@ -242,16 +242,24 @@ feature "notice submission" do
     end
   end
 
-  scenario "submitting a notice without required fields present" do
-    sign_in( create(:user, :submitter) )
+  scenario 'submitting a notice without required fields present' do
+    sign_in(create(:user, :submitter))
 
-    visit "/notices/new?type=DMCA"
+    visit '/notices/new?type=DMCA'
 
-    click_on "Submit"
+    click_on 'Submit'
 
     all("form .#{entity_name_class}").each do |elem|
       within(elem) { expect(page).to have_css('.error') }
     end
+  end
+
+  scenario 'government requests include submitter' do
+    sign_in(create(:user, :submitter))
+
+    visit '/notices/new?type=GovernmentRequest'
+
+    expect(page).to have_text('Submitter of the Notice')
   end
 
   private
@@ -263,5 +271,4 @@ feature "notice submission" do
   def entity_name_class
     'notice_entity_notice_roles_entity_name'
   end
-
 end


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Adds submitter field to Government Request notice type per client request. This is based on master so we can deploy it as a hotfix since the client is eager to see it.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Compare `/notices/new?type=GovernmentRequest` on localhost and prod. 

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15439

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- ~~[ ] Documentation~~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
