### PR TITLE
Suppress irritating find errors

### DIFF
--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -652,8 +652,8 @@ where works.id in (
     # clear out any files more than 20 minutes old;
     # remove empty directories.
     cmd = "cd #{__dir__}/../../tmp/cache && " \
-          'find . -type f -amin +20 -delete && ' \
-          'find . -type d -empty -delete'
+          'find . -type f -amin +20 -delete 2> /dev/null && ' \
+          'find . -type d -empty -delete 2> /dev/null'
     system(cmd)
   end
 end

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -650,10 +650,14 @@ where works.id in (
   task safer_cache_clear: :environment do
     # Go to cache dir;
     # clear out any files more than 20 minutes old;
-    # remove empty directories.
+    # remove empty directories;
+    # dump stderr to logfiles so it stops emailing us.
+    # (Everything in log/ should get autorotated on prod based on its logrotate
+    # configuration.)
     cmd = "cd #{__dir__}/../../tmp/cache && " \
-          'find . -type f -amin +20 -delete 2> /dev/null && ' \
-          'find . -type d -empty -delete 2> /dev/null'
+          "touch #{__dir__}/../../log/safer_cache_clear.log &&" \
+          "find . -type f -amin +20 -delete 2>> #{__dir__}/../../log/safer_cache_clear.log && " \
+          "find . -type d -empty -delete 2>> #{__dir__}/../../log/safer_cache_clear.log"
     system(cmd)
   end
 end


### PR DESCRIPTION
We're still getting email every 20 minutes when find has a time of
check/time of use problem with identifying vs deleting empty
directories. Let's just not bother hearing those errors.

This only affects the output of the find command; we'll still get
errors logged if the rake task itself encounters problems.

## Ready for merge?
**YES**

#### What does this PR do?
see commit message above

#### How can a reviewer manually see the effects of these changes?
20 minutes after it's deployed, you shouldn't have email from chill-prod.

#### What are the relevant tickets?
n/a

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
