### PR TITLE
14893 webform doc type

### DIFF
--- a/app/assets/javascripts/notices_new.js.coffee
+++ b/app/assets/javascripts/notices_new.js.coffee
@@ -1,5 +1,6 @@
 addFileUploadInput = (field, parent, updateContainer) ->
   containers = parent.find(".notice_file_uploads_#{field}")
+  console.log(containers.length)
 
   nextId = "notice_file_uploads_attributes_#{containers.length}_#{field}"
   nextName =  "notice[file_uploads_attributes][#{containers.length}][#{field}]"
@@ -9,7 +10,7 @@ addFileUploadInput = (field, parent, updateContainer) ->
 
   updateContainer(newContainer, nextId, nextName)
 
-  newContainer.insertAfter(container)
+  newContainer.appendTo($('#file_uploads_inputs'))
 
 $('.new_notice select').each ->
   $(this).select2
@@ -27,10 +28,11 @@ $('.attach #add-another').click ->
 
   addFileUploadInput 'file', parent, (newContainer, nextId, nextName) ->
     newContainer.find('input').attr('id', nextId).attr('name', nextName)
-    newContainer.find('label').attr('for', nextId).html('Other Documents')
+    newContainer.find('label').attr('for', nextId).html('Additional document')
 
   addFileUploadInput 'kind', parent, (newContainer, nextId, nextName) ->
-    newContainer.find('input').attr('id', nextId).attr('name', nextName).attr('value', 'supporting')
+    newContainer.find('select').attr('id', nextId).attr('name', nextName).attr('value', 'supporting')
+    newContainer.find('label').attr('for', nextId).html('Document type')
 
 $(document).on 'click', '.add-another-url', ->
   anchor = $(this)
@@ -62,5 +64,3 @@ toggleReportNoticePanels = ->
       $info.find("[data-id='#{id}']").addClass('active').siblings().removeClass('active')
 
 toggleReportNoticePanels()
-
-

--- a/app/assets/javascripts/notices_new.js.coffee
+++ b/app/assets/javascripts/notices_new.js.coffee
@@ -33,7 +33,7 @@ $('.attach #add-another').click ->
   parent = $(this).parent()
 
   addFileUploadInput 'file', parent, (newContainer, nextId, nextName) ->
-    newContainer.find('input').attr('id', nextId).attr('name', nextName)
+    newContainer.find('input').attr('id', nextId).attr('name', nextName).val('')
     newContainer.find('label').attr('for', nextId).html('Additional document')
 
   addFileUploadInput 'kind', parent, (newContainer, nextId, nextName) ->

--- a/app/assets/javascripts/notices_new.js.coffee
+++ b/app/assets/javascripts/notices_new.js.coffee
@@ -1,6 +1,7 @@
 addFileUploadInput = (field, parent, updateContainer) ->
   containers = parent.find(".notice_file_uploads_#{field}")
-  console.log(containers.length)
+
+  containers.find('select').select2('destroy')
 
   nextId = "notice_file_uploads_attributes_#{containers.length}_#{field}"
   nextName =  "notice[file_uploads_attributes][#{containers.length}][#{field}]"
@@ -11,6 +12,11 @@ addFileUploadInput = (field, parent, updateContainer) ->
   updateContainer(newContainer, nextId, nextName)
 
   newContainer.appendTo($('#file_uploads_inputs'))
+
+  $('#file_uploads_inputs').find('select').each ->
+    $(this).select2
+      placeholder: ''
+      width: 'off'
 
 $('.new_notice select').each ->
   $(this).select2
@@ -50,7 +56,6 @@ $(document).on 'click', '.remove-url', ->
   $(this).parent().remove()
   if $('#notice_url_count').length > 0
     $('#notice_url_count').val(section.find('.input.url').length)
-
 
 toggleReportNoticePanels = ->
   $list = $('.notices-list ul')

--- a/app/assets/stylesheets/notices/_forms.scss
+++ b/app/assets/stylesheets/notices/_forms.scss
@@ -25,6 +25,7 @@ section.notice-new {
     div.body-wrapper {
       float: left;
       width: 50%;
+      padding-right: 5%;
 
       @include media($mobile) {
         float: none;
@@ -89,6 +90,12 @@ form.new_notice, form.new_counter_notice {
     clear: left;
   }
 
+  // Increase margin below file kind dropdown so there is visual separation
+  // between each upload's pair of inputs.
+  div.input.notice_file_uploads_kind {
+    margin-bottom: 34px;
+  }
+
   span.radio{
     display: block;
   }
@@ -107,7 +114,6 @@ form.new_notice, form.new_counter_notice {
     top: 1px;
     width: $form-label-width;
     z-index: 1;
-
 
     &.boolean, &.collection_radio_buttons {
       width: auto;
@@ -136,6 +142,19 @@ form.new_notice, form.new_counter_notice {
       width: auto;
       border-radius: $form-border-radius $form-border-radius 0 0;
     }
+
+    // The 'state' and 'zip code' inputs are unreadably narrow unless we
+    // shrink the label.
+    &.half-width {
+      width: $form-label-width / 2;
+    }
+  }
+
+  .input.select label {
+    border: solid $form-border-color;
+    border-width: 1px;
+    box-shadow: inset 0 1px 0 hsla(0, 0%, 100%, 0.5);
+    border-radius: $form-border-radius 0 0 $form-border-radius;
   }
 
   .select2 {
@@ -146,7 +165,7 @@ form.new_notice, form.new_counter_notice {
 
   .select2-selection {
     border-radius: 0;
-    height: 32px;
+    height: 34px;
   }
 
   input {
@@ -164,6 +183,10 @@ form.new_notice, form.new_counter_notice {
       color: #999;
       font-weight: 300;
     }
+  }
+
+  input[type="file"] {
+    height: 34px;
   }
 
   #{$all-text-inputs} {

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -11,7 +11,7 @@ class NoticesController < ApplicationController
     model_class = get_notice_type(params)
     @notice = model_class.new
     build_entity_notice_roles(model_class)
-    @notice.file_uploads.build(kind: 'original')
+    @notice.file_uploads.build(kind: 'supporting')
     build_works(@notice)
   end
 
@@ -97,7 +97,7 @@ class NoticesController < ApplicationController
   end
 
   def notice_params
-    params.require(:notice).permit(
+    params.require(:notice).except(:type).permit(
       :title,
       :subject,
       :body,

--- a/app/controllers/original_files_controller.rb
+++ b/app/controllers/original_files_controller.rb
@@ -16,7 +16,8 @@ class OriginalFilesController < ApplicationController
 
   def path_params
     url_params = params[:file_path].split('/').reject { |x| x == '..' }
-    File.join([Rails.root, 'paperclip', 'file_uploads', 'files', url_params].flatten)
+    File.join([Rails.root, 'paperclip', 'file_uploads', 'files',
+               url_params].flatten)
   end
 
   def viewing_allowed?
@@ -28,6 +29,7 @@ class OriginalFilesController < ApplicationController
   end
 
   def params_match?
-    @upload && file_path && file_path == @upload.file.path && File.file?(file_path)
+    @upload && file_path && file_path ==
+      @upload.file.path && File.file?(file_path)
   end
 end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -10,7 +10,7 @@ class Entity < ActiveRecord::Base
   include Elasticsearch::Model
 
   PER_PAGE = 10
-  HIGHLIGHTS = %i(name)
+  HIGHLIGHTS = %i[name].freeze
 
   validates :address_line_1, length: { maximum: 255 }
 
@@ -21,16 +21,21 @@ class Entity < ActiveRecord::Base
   delegate :publication_delay, to: :user, allow_nil: true
 
   mappings do
-    Entity.columns.map(&:name).reject{|name| name == 'id'}.each do |column_name|
+    Entity.columns
+          .map(&:name)
+          .reject { |name| name == 'id' }
+          .each do |column_name|
       indexes column_name
     end
 
     indexes :parent_id
   end
 
-  index_name [Rails.application.engine_name, Rails.env, self.name.demodulize.downcase].join('_')
+  index_name [Rails.application.engine_name,
+              Rails.env,
+              self.name.demodulize.downcase].join('_')
 
-  def as_indexed_json(options)
+  def as_indexed_json(_options)
     out = as_json
 
     out[:class_name] = 'entity'
@@ -38,22 +43,22 @@ class Entity < ActiveRecord::Base
     out
   end
 
-  KINDS = %w[organization individual]
+  KINDS = %w[organization individual].freeze
   ADDITIONAL_DEDUPLICATION_FIELDS =
-    %i(address_line_1 city state zip country_code phone email)
+    %i[address_line_1 city state zip country_code phone email].freeze
 
   validates_inclusion_of :kind, in: KINDS
   validates_uniqueness_of :name,
-    scope: ADDITIONAL_DEDUPLICATION_FIELDS
+                          scope: ADDITIONAL_DEDUPLICATION_FIELDS
 
-  after_update { EntityIndexQueuer.for(self.id) }
+  after_update { EntityIndexQueuer.for(id) }
 
   def attributes_for_deduplication
     all_deduplication_attributes = [
       :name, ADDITIONAL_DEDUPLICATION_FIELDS
     ].flatten
 
-    attributes.select do |key, value|
+    attributes.select do |key, _value|
       all_deduplication_attributes.include?(key.to_sym)
     end
   end

--- a/app/models/file_upload.rb
+++ b/app/models/file_upload.rb
@@ -5,9 +5,6 @@ class FileUpload < ActiveRecord::Base
 
   attr_accessor :file_name
 
-  # attr_protected :id, :pdf_requested, :pdf_request_fulfilled
-  # attr_protected :id, as: :admin
-
   validates_inclusion_of :kind, in: %w[original supporting]
   validates :kind, length: { maximum: 255 }
 

--- a/app/models/file_upload.rb
+++ b/app/models/file_upload.rb
@@ -5,7 +5,9 @@ class FileUpload < ActiveRecord::Base
 
   attr_accessor :file_name
 
-  validates_inclusion_of :kind, in: %w[original supporting]
+  ALLOWED_KINDS = %w[original supporting].freeze
+
+  validates_inclusion_of :kind, in: ALLOWED_KINDS
   validates :kind, length: { maximum: 255 }
 
   belongs_to :notice

--- a/app/views/notices/_counternotice_form.html.erb
+++ b/app/views/notices/_counternotice_form.html.erb
@@ -9,58 +9,19 @@
     <p><%= raw( t( 'views.counternotice_form.step1_info' ) ) %></p>
     <p><b><%= t( 'views.counternotice_form.reason_h' ) %></b></p>
     <div class="body-wrapper main">
-      <%= form.input :body, 
+      <%= form.input :body,
         collection: Counternotice::REASONS.map { |r| t( "views.counternotice_form.reasons.#{r}" ) },
         label: t( 'views.counternotice_form.body_label' ),
         required: true
       %>
       <%= form.input :counternotice_for_id, as: :integer, placeholder: 'Lumen DMCA Notice ID (if available)' %>
     </div>
-    <div class="body-wrapper left main">
-      <%= form.input :type, as: :hidden %>
-      <%=
-        form.input :title, label_html: { data: {
-          tooltip: "If the notice you sent/received had a subject line, enter it here"
-        }}
-      %>
-      <%= form.hidden_field :webform, :value => true %>
-      <%= form.input :subject %>
-      <%= form.input :date_sent, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :date_received, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :source, label: "Sent via", placeholder: 'Online form, Email, Postal mail, etc.' %>
-      <%= form.input :tag_list, placeholder: 'movie, youtube, video, etc.' %>
-      <%=
-        form.input :topic_ids,
-          label: "Topics",
-          prompt: nil,
-          collection: available_topics,
-          input_html: { multiple: true }
-        %>
-      <%= form.input :language, collection: Language.all, label_method: :label, value_method: :code %>
-      <%= form.input :jurisdiction_list, label: "Jurisdiction", placeholder: 'a list of countries - US, CA, etc.' %>
-      <%#=
-        form.input :action_taken,
-          collection: Notice::VALID_ACTIONS,
-          label_html: { data: {
-            tooltip: "Did the recipient of the notice take action in response?"
-          }}
-        %>
-    </div>
-    <div class="body-wrapper right attach">
-      <%#= form.input :body %>
-      <%#= form.input :body, 
-        collection: Counternotice::REASONS,
-        html: { class: 'text' },
-        label: t( 'views.counternotice_form.body_label' ),
-        label_html: { class: 'text' }
-      %>
-
-      <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
-        <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="javascript:void(0);" id="add-another">Attach another</a>
-        <%= file_uploads_form.input :kind, as: :hidden %>
-      <% end %>
-    </div>
+    <%= render 'notices/form_components/main_metadata',
+               action_taken: false,
+               form: form %>
+    <%= render 'notices/form_components/additional_metadata',
+               body: false,
+               form: form %>
   </section>
 
   <section class="works">
@@ -86,36 +47,6 @@
     <% end %>
   </section>
 
-  <% step_number = 3 %>
-  <%= form.simple_fields_for(:entity_notice_roles) do |roles_form| %>
-    <% role = roles_form.object.name.titleize %>
-    <section class="role <%= role.downcase %>">
-      <h4><span>Step <%= step_number %>.</span> <%= role %> of the Notice</h4>
-      <p>Enter information about the <b><%= role %></b> of the DMCA counternotice.</p>
-      <%= roles_form.input :name, as: :hidden %>
-      <%= roles_form.simple_fields_for(:entity) do |entity_form| %>
-        <div class="body-wrapper left required">
-          <%= entity_form.input :name, label: "Name" %>
-          <%= entity_form.input :kind,
-            label: "#{role} Type", prompt: nil, collection: Entity::KINDS %>
-        </div>
-        <div class="body-wrapper right optional">
-          <%= entity_form.input :address_line_1, label: "Address Line 1" %>
-          <%= entity_form.input :address_line_2, label: "Address Line 2" %>
-          <%= entity_form.input :city, label: "City" %>
-          <%= entity_form.input :state, label: "State", maxlength: "2" %>
-          <%= entity_form.input :zip, label: "Zip Code" %>
-          <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
-          <%= entity_form.input :phone, label: "Phone" %>
-          <%= entity_form.input :email, label: "Email" %>
-          <%= entity_form.input :url, label: "#{role} URL" %>
-        </div>
-      <% end %>
-    </section>
-    <% step_number += 1 %>
-  <% end %>
-
-  <div class="buttons-wrapper">
-    <%= form.submit "Submit Notice", :class => "submit" %>
-  </div>
+  <%= render 'notices/form_components/roles', form: form %>
+  <%= render 'notices/form_components/submit', form: form %>
 <% end %>

--- a/app/views/notices/_court_order_form.html.erb
+++ b/app/views/notices/_court_order_form.html.erb
@@ -1,50 +1,14 @@
-<header>
-  <h3 class="title">Report a Court Order Takedown Notice</h3>
-  <p>If you have sent or received a Court Order and want to submit it to our database, fill out the form below.</p>
-  <p class="disclaimer">Please do not include phone numbers, email addresses, personal name, or other private information other than those of the complainant.</p>
-</header>
+<%= render 'notices/form_components/header',
+           label: 'Court Order takedown notice' %>
 <%= simple_form_for(notice) do |form| %>
   <section class="notice-body">
     <h4><span>Step 1.</span> Describe the Notice</h4>
     <p>Provide us with information about the Court Order you <em>sent</em> or <em>received</em>.</p>
-    <div class="body-wrapper left main">
-      <%= form.input :type, as: :hidden %>
-      <%=
-        form.input :title, label_html: { data: {
-          tooltip: "If the notice you sent/received had a subject line, enter it here"
-        }}
-      %>
-      <%= form.hidden_field :webform, :value => true %>
-      <%= form.input :subject %>
-      <%= form.input :date_sent, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :date_received, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :source, label: "Sent via", placeholder: 'Online form, Email, Postal mail, etc.' %>
-      <%= form.input :tag_list, placeholder: 'movie, youtube, video, etc.' %>
-      <%=
-        form.input :topic_ids,
-          label: "Topics",
-          prompt: nil,
-          collection: available_topics,
-          input_html: { multiple: true }
-        %>
-      <%= form.input :language, collection: Language.all, label_method: :label, value_method: :code %>
-      <%= form.input :jurisdiction_list, label: "Jurisdiction", placeholder: 'a list of countries - US, CA, etc.' %>
-      <%=
-        form.input :action_taken,
-          collection: Notice::VALID_ACTIONS,
-          label_html: { data: {
-            tooltip: "Did the recipient of the notice take action in response?"
-          }}
-        %>
-    </div>
-    <div class="body-wrapper right attach">
-      <%= form.input :body, label: "Explanation of Court Order" %>
-      <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
-        <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="javascript:void(0);" id="add-another">Attach another</a>
-        <%= file_uploads_form.input :kind, as: :hidden %>
-      <% end %>
-    </div>
+    <%= render 'notices/form_components/main_metadata',
+               form: form %>
+    <%= render 'notices/form_components/additional_metadata',
+               label: 'Explanation of Court Order',
+               form: form %>
   </section>
 
   <section class="works">
@@ -66,37 +30,6 @@
     <%= form.input :regulation_list, label: 'Laws Referenced by Court Order', placeholder: 'A comma separated list' %>
   </section>
 
-  <% step_number = 3 %>
-  <%= form.simple_fields_for(:entity_notice_roles) do |roles_form| %>
-    <% role = roles_form.object.name.titleize %>
-    <% role_class = roles_form.object.name.tableize.singularize %>
-    <section class="role <%= role_class.downcase %>">
-      <h4><span>Step <%= step_number %>.</span> <%= role %> of the Notice</h4>
-      <p>Enter information about the <b><%= role %></b> of the Court Order.</p>
-      <%= roles_form.input :name, as: :hidden %>
-      <%= roles_form.simple_fields_for(:entity) do |entity_form| %>
-        <div class="body-wrapper left required">
-          <%= entity_form.input :name, label: "Name" %>
-          <%= entity_form.input :kind,
-            label: "#{role} Type", prompt: nil, collection: Entity::KINDS %>
-        </div>
-        <div class="body-wrapper right optional">
-          <%= entity_form.input :address_line_1, label: "Address Line 1" %>
-          <%= entity_form.input :address_line_2, label: "Address Line 2" %>
-          <%= entity_form.input :city, label: "City" %>
-          <%= entity_form.input :state, label: "State", maxlength: "2" %>
-          <%= entity_form.input :zip, label: "Zip Code" %>
-          <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
-          <%= entity_form.input :phone, label: "Phone" %>
-          <%= entity_form.input :email, label: "Email" %>
-          <%= entity_form.input :url, label: "#{role} URL" %>
-        </div>
-      <% end %>
-    </section>
-    <% step_number += 1 %>
-  <% end %>
-
-  <div class="buttons-wrapper">
-    <%= form.submit "Submit Notice", :class => "submit" %>
-  </div>
+  <%= render 'notices/form_components/roles', form: form %>
+  <%= render 'notices/form_components/submit', form: form %>
 <% end %>

--- a/app/views/notices/_data_protection_form.html.erb
+++ b/app/views/notices/_data_protection_form.html.erb
@@ -1,41 +1,15 @@
-<header>
-  <h3 class="title">Report a Data Protection Takedown Notice</h3>
-  <p>If you have sent or received a Data Protection takedown notice and want to submit it to our database, fill out the form below.</p>
-  <p class="disclaimer">Please do not include phone numbers, email addresses, personal name, or other private information other than those of the complainant.</p>
-</header>
+<%= render 'notices/form_components/header',
+           label: 'Data Protection takedown notice' %>
 <%= simple_form_for(notice) do |form| %>
   <section class="notice-body">
     <h4><span>Step 1.</span> Describe the Notice</h4>
     <p>Provide us with information about the Data Protection takedown notice you <em>sent</em> or <em>received</em>.</p>
-    <div class="body-wrapper left main">
-      <%= form.input :type, as: :hidden %>
-      <%=
-        form.input :title, label_html: { data: {
-          tooltip: "If the notice you sent/received had a subject line, enter it here"
-        }}
-      %>
-      <%= form.hidden_field :webform, :value => true %>
-      <%= form.input :date_sent, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :date_received, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :source, label: "Sent via", placeholder: 'Online form, Email, Postal mail, etc.' %>
-      <%= form.input :language, collection: Language.all, label_method: :label, value_method: :code %>
-      <%= form.input :jurisdiction_list, label: "Jurisdiction", placeholder: 'a list of countries - US, CA, etc.' %>
-      <%=
-        form.input :action_taken,
-          collection: Notice::VALID_ACTIONS,
-          label_html: { data: {
-            tooltip: "Did the recipient of the notice take action in response?"
-          }}
-        %>
-    </div>
-    <div class="body-wrapper right attach">
-      <%= form.input :body, label: 'Legal Complaint' %>
-      <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
-        <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="javascript:void(0);" id="add-another">Attach another</a>
-        <%= file_uploads_form.input :kind, as: :hidden %>
-      <% end %>
-    </div>
+    <%= render 'notices/form_components/main_metadata',
+               subject: false, topics: false, tag_list: false,
+               form: form %>
+    <%= render 'notices/form_components/additional_metadata',
+               label: 'Legal Complaint',
+               form: form %>
   </section>
 
   <section class="works">
@@ -48,7 +22,7 @@
             locals: { notice: notice, assoc: :infringing_urls, works_form: works_form, index: index }
           ) %>
         </div>
-      <% end %> 
+      <% end %>
     <% end %>
     <div class="body-wrapper left">
       <%= form.input :url_count, label: "Number of URLs", label_html: { class: 'url', data: {
@@ -56,36 +30,8 @@
     </div>
   </section>
 
-  <% step_number = 3 %>
-  <%= form.simple_fields_for(:entity_notice_roles) do |roles_form| %>
-    <% role = roles_form.object.name.titleize %>
-    <section class="role <%= role.downcase %>">
-      <h4><span>Step <%= step_number %>.</span> <%= role %> of the Notice</h4>
-      <p>Enter information about the <b><%= role %></b> of the Data Protection takedown notice.</p>
-      <%= roles_form.input :name, as: :hidden %>
-      <%= roles_form.simple_fields_for(:entity) do |entity_form| %>
-        <div class="body-wrapper left required">
-          <%= entity_form.input :name, label: "Name" %>
-          <%= entity_form.input :kind,
-            label: "#{role} Type", prompt: nil, collection: Entity::KINDS %>
-        </div>
-        <div class="body-wrapper right optional">
-          <%= entity_form.input :address_line_1, label: "Address Line 1" %>
-          <%= entity_form.input :address_line_2, label: "Address Line 2" %>
-          <%= entity_form.input :city, label: "City" %>
-          <%= entity_form.input :state, label: "State", maxlength: "2" %>
-          <%= entity_form.input :zip, label: "Zip Code" %>
-          <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
-          <%= entity_form.input :phone, label: "Phone" %>
-          <%= entity_form.input :email, label: "Email" %>
-          <%= entity_form.input :url, label: "#{role} URL" %>
-        </div>
-      <% end %>
-    </section>
-    <% step_number += 1 %>
-  <% end %>
-
-  <div class="buttons-wrapper">
-    <%= form.submit "Submit Notice", :class => "submit" %>
-  </div>
+  <%= render 'notices/form_components/roles',
+             label: 'Data Protection takedown notice',
+             form: form %>
+  <%= render 'notices/form_components/submit', form: form %>
 <% end %>

--- a/app/views/notices/_defamation_form.html.erb
+++ b/app/views/notices/_defamation_form.html.erb
@@ -1,50 +1,13 @@
-<header>
-  <h3 class="title">Report a Defamation Takedown Notice</h3>
-  <p>If you have sent or received a Defamation takedown notice and want to submit it to our database, fill out the form below.</p>
-  <p class="disclaimer">Please do not include phone numbers, email addresses, personal name, or other private information other than those of the complainant.</p>
-</header>
+<%= render 'notices/form_components/header',
+           label: 'Defamation takedown notice' %>
 <%= simple_form_for(notice) do |form| %>
   <section class="notice-body">
     <h4><span>Step 1.</span> Describe the Notice</h4>
     <p>Provide us with information about the Defamation takedown notice you <em>sent</em> or <em>received</em>.</p>
-    <div class="body-wrapper left main">
-      <%= form.input :type, as: :hidden %>
-      <%=
-        form.input :title, label_html: { data: {
-          tooltip: "If the notice you sent/received had a subject line, enter it here"
-        }}
-      %>
-      <%= form.hidden_field :webform, :value => true %>
-      <%= form.input :subject %>
-      <%= form.input :date_sent, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :date_received, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :source, label: "Sent via", placeholder: 'Online form, Email, Postal mail, etc.' %>
-      <%= form.input :tag_list, placeholder: 'movie, youtube, video, etc.' %>
-      <%=
-        form.input :topic_ids,
-          label: "Topics",
-          prompt: nil,
-          collection: available_topics,
-          input_html: { multiple: true }
-        %>
-      <%= form.input :language, collection: Language.all, label_method: :label, value_method: :code %>
-      <%= form.input :jurisdiction_list, label: "Jurisdiction", placeholder: 'a list of countries - US, CA, etc.' %>
-      <%=
-        form.input :action_taken,
-          collection: Notice::VALID_ACTIONS,
-          label_html: { data: {
-            tooltip: "Did the recipient of the notice take action in response?"
-          }}
-        %>
-    </div>
-    <div class="body-wrapper right attach">
-      <%= form.input :body, label: 'Legal Complaint' %>
-      <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
-        <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="javascript:void(0);" id="add-another">Attach another</a>
-        <%= file_uploads_form.input :kind, as: :hidden %>
-      <% end %>
-    </div>
+    <%= render 'notices/form_components/main_metadata', form: form %>
+    <%= render 'notices/form_components/additional_metadata',
+               label: 'Legal Complaint',
+               form: form %>
   </section>
 
   <section class="works">
@@ -62,36 +25,8 @@
     <% end %>
   </section>
 
-  <% step_number = 3 %>
-  <%= form.simple_fields_for(:entity_notice_roles) do |roles_form| %>
-    <% role = roles_form.object.name.titleize %>
-    <section class="role <%= role.downcase %>">
-      <h4><span>Step <%= step_number %>.</span> <%= role %> of the Notice</h4>
-      <p>Enter information about the <b><%= role %></b> of the Defamation takedown notice.</p>
-      <%= roles_form.input :name, as: :hidden %>
-      <%= roles_form.simple_fields_for(:entity) do |entity_form| %>
-        <div class="body-wrapper left required">
-          <%= entity_form.input :name, label: "Name" %>
-          <%= entity_form.input :kind,
-            label: "#{role} Type", prompt: nil, collection: Entity::KINDS %>
-        </div>
-        <div class="body-wrapper right optional">
-          <%= entity_form.input :address_line_1, label: "Address Line 1" %>
-          <%= entity_form.input :address_line_2, label: "Address Line 2" %>
-          <%= entity_form.input :city, label: "City" %>
-          <%= entity_form.input :state, label: "State", maxlength: "2" %>
-          <%= entity_form.input :zip, label: "Zip Code" %>
-          <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
-          <%= entity_form.input :phone, label: "Phone" %>
-          <%= entity_form.input :email, label: "Email" %>
-          <%= entity_form.input :url, label: "#{role} URL" %>
-        </div>
-      <% end %>
-    </section>
-    <% step_number += 1 %>
-  <% end %>
-
-  <div class="buttons-wrapper">
-    <%= form.submit "Submit Notice", :class => "submit" %>
-  </div>
+  <%= render 'notices/form_components/roles',
+             label: 'Defamation takedown notice',
+             form: form %>
+  <%= render 'notices/form_components/submit', form: form %>
 <% end %>

--- a/app/views/notices/_dmca_form.html.erb
+++ b/app/views/notices/_dmca_form.html.erb
@@ -1,50 +1,12 @@
-<header>
-  <h3 class="title">Report a DMCA Takedown Notice</h3>
-  <p>If you have sent or received a DMCA takedown notice and want to submit it to our database, fill out the form below.</p>
-  <p class="disclaimer">Please do not include phone numbers, email addresses, personal name, or other private information other than those of the complainant.</p>
-</header>
+<%= render 'notices/form_components/header',
+           label: 'DMCA takedown notice' %>
 <%= simple_form_for(notice) do |form| %>
   <section class="notice-body">
     <h4><span>Step 1.</span> Describe the Notice</h4>
     <p>Provide us with information about the DMCA takedown notice you <em>sent</em> or <em>received</em>.</p>
-    <div class="body-wrapper left main">
-      <%= form.input :type, as: :hidden %>
-      <%=
-        form.input :title, label_html: { data: {
-          tooltip: "If the notice you sent/received had a subject line, enter it here"
-        }}
-      %>
-      <%= form.hidden_field :webform, :value => true %>
-      <%= form.input :subject %>
-      <%= form.input :date_sent, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :date_received, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :source, label: "Sent via", placeholder: 'Online form, Email, Postal mail, etc.' %>
-      <%= form.input :tag_list, placeholder: 'movie, youtube, video, etc.' %>
-      <%=
-        form.input :topic_ids,
-          label: "Topics",
-          prompt: nil,
-          collection: available_topics,
-          input_html: { multiple: true }
-        %>
-      <%= form.input :language, collection: Language.all, label_method: :label, value_method: :code %>
-      <%= form.input :jurisdiction_list, label: "Jurisdiction", placeholder: 'a list of countries - US, CA, etc.' %>
-      <%=
-        form.input :action_taken,
-          collection: Notice::VALID_ACTIONS,
-          label_html: { data: {
-            tooltip: "Did the recipient of the notice take action in response?"
-          }}
-        %>
-    </div>
-    <div class="body-wrapper right attach">
-      <%= form.input :body %>
-      <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
-        <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="javascript:void(0);" id="add-another">Attach another</a>
-        <%= file_uploads_form.input :kind, as: :hidden %>
-      <% end %>
-    </div>
+    <%= render 'notices/form_components/main_metadata', form: form %>
+    <%= render 'notices/form_components/additional_metadata',
+               form: form %>
   </section>
 
   <section class="works">
@@ -69,36 +31,8 @@
     <% end %>
   </section>
 
-  <% step_number = 3 %>
-  <%= form.simple_fields_for(:entity_notice_roles) do |roles_form| %>
-    <% role = roles_form.object.name.titleize %>
-    <section class="role <%= role.downcase %>">
-      <h4><span>Step <%= step_number %>.</span> <%= role %> of the Notice</h4>
-      <p>Enter information about the <b><%= role %></b> of the DMCA takedown notice.</p>
-      <%= roles_form.input :name, as: :hidden %>
-      <%= roles_form.simple_fields_for(:entity) do |entity_form| %>
-        <div class="body-wrapper left required">
-          <%= entity_form.input :name, label: "Name" %>
-          <%= entity_form.input :kind,
-            label: "#{role} Type", prompt: nil, collection: Entity::KINDS %>
-        </div>
-        <div class="body-wrapper right optional">
-          <%= entity_form.input :address_line_1, label: "Address Line 1" %>
-          <%= entity_form.input :address_line_2, label: "Address Line 2" %>
-          <%= entity_form.input :city, label: "City" %>
-          <%= entity_form.input :state, label: "State", maxlength: "2" %>
-          <%= entity_form.input :zip, label: "Zip Code" %>
-          <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
-          <%= entity_form.input :phone, label: "Phone" %>
-          <%= entity_form.input :email, label: "Email" %>
-          <%= entity_form.input :url, label: "#{role} URL" %>
-        </div>
-      <% end %>
-    </section>
-    <% step_number += 1 %>
-  <% end %>
-
-  <div class="buttons-wrapper">
-    <%= form.submit "Submit Notice", :class => "submit" %>
-  </div>
+  <%= render 'notices/form_components/roles',
+             label: 'DMCA takedown notice',
+             form: form %>
+  <%= render 'notices/form_components/submit', form: form %>
 <% end %>

--- a/app/views/notices/_government_request_form.html.erb
+++ b/app/views/notices/_government_request_form.html.erb
@@ -1,51 +1,13 @@
-<header>
-  <h3 class="title">Report a Government Request</h3>
-  <p>If you have sent or received a Government Request and want to submit it to our database, fill out the form below.</p>
-  <p class="disclaimer">Please do not include phone numbers, email addresses, personal name, or other private information other than those of the complainant.</p>
-</header>
+<%= render 'notices/form_components/header' %>
 <%= simple_form_for(notice) do |form| %>
   <section class="notice-body">
     <h4><span>Step 1.</span> Describe the Notice</h4>
     <p>Provide us with information about the Government Request you <em>sent</em> or <em>received</em>.</p>
-    <div class="body-wrapper left main">
-      <%= form.input :type, as: :hidden %>
-      <%=
-        form.input :title, label_html: { data: {
-          tooltip: "If the notice you sent/received had a subject line, enter it here"
-        }}
-      %>
-      <%= form.hidden_field :webform, :value => true %>
-      <%= form.input :subject %>
-      <%= form.input :date_sent, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :date_received, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :source, label: "Sent via", placeholder: 'Online form, Email, Postal mail, etc.' %>
-      <%= form.input :tag_list, placeholder: 'movie, youtube, video, etc.' %>
-      <%=
-        form.input :topic_ids,
-          label: "Topics",
-          prompt: nil,
-          collection: available_topics,
-          input_html: { multiple: true }
-        %>
-      <%= form.input :language, collection: Language.all, label_method: :label, value_method: :code %>
-      <%= form.input :jurisdiction_list, label: "Jurisdiction", placeholder: 'a list of countries - US, CA, etc.' %>
-      <%=
-        form.input :action_taken,
-          collection: Notice::VALID_ACTIONS,
-          label_html: { data: {
-            tooltip: "Did the recipient of the notice take action in response?"
-          }}
-        %>
-    </div>
-    <div class="body-wrapper right attach">
-      <%= form.input :body, label: "Explanation of Government Request" %>
-      <%= form.input :request_type, collection: GovernmentRequest::VALID_REQUEST_TYPES %>
-      <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
-        <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="javascript:void(0);" id="add-another">Attach another</a>
-        <%= file_uploads_form.input :kind, as: :hidden %>
-      <% end %>
-    </div>
+    <%= render 'notices/form_components/main_metadata', form: form %>
+    <%= render 'notices/form_components/additional_metadata',
+               label: 'Explanation of Government Request',
+               request_collection: GovernmentRequest::VALID_REQUEST_TYPES,
+               form: form %>
   </section>
 
   <section class="works">
@@ -68,36 +30,6 @@
     <%= form.input :regulation_list, label: 'Relevant laws or regulations', placeholder: 'A comma separated list' %>
   </section>
 
-  <% step_number = 3 %>
-  <%= form.simple_fields_for(:entity_notice_roles) do |roles_form| %>
-    <% role = roles_form.object.name.titleize %>
-    <section class="role <%= role.downcase %>">
-      <h4><span>Step <%= step_number %>.</span> <%= role %> of the Notice</h4>
-      <p>Enter information about the <b><%= role %></b> of the Government Request.</p>
-      <%= roles_form.input :name, as: :hidden %>
-      <%= roles_form.simple_fields_for(:entity) do |entity_form| %>
-        <div class="body-wrapper left required">
-          <%= entity_form.input :name, label: "Name" %>
-          <%= entity_form.input :kind,
-            label: "#{role} Type", prompt: nil, collection: Entity::KINDS %>
-        </div>
-        <div class="body-wrapper right optional">
-          <%= entity_form.input :address_line_1, label: "Address Line 1" %>
-          <%= entity_form.input :address_line_2, label: "Address Line 2" %>
-          <%= entity_form.input :city, label: "City" %>
-          <%= entity_form.input :state, label: "State", maxlength: "2" %>
-          <%= entity_form.input :zip, label: "Zip Code" %>
-          <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
-          <%= entity_form.input :phone, label: "Phone" %>
-          <%= entity_form.input :email, label: "Email" %>
-          <%= entity_form.input :url, label: "#{role} URL" %>
-        </div>
-      <% end %>
-    </section>
-    <% step_number += 1 %>
-  <% end %>
-
-  <div class="buttons-wrapper">
-    <%= form.submit "Submit Notice", :class => "submit" %>
-  </div>
+  <%= render 'notices/form_components/roles', form: form %>
+  <%= render 'notices/form_components/submit', form: form %>
 <% end %>

--- a/app/views/notices/_law_enforcement_request_form.html.erb
+++ b/app/views/notices/_law_enforcement_request_form.html.erb
@@ -1,51 +1,13 @@
-<header>
-  <h3 class="title">Report a Law Enforcement Request</h3>
-  <p>If you have sent or received a Law Enforcement Request and want to submit it to our database, fill out the form below.</p>
-  <p class="disclaimer">Please do not include phone numbers, email addresses, personal name, or other private information other than those of the complainant.</p>
-</header>
+<%= render 'notices/form_components/header' %>
 <%= simple_form_for(notice) do |form| %>
   <section class="notice-body">
     <h4><span>Step 1.</span> Describe the Notice</h4>
     <p>Provide us with information about the Law Enforcement Request you <em>sent</em> or <em>received</em>.</p>
-    <div class="body-wrapper left main">
-      <%= form.input :type, as: :hidden %>
-      <%=
-        form.input :title, label_html: { data: {
-          tooltip: "If the notice you sent/received had a subject line, enter it here"
-        }}
-      %>
-      <%= form.hidden_field :webform, :value => true %>
-      <%= form.input :subject %>
-      <%= form.input :date_sent, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :date_received, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :source, label: "Sent via", placeholder: 'Online form, Email, Postal mail, etc.' %>
-      <%= form.input :tag_list, placeholder: 'movie, youtube, video, etc.' %>
-      <%=
-        form.input :topic_ids,
-          label: "Topics",
-          prompt: nil,
-          collection: available_topics,
-          input_html: { multiple: true }
-        %>
-      <%= form.input :language, collection: Language.all, label_method: :label, value_method: :code %>
-      <%= form.input :jurisdiction_list, label: "Jurisdiction", placeholder: 'a list of countries - US, CA, etc.' %>
-      <%=
-        form.input :action_taken,
-          collection: Notice::VALID_ACTIONS,
-          label_html: { data: {
-            tooltip: "Did the recipient of the notice take action in response?"
-          }}
-        %>
-    </div>
-    <div class="body-wrapper right attach">
-      <%= form.input :body, label: "Explanation of Law Enforcement Request" %>
-      <%= form.input :request_type, collection: LawEnforcementRequest::VALID_REQUEST_TYPES %>
-      <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
-        <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="javascript:void(0);" id="add-another">Attach another</a>
-        <%= file_uploads_form.input :kind, as: :hidden %>
-      <% end %>
-    </div>
+    <%= render 'notices/form_components/main_metadata', form: form %>
+    <%= render 'notices/form_components/additional_metadata',
+               label: 'Explanation of Law Enforcement Request',
+               request_collection: LawEnforcementRequest::VALID_REQUEST_TYPES,
+               form: form %>
   </section>
 
   <section class="works">
@@ -70,36 +32,7 @@
     <%= form.input :regulation_list, label: 'Relevant laws or regulations', placeholder: 'A comma separated list' %>
   </section>
 
-  <% step_number = 3 %>
-  <%= form.simple_fields_for(:entity_notice_roles) do |roles_form| %>
-    <% role = roles_form.object.name.titleize %>
-    <section class="role <%= role.downcase %>">
-      <h4><span>Step <%= step_number %>.</span> <%= role %> of the Notice</h4>
-      <p>Enter information about the <b><%= role %></b> of the Law Enforcement Request.</p>
-      <%= roles_form.input :name, as: :hidden %>
-      <%= roles_form.simple_fields_for(:entity) do |entity_form| %>
-        <div class="body-wrapper left required">
-          <%= entity_form.input :name, label: "Name" %>
-          <%= entity_form.input :kind,
-            label: "#{role} Type", prompt: nil, collection: Entity::KINDS %>
-        </div>
-        <div class="body-wrapper right optional">
-          <%= entity_form.input :address_line_1, label: "Address Line 1" %>
-          <%= entity_form.input :address_line_2, label: "Address Line 2" %>
-          <%= entity_form.input :city, label: "City" %>
-          <%= entity_form.input :state, label: "State", maxlength: "2" %>
-          <%= entity_form.input :zip, label: "Zip Code" %>
-          <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
-          <%= entity_form.input :phone, label: "Phone" %>
-          <%= entity_form.input :email, label: "Email" %>
-          <%= entity_form.input :url, label: "#{role} URL" %>
-        </div>
-      <% end %>
-    </section>
-    <% step_number += 1 %>
-  <% end %>
-
-  <div class="buttons-wrapper">
-    <%= form.submit "Submit Notice", :class => "submit" %>
-  </div>
+  <%= render 'notices/form_components/roles',
+             form: form %>
+  <%= render 'notices/form_components/submit', form: form %>
 <% end %>

--- a/app/views/notices/_other_form.html.erb
+++ b/app/views/notices/_other_form.html.erb
@@ -1,50 +1,13 @@
-<header>
-  <h3 class="title">Report a Notice</h3>
-  <p>If you have sent or received a notice and want to submit it to our database, fill out the form below.</p>
-  <p class="disclaimer">Please do not include phone numbers, email addresses, personal name, or other private information other than those of the complainant.</p>
-</header>
+<%= render 'notices/form_components/header',
+           label: 'notice' %>
 <%= simple_form_for(notice) do |form| %>
   <section class="notice-body">
     <h4><span>Step 1.</span> Describe the Notice</h4>
     <p>Provide us with information about the notice you <em>sent</em> or <em>received</em>.</p>
-    <div class="body-wrapper left main">
-      <%= form.input :type, as: :hidden %>
-      <%=
-        form.input :title, label_html: { data: {
-          tooltip: "If the notice you sent/received had a subject line, enter it here"
-        }}
-      %>
-      <%= form.hidden_field :webform, :value => true %>
-      <%= form.input :subject %>
-      <%= form.input :date_sent, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :date_received, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :source, label: "Sent via", placeholder: 'Online form, Email, Postal mail, etc.' %>
-      <%= form.input :tag_list, placeholder: 'movie, youtube, video, etc.' %>
-      <%=
-        form.input :topic_ids,
-          label: "Topics",
-          prompt: nil,
-          collection: available_topics,
-          input_html: { multiple: true }
-        %>
-      <%= form.input :language, collection: Language.all, label_method: :label, value_method: :code %>
-      <%= form.input :jurisdiction_list, label: "Jurisdiction", placeholder: 'a list of countries - US, CA, etc.' %>
-      <%=
-        form.input :action_taken,
-          collection: Notice::VALID_ACTIONS,
-          label_html: { data: {
-            tooltip: "Did the recipient of the notice take action in response?"
-          }}
-        %>
-    </div>
-    <div class="body-wrapper right attach">
-      <%= form.input :body, label: "Explanation of Complaint" %>
-      <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
-        <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="javascript:void(0);" id="add-another">Attach another</a>
-        <%= file_uploads_form.input :kind, as: :hidden %>
-      <% end %>
-    </div>
+    <%= render 'notices/form_components/main_metadata', form: form %>
+    <%= render 'notices/form_components/additional_metadata',
+               label: 'Explanation of Complaint',
+               form: form %>
   </section>
 
   <section class="works">
@@ -67,36 +30,8 @@
     <% end %>
   </section>
 
-  <% step_number = 3 %>
-  <%= form.simple_fields_for(:entity_notice_roles) do |roles_form| %>
-    <% role = roles_form.object.name.titleize %>
-    <section class="role <%= role.downcase %>">
-      <h4><span>Step <%= step_number %>.</span> <%= role %> of the Notice</h4>
-      <p>Enter information about the <b><%= role %></b> of the notice.</p>
-      <%= roles_form.input :name, as: :hidden %>
-      <%= roles_form.simple_fields_for(:entity) do |entity_form| %>
-        <div class="body-wrapper left required">
-          <%= entity_form.input :name, label: "Name" %>
-          <%= entity_form.input :kind,
-            label: "#{role} Type", prompt: nil, collection: Entity::KINDS %>
-        </div>
-        <div class="body-wrapper right optional">
-          <%= entity_form.input :address_line_1, label: "Address Line 1" %>
-          <%= entity_form.input :address_line_2, label: "Address Line 2" %>
-          <%= entity_form.input :city, label: "City" %>
-          <%= entity_form.input :state, label: "State", maxlength: "2" %>
-          <%= entity_form.input :zip, label: "Zip Code" %>
-          <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
-          <%= entity_form.input :phone, label: "Phone" %>
-          <%= entity_form.input :email, label: "Email" %>
-          <%= entity_form.input :url, label: "#{role} URL" %>
-        </div>
-      <% end %>
-    </section>
-    <% step_number += 1 %>
-  <% end %>
-
-  <div class="buttons-wrapper">
-    <%= form.submit "Submit Notice", :class => "submit" %>
-  </div>
+  <%= render 'notices/form_components/roles',
+             label: 'Notice',
+             form: form %>
+  <%= render 'notices/form_components/submit', form: form %>
 <% end %>

--- a/app/views/notices/_private_information_form.html.erb
+++ b/app/views/notices/_private_information_form.html.erb
@@ -1,50 +1,13 @@
-<header>
-  <h3 class="title">Report a Private Information Notice</h3>
-  <p>If you have sent or received a Private Information notice and want to submit it to our database, fill out the form below.</p>
-  <p class="disclaimer">Please do not include phone numbers, email addresses, personal name, or other private information other than those of the complainant.</p>
-</header>
+<%= render 'notices/form_components/header',
+           label: 'Private Information notice' %>
 <%= simple_form_for(notice) do |form| %>
   <section class="notice-body">
     <h4><span>Step 1.</span> Describe the Notice</h4>
     <p>Provide us with information about the Private Information notice you <em>sent</em> or <em>received</em>.</p>
-    <div class="body-wrapper left main">
-      <%= form.input :type, as: :hidden %>
-      <%=
-        form.input :title, label_html: { data: {
-          tooltip: "If the notice you sent/received had a subject line, enter it here"
-        }}
-      %>
-      <%= form.hidden_field :webform, :value => true %>
-      <%= form.input :subject %>
-      <%= form.input :date_sent, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :date_received, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :source, label: "Sent via", placeholder: 'Online form, Email, Postal mail, etc.' %>
-      <%= form.input :tag_list, placeholder: 'movie, youtube, video, etc.' %>
-      <%=
-        form.input :topic_ids,
-          label: "Topics",
-          prompt: nil,
-          collection: available_topics,
-          input_html: { multiple: true }
-        %>
-      <%= form.input :language, collection: Language.all, label_method: :label, value_method: :code %>
-      <%= form.input :jurisdiction_list, label: "Jurisdiction", placeholder: 'a list of countries - US, CA, etc.' %>
-      <%=
-        form.input :action_taken,
-          collection: Notice::VALID_ACTIONS,
-          label_html: { data: {
-            tooltip: "Did the recipient of the notice take action in response?"
-          }}
-        %>
-    </div>
-    <div class="body-wrapper right attach">
-      <%= form.input :body, label: "Explanation of Complaint" %>
-      <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
-        <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="javascript:void(0);" id="add-another">Attach another</a>
-        <%= file_uploads_form.input :kind, as: :hidden %>
-      <% end %>
-    </div>
+    <%= render 'notices/form_components/main_metadata', form: form %>
+    <%= render 'notices/form_components/additional_metadata',
+               label: 'Explanation of Complaint',
+               form: form %>
   </section>
 
   <section class="works">
@@ -65,36 +28,8 @@
     <% end %>
   </section>
 
-  <% step_number = 3 %>
-  <%= form.simple_fields_for(:entity_notice_roles) do |roles_form| %>
-    <% role = roles_form.object.name.titleize %>
-    <section class="role <%= role.downcase %>">
-      <h4><span>Step <%= step_number %>.</span> <%= role %> of the Notice</h4>
-      <p>Enter information about the <b><%= role %></b> of the Private Information notice.</p>
-      <%= roles_form.input :name, as: :hidden %>
-      <%= roles_form.simple_fields_for(:entity) do |entity_form| %>
-        <div class="body-wrapper left required">
-          <%= entity_form.input :name, label: "Name" %>
-          <%= entity_form.input :kind,
-            label: "#{role} Type", prompt: nil, collection: Entity::KINDS %>
-        </div>
-        <div class="body-wrapper right optional">
-          <%= entity_form.input :address_line_1, label: "Address Line 1" %>
-          <%= entity_form.input :address_line_2, label: "Address Line 2" %>
-          <%= entity_form.input :city, label: "City" %>
-          <%= entity_form.input :state, label: "State", maxlength: "2" %>
-          <%= entity_form.input :zip, label: "Zip Code" %>
-          <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
-          <%= entity_form.input :phone, label: "Phone" %>
-          <%= entity_form.input :email, label: "Email" %>
-          <%= entity_form.input :url, label: "#{role} URL" %>
-        </div>
-      <% end %>
-    </section>
-    <% step_number += 1 %>
-  <% end %>
-
-  <div class="buttons-wrapper">
-    <%= form.submit "Submit Notice", :class => "submit" %>
-  </div>
+  <%= render 'notices/form_components/roles',
+             label: 'Private Information notice',
+             form: form %>
+  <%= render 'notices/form_components/submit', form: form %>
 <% end %>

--- a/app/views/notices/_trademark_form.html.erb
+++ b/app/views/notices/_trademark_form.html.erb
@@ -1,51 +1,14 @@
-<header>
-  <h3 class="title">Report a Trademark Takedown Notice</h3>
-  <p>If you have sent or received a Trademark takedown notice and want to submit it to our database, fill out the form below.</p>
-  <p class="disclaimer">Please do not include phone numbers, email addresses, personal name, or other private information other than those of the complainant.</p>
-</header>
+<%= render 'notices/form_components/header',
+           label: 'Trademark takedown notice' %>
 <%= simple_form_for(notice) do |form| %>
   <section class="notice-body">
     <h4><span>Step 1.</span> Describe the Notice</h4>
     <p>Provide us with information about the Trademark takedown notice you <em>sent</em> or <em>received</em>.</p>
-    <div class="body-wrapper left main">
-      <%= form.input :type, as: :hidden %>
-      <%=
-        form.input :title, label_html: { data: {
-          tooltip: "If the notice you sent/received had a subject line, enter it here"
-        }}
-      %>
-      <%= form.hidden_field :webform, :value => true %>
-      <%= form.input :subject %>
-      <%= form.input :date_sent, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :date_received, as: :string, placeholder: "YYYY-MM-DD" %>
-      <%= form.input :source, label: "Sent via", placeholder: 'Online form, Email, Postal mail, etc.' %>
-      <%= form.input :tag_list, placeholder: 'movie, youtube, video, etc.' %>
-      <%=
-        form.input :topic_ids,
-          label: "Topics",
-          prompt: nil,
-          collection: available_topics,
-          input_html: { multiple: true }
-        %>
-      <%= form.input :language, collection: Language.all, label_method: :label, value_method: :code %>
-      <%= form.input :jurisdiction_list, label: "Jurisdiction", placeholder: 'a list of countries - US, CA, etc.' %>
-      <%=
-        form.input :action_taken,
-          collection: Notice::VALID_ACTIONS,
-          label_html: { data: {
-            tooltip: "Did the recipient of the notice take action in response?"
-          }}
-        %>
-    </div>
-    <div class="body-wrapper right attach">
-      <%= form.input :body, label: 'Describe the alleged infringement of trademark' %>
-      <%= form.input :mark_registration_number, label: "Registration Number" %>
-      <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
-        <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-        <a href="javascript:void(0);" id="add-another">Attach another</a>
-        <%= file_uploads_form.input :kind, as: :hidden %>
-      <% end %>
-    </div>
+    <%= render 'notices/form_components/main_metadata', form: form %>
+    <%= render 'notices/form_components/additional_metadata',
+               label: 'Describe the alleged infringement of trademark',
+               mark_reg: true,
+               form: form %>
   </section>
 
   <section class="works">
@@ -72,36 +35,8 @@
     <% end %>
   </section>
 
-  <% step_number = 3 %>
-  <%= form.simple_fields_for(:entity_notice_roles) do |roles_form| %>
-    <% role = roles_form.object.name.titleize %>
-    <section class="role <%= role.downcase %>">
-      <h4><span>Step <%= step_number %>.</span> <%= role %> of the Notice</h4>
-      <p>Enter information about the <b><%= role %></b> of the Trademark takedown notice.</p>
-      <%= roles_form.input :name, as: :hidden %>
-      <%= roles_form.simple_fields_for(:entity) do |entity_form| %>
-        <div class="body-wrapper left required">
-          <%= entity_form.input :name, label: "Name" %>
-          <%= entity_form.input :kind,
-            label: "#{role} Type", prompt: nil, collection: Entity::KINDS %>
-        </div>
-        <div class="body-wrapper right optional">
-          <%= entity_form.input :address_line_1, label: "Address Line 1" %>
-          <%= entity_form.input :address_line_2, label: "Address Line 2" %>
-          <%= entity_form.input :city, label: "City" %>
-          <%= entity_form.input :state, label: "State", maxlength: "2" %>
-          <%= entity_form.input :zip, label: "Zip Code" %>
-          <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
-          <%= entity_form.input :phone, label: "Phone" %>
-          <%= entity_form.input :email, label: "Email" %>
-          <%= entity_form.input :url, label: "#{role} URL" %>
-        </div>
-      <% end %>
-    </section>
-    <% step_number += 1 %>
-  <% end %>
-
-  <div class="buttons-wrapper">
-    <%= form.submit "Submit Notice", :class => "submit" %>
-  </div>
+  <%= render 'notices/form_components/roles',
+             label: 'Trademark takedown notice',
+             form: form %>
+  <%= render 'notices/form_components/submit', form: form %>
 <% end %>

--- a/app/views/notices/feed.rss.builder
+++ b/app/views/notices/feed.rss.builder
@@ -1,28 +1,26 @@
-#encoding: UTF-8
-
-xml.instruct! :xml, :version => "1.0"
-xml.rss :version => "2.0" do
+xml.instruct! :xml, version: '1.0'
+xml.rss version: '2.0' do
   xml.channel do
-    xml.title "Recent Notices from Lumen Database"
-    xml.author "Lumen Database"
-    xml.description "Lumen Database is an independent 3rd party research project studying cease and desist letters concerning online content."
-    xml.link "https://www.lumendatabase.org/"
-    xml.language "en"
+    xml.title 'Recent Notices from Lumen Database'
+    xml.author 'Lumen Database'
+    xml.description 'Lumen Database is an independent 3rd party research project studying cease and desist letters concerning online content.'
+    xml.link 'https://www.lumendatabase.org/'
+    xml.language 'en'
 
-    for notice in @recent_notices
+    @recent_notices.each do |notice|
       xml.item do
         if notice.title
           xml.title notice.title
         else
-          xml.title ""
+          xml.title ''
         end
         xml.author notice.sender_name
         xml.pubDate notice.created_at.to_s(:rfc822)
-        xml.link "https://www.lumendatabase.org/notices/" + notice.id.to_s
+        xml.link "https://www.lumendatabase.org/notices/#{notice.id}"
         xml.guid notice.id
         xml.type notice.type
 
-        xml.description "<p> To: " + notice.recipient_name + "\nFrom: " + notice.sender_name + "\n" + notice.body.to_s + "</p>" 
+        xml.description "<p> To: #{notice.recipient_name}\nFrom: #{notice.sender_name}\n#{notice.body}</p>"
       end
     end
   end

--- a/app/views/notices/form_components/_additional_metadata.html.erb
+++ b/app/views/notices/form_components/_additional_metadata.html.erb
@@ -1,0 +1,28 @@
+<%# Displays the right-hand column of the top of a notice form.
+    Required: form
+    Optional: body (default: true),
+              label (default: 'Explanation'),
+              request_collection (default: nil),
+              mark_reg (default: false)
+    body, if false, will suppress display the body section.
+    #%>
+<% body = true if local_assigns[:body].nil? %>
+<% label = 'Body' if local_assigns[:label].nil? %>
+<% request_collection = nil if local_assigns[:request_collection].nil? %>
+<% mark_reg = nil if local_assigns[:mark_reg].nil? %>
+<div class="body-wrapper right attach">
+  <% if body %>
+    <%= form.input :body, label: label %>
+  <% end %>
+  <% if request_collection.present? %>
+    <%= form.input :request_type, collection: request_collection %>
+  <% end %>
+  <% if mark_reg %>
+    <%= form.input :mark_registration_number, label: "Registration Number" %>
+  <% end %>
+  <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
+    <%= file_uploads_form.input :file, label: 'Attach Notice' %>
+    <a href="javascript:void(0);" id="add-another">Attach another</a>
+    <%= file_uploads_form.input :kind, as: :hidden %>
+  <% end %>
+</div>

--- a/app/views/notices/form_components/_additional_metadata.html.erb
+++ b/app/views/notices/form_components/_additional_metadata.html.erb
@@ -28,6 +28,6 @@
           prompt: nil,
           collection: FileUpload::ALLOWED_KINDS %>
     </div>
-    <a href="javascript:void(0);" id="add-another">Attach another</a>
+    <a href="javascript:void(0);" id="add-another" class="button">Attach another</a>
   <% end %>
 </div>

--- a/app/views/notices/form_components/_additional_metadata.html.erb
+++ b/app/views/notices/form_components/_additional_metadata.html.erb
@@ -21,8 +21,13 @@
     <%= form.input :mark_registration_number, label: "Registration Number" %>
   <% end %>
   <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
-    <%= file_uploads_form.input :file, label: 'Attach Notice' %>
+    <div id="file_uploads_inputs">
+      <%= file_uploads_form.input :file, label: 'Attach Notice' %>
+      <%= file_uploads_form.input :kind,
+          label: 'Document type',
+          prompt: nil,
+          collection: FileUpload::ALLOWED_KINDS %>
+    </div>
     <a href="javascript:void(0);" id="add-another">Attach another</a>
-    <%= file_uploads_form.input :kind, as: :hidden %>
   <% end %>
 </div>

--- a/app/views/notices/form_components/_header.html.erb
+++ b/app/views/notices/form_components/_header.html.erb
@@ -1,0 +1,6 @@
+<% label = local_assigns[:label] || @notice.class.label %>
+<header>
+  <h3 class="title">Report a <%= label.titleize %></h3>
+  <p>If you have sent or received a <%= label %> and want to submit it to our database, fill out the form below.</p>
+  <p class="disclaimer">Please do not include phone numbers, email addresses, personal name, or other private information other than those of the complainant.</p>
+</header>

--- a/app/views/notices/form_components/_main_metadata.html.erb
+++ b/app/views/notices/form_components/_main_metadata.html.erb
@@ -1,0 +1,48 @@
+<%# Displays the right-hand column of the top of a notice form.
+    Required: form
+    Optional: action_taken, subject, topics, tag_list (default: true)
+    The optional parameters, if false, will suppress display of associated
+    sections.
+    #%>
+<% action_taken = true if local_assigns[:action_taken].nil? %>
+<% subject = true if local_assigns[:subject].nil? %>
+<% topics = true if local_assigns[:topics].nil? %>
+<% tag_list = true if local_assigns[:tag_list].nil? %>
+<div class="body-wrapper left main">
+  <%= form.input :type, as: :hidden %>
+  <%=
+    form.input :title, label_html: { data: {
+      tooltip: "If the notice you sent/received had a subject line, enter it here"
+    }}
+  %>
+  <%= form.hidden_field :webform, :value => true %>
+  <% if subject %>
+    <%= form.input :subject %>
+  <% end %>
+  <%= form.input :date_sent, as: :string, placeholder: "YYYY-MM-DD" %>
+  <%= form.input :date_received, as: :string, placeholder: "YYYY-MM-DD" %>
+  <%= form.input :source, label: "Sent via", placeholder: 'Online form, Email, Postal mail, etc.' %>
+  <%if tag_list %>
+    <%= form.input :tag_list, placeholder: 'movie, youtube, video, etc.' %>
+  <% end %>
+  <%if topics %>
+    <%=
+      form.input :topic_ids,
+        label: "Topics",
+        prompt: nil,
+        collection: available_topics,
+        input_html: { multiple: true }
+      %>
+  <% end %>
+  <%= form.input :language, collection: Language.all, label_method: :label, value_method: :code %>
+  <%= form.input :jurisdiction_list, label: "Jurisdiction", placeholder: 'a list of countries - US, CA, etc.' %>
+  <% if action_taken %>
+    <%=
+      form.input :action_taken,
+        collection: Notice::VALID_ACTIONS,
+        label_html: { data: {
+          tooltip: "Did the recipient of the notice take action in response?"
+        }}
+      %>
+  <% end %>
+</div>

--- a/app/views/notices/form_components/_main_metadata.html.erb
+++ b/app/views/notices/form_components/_main_metadata.html.erb
@@ -15,7 +15,7 @@
       tooltip: "If the notice you sent/received had a subject line, enter it here"
     }}
   %>
-  <%= form.hidden_field :webform, :value => true %>
+  <%= form.hidden_field :webform, value: true %>
   <% if subject %>
     <%= form.input :subject %>
   <% end %>

--- a/app/views/notices/form_components/_roles.html.erb
+++ b/app/views/notices/form_components/_roles.html.erb
@@ -1,0 +1,31 @@
+<% label = local_assigns[:label] || @notice.class.label %>
+<% step_number = 3 %>
+<%= form.simple_fields_for(:entity_notice_roles) do |roles_form| %>
+  <% role = roles_form.object.name %>
+  <%# don't titleize the role until after the following line or it will break the css selector %>
+  <section class="role <%= role.downcase %>">
+    <% role = role.titleize %>
+    <h4><span>Step <%= step_number %>.</span> <%= role %> of the Notice</h4>
+    <p>Enter information about the <b><%= role %></b> of the <%= label %>.</p>
+    <%= roles_form.input :name, as: :hidden %>
+    <%= roles_form.simple_fields_for(:entity) do |entity_form| %>
+      <div class="body-wrapper left required">
+        <%= entity_form.input :name, label: "Name" %>
+        <%= entity_form.input :kind,
+          label: "#{role} Type", prompt: nil, collection: Entity::KINDS %>
+      </div>
+      <div class="body-wrapper right optional">
+        <%= entity_form.input :address_line_1, label: "Address Line 1" %>
+        <%= entity_form.input :address_line_2, label: "Address Line 2" %>
+        <%= entity_form.input :city, label: "City" %>
+        <%= entity_form.input :state, label: "State", maxlength: "2" %>
+        <%= entity_form.input :zip, label: "Zip Code" %>
+        <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
+        <%= entity_form.input :phone, label: "Phone" %>
+        <%= entity_form.input :email, label: "Email" %>
+        <%= entity_form.input :url, label: "#{role} URL" %>
+      </div>
+    <% end %>
+  </section>
+  <% step_number += 1 %>
+<% end %>

--- a/app/views/notices/form_components/_roles.html.erb
+++ b/app/views/notices/form_components/_roles.html.erb
@@ -18,8 +18,8 @@
         <%= entity_form.input :address_line_1, label: "Address Line 1" %>
         <%= entity_form.input :address_line_2, label: "Address Line 2" %>
         <%= entity_form.input :city, label: "City" %>
-        <%= entity_form.input :state, label: "State", maxlength: "2" %>
-        <%= entity_form.input :zip, label: "Zip Code" %>
+        <%= entity_form.input :state, label: "State", label_html: { class: 'half-width' }, maxlength: "2" %>
+        <%= entity_form.input :zip, label: "Zip Code", label_html: { class: 'half-width' } %>
         <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
         <%= entity_form.input :phone, label: "Phone" %>
         <%= entity_form.input :email, label: "Email" %>

--- a/app/views/notices/form_components/_submit.html.erb
+++ b/app/views/notices/form_components/_submit.html.erb
@@ -1,0 +1,3 @@
+<div class="buttons-wrapper">
+  <%= form.submit "Submit Notice", :class => "submit" %>
+</div>

--- a/app/views/notices/form_components/_submit.html.erb
+++ b/app/views/notices/form_components/_submit.html.erb
@@ -1,3 +1,3 @@
 <div class="buttons-wrapper">
-  <%= form.submit "Submit Notice", :class => "submit" %>
+  <%= form.submit "Submit Notice", class: "submit" %>
 </div>

--- a/app/views/notices/search/index.html.erb
+++ b/app/views/notices/search/index.html.erb
@@ -27,8 +27,8 @@
               <li class="facet">
               <%=
                 link_to(
-                  sorting.label, '#', 'data-value' => sorting.key,
-                  'data-label' => sorting.label
+                  sorting.label, '#', 'data-value': sorting.key,
+                  'data-label': sorting.label
                 ) %>
               </li>
             <% end %>

--- a/app/views/notices/select_type.html.erb
+++ b/app/views/notices/select_type.html.erb
@@ -2,7 +2,9 @@
 
 <div class="inner-padding">
   <h1>Which type of demand would you like to report?</h1>
-  <b>To help us serve you better, we ask that you submit only notices you have received, not items you have heard about second-hand, and that you add only information whose accuracy you can verify. We may mask additional identifying information before making the notice publicly viewable.</b> 
+  <p>
+    <b>To help us serve you better, we ask that you submit only notices you have received, not items you have heard about second-hand, and that you add only information whose accuracy you can verify. We may mask additional identifying information before making the notice publicly viewable.</b>
+  </p>
   <section class="notices-list">
     <ul>
       <% Notice.type_models.each do |model| %>
@@ -27,12 +29,12 @@
             )
           %>
           <% if model.name == "DMCA" %>
-          <%= 
+          <%=
             link_to(
-              "Create DMCA Counter Notice", 
-              new_counter_notice_path, 
+              "Create DMCA Counter Notice",
+              new_counter_notice_path,
               class: "button"
-            ) 
+            )
           %>
           <% end %>
         </div>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -9,7 +9,7 @@
   <% end %>
 
   <% cache(@notice) do %>
-    <%= content_tag('section', class: 'first-time-visitor', style: 'display: none;', 'data-content' => first_time_visitor_content) do %>
+    <%= content_tag('section', class: 'first-time-visitor', style: 'display: none;', 'data-content': first_time_visitor_content) do %>
       <div class="first-time-visitor-content">
         <p id="hide-first-time-visitor-content"><a href="#">Close</a></p>
       </div>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -84,7 +84,7 @@ RailsAdmin.config do |config|
       edit do
         configure :action_taken, :enum do
           enum do
-            ['Yes', 'No', 'Partial', 'Unspecified']
+            %w[Yes No Partial Unspecified]
           end
           default_value 'Unspecified'
         end
@@ -93,7 +93,7 @@ RailsAdmin.config do |config|
           hide
         end
         configure :reset_type, :enum do
-          label "Type"
+          label 'Type'
           required true
         end
         configure(:topic_assignments) { hide }
@@ -168,7 +168,7 @@ RailsAdmin.config do |config|
     edit do
       configure :kind, :enum do
         enum do
-          ['individual', 'organization']
+          %w[individual organization]
         end
         default_value 'organization'
       end
@@ -191,7 +191,7 @@ RailsAdmin.config do |config|
 
   config.model 'Work' do
     object_label_method { :custom_work_label }
-    
+
     edit do
       configure(:notices) { hide }
     end
@@ -204,7 +204,6 @@ RailsAdmin.config do |config|
       configure(:infringing_urls) { hide }
       configure(:copyrighted_urls) { hide }
     end
-
   end
 
   config.model 'InfringingUrl' do
@@ -215,18 +214,17 @@ RailsAdmin.config do |config|
     edit do
       configure :kind, :enum do
         enum do
-          ['original', 'supporting']
+          %w[original supporting]
         end
       end
     end
   end
 
   config.model 'ReindexRun' do
-
   end
 
   def custom_work_label
-    %Q|#{self.id}: #{self.description && self.description[0,30]}...|
+    %Q(#{self.id}: #{self.description && self.description[0,30]}...)
   end
 
   config.model 'User' do

--- a/doc/release.md
+++ b/doc/release.md
@@ -42,13 +42,13 @@ If any deploys have special instructions, write them here, with a date and PR nu
 * `sudo -su chill-prod` (enyos) or `sudo -su chill-dev` (flutie) or `sudo -su chill-api` (percy)
 * cd into the directory where chill files live (look under `/web/<servername>`)
 * `cp .env ../` (as a precaution)
-* `git checkout <branch>`
 * `git checkout db/schema.rb`
+* `git checkout <branch>`
   * This will differ from the version-controlled one as running db:migrate will change its datestamp
   * You don't want merge conflicts
-* `git pull origin <branch>`
-  * Servers have correct default branches set so this is just `git pull` unless you need a different branch
+* `git pull`
 * `bundle install`
+  * This will throw an error if the user doesn't have write permissions on the home directory inferred by bundler (probably the one specified in /etc/passwd/), but it probably works anyway.
 * `cp ../.env .`
 * `rake db:migrate`
   - If this throws a `PG::ConnectionBad:` and asks something like "Is the server running locally and accepting connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?", use `RAILS_ENV=production rake db:migrate`

--- a/spec/controllers/original_files_controller_spec.rb
+++ b/spec/controllers/original_files_controller_spec.rb
@@ -1,19 +1,17 @@
 require 'rails_helper'
 
 describe OriginalFilesController do
-
-  describe "GET 'show'" do
+  describe 'GET #show' do
     let(:upload) { create(:file_upload) }
-    it "returns not found without valid params" do
-      get 'show', id: upload.id, file_path: ['a', 'b', 'c']
+    it 'returns not found without valid params' do
+      get 'show', id: upload.id, file_path: %w[a b c]
       expect(response).not_to be_success
     end
 
-    it "returns http success" do
-      allow(File).to receive(:file?).and_return(:true)
+    it 'returns http success' do
+      allow(File).to receive(:file?).and_return(true)
       allow(File).to receive(:read).and_return('Content!')
       expect(response).to be_success
     end
   end
-
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,4 @@
 FactoryGirl.define do
-
   sequence(:email) { |n| "user_#{n}@example.com" }
 
   sequence(:url) { |n| "http://example.com/url_#{n}" }
@@ -23,15 +22,15 @@ FactoryGirl.define do
   end
 
   factory :topic_manager do
-    name "A name"
+    name 'A name'
   end
 
   factory :dmca do
     sequence(:id) { |n| n }
-    title "A title"
+    title 'A title'
     date_received Time.now
     date_sent Time.now
-    
+
     works { build_list(:work, 1) }
 
     ignore do
@@ -46,7 +45,7 @@ FactoryGirl.define do
     end
 
     trait :with_body do
-      body "A body"
+      body 'A body'
     end
 
     trait :with_tags do
@@ -85,13 +84,13 @@ FactoryGirl.define do
       with_tags
       with_jurisdictions
       with_topics
-      role_names %w( sender principal recipient )
+      role_names %w[sender principal recipient]
       date_received Time.now
     end
 
     trait :redactable do
-      body "Some [REDACTED] body"
-      body_original "Some sensitive body"
+      body 'Some [REDACTED] body'
+      body_original 'Some sensitive body'
       review_required true
     end
 
@@ -136,7 +135,7 @@ FactoryGirl.define do
 
   factory :file_upload do
     ignore do
-      content "Content"
+      content 'Content'
     end
 
     kind 'original'
@@ -146,7 +145,7 @@ FactoryGirl.define do
         fh.write(content)
         fh.flush
 
-        Rack::Test::UploadedFile.new(fh.path, "text/plain")
+        Rack::Test::UploadedFile.new(fh.path, 'text/plain')
       end
     end
   end
@@ -159,16 +158,16 @@ FactoryGirl.define do
 
   factory :entity do
     sequence(:name) { |n| "Entity name #{n}" }
-    kind "individual"
-    address_line_1 "Address 1"
-    address_line_2 "Address 2"
-    city "City"
-    state "State"
-    zip "01222"
-    country_code "US"
-    phone "555-555-1212"
-    email "foo@example.com"
-    url "http://www.example.com"
+    kind 'individual'
+    address_line_1 'Address 1'
+    address_line_2 'Address 2'
+    city 'City'
+    state 'State'
+    zip '01222'
+    country_code 'US'
+    phone '555-555-1212'
+    email 'foo@example.com'
+    url 'http://www.example.com'
 
     trait :with_children do
       after(:create) do |instance|
@@ -185,8 +184,8 @@ FactoryGirl.define do
 
   factory :user do
     email
-    password "secretsauce"
-    password_confirmation "secretsauce"
+    password 'secretsauce'
+    password_confirmation 'secretsauce'
 
     trait :submitter do
       roles { [Role.submitter] }
@@ -211,19 +210,19 @@ FactoryGirl.define do
     trait :with_entity do
       entity
     end
-    
+
     trait :researcher do
       roles { [Role.researcher] }
     end
   end
 
   factory :relevant_question do
-    question "What is the meaning of life?"
-    answer "42"
+    question 'What is the meaning of life?'
+    answer '42'
   end
 
   factory :work do
-    description "Something copyrighted"
+    description 'Something copyrighted'
 
     trait :with_infringing_urls do
       after(:build) do |work|
@@ -249,8 +248,8 @@ FactoryGirl.define do
   end
 
   factory :blog_entry do
-    title "Blog title"
-    author "John Smith"
+    title 'Blog title'
+    author 'John Smith'
 
     trait :published do
       published_at 5.days.ago
@@ -265,7 +264,7 @@ FactoryGirl.define do
     end
 
     trait :with_content do
-      content "Some *markdown* content"
+      content 'Some *markdown* content'
     end
   end
 
@@ -289,5 +288,4 @@ FactoryGirl.define do
       jurisdiction 'I live outside the United States'
     end
   end
-
 end

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -262,6 +262,192 @@ feature 'notice submission' do
     expect(page).to have_text('Submitter of the Notice')
   end
 
+  context 'template rendering' do
+    scenario 'counternotice form' do
+      sign_in(create(:user, :submitter))
+      visit '/notices/new?type=Counternotice'
+
+      expect(page).to have_content 'Provide us with information about the DMCA counternotice'
+      expect(page).to have_css '#notice_counternotice_for_id'
+      expect(page).not_to have_css '#notice_action_taken'
+      expect(page).not_to have_css 'textarea#notice_body'
+      expect(page).to have_css 'select#notice_body'
+
+      check_all_sections_rendered(page)
+    end
+
+    scenario 'court order form' do
+      sign_in(create(:user, :submitter))
+      visit '/notices/new?type=CourtOrder'
+
+      expect(page).to have_content 'Provide us with information about the Court Order'
+      expect(page).to have_css '#notice_action_taken'
+      expect(page).to have_css '#notice_subject'
+      expect(page).to have_css '#notice_topic_ids'
+      expect(page).to have_css '#notice_tag_list'
+      expect(page).not_to have_css 'select#notice_body'
+      expect(page).to have_css('textarea#notice_body')
+      expect(page).to have_css('.notice_body label',
+                               text: 'Explanation of Court Order')
+      expect(page).not_to have_css '#notice_request_type'
+      expect(page).not_to have_css '#notice_mark_registration_number'
+
+      check_all_sections_rendered(page)
+    end
+
+    scenario 'data protection form' do
+      sign_in(create(:user, :submitter))
+      visit '/notices/new?type=DataProtection'
+
+      expect(page).to have_content 'Provide us with information about the Data Protection takedown notice'
+      expect(page).to have_css '#notice_action_taken'
+      expect(page).not_to have_css '#notice_subject'
+      expect(page).not_to have_css '#notice_topic_ids'
+      expect(page).not_to have_css '#notice_tag_list'
+      expect(page).not_to have_css 'select#notice_body'
+      expect(page).to have_css('textarea#notice_body')
+      expect(page).to have_css('.notice_body label',
+                               text: 'Legal Complaint')
+      expect(page).not_to have_css '#notice_request_type'
+      expect(page).not_to have_css '#notice_mark_registration_number'
+
+      check_all_sections_rendered(page)
+    end
+
+    scenario 'defamation form' do
+      sign_in(create(:user, :submitter))
+      visit '/notices/new?type=Defamation'
+
+      expect(page).to have_content 'Provide us with information about the Defamation takedown notice'
+      expect(page).to have_css '#notice_action_taken'
+      expect(page).to have_css '#notice_subject'
+      expect(page).to have_css '#notice_topic_ids'
+      expect(page).to have_css '#notice_tag_list'
+      expect(page).not_to have_css 'select#notice_body'
+      expect(page).to have_css('textarea#notice_body')
+      expect(page).to have_css('.notice_body label',
+                               text: 'Legal Complaint')
+      expect(page).not_to have_css '#notice_request_type'
+      expect(page).not_to have_css '#notice_mark_registration_number'
+
+      check_all_sections_rendered(page)
+    end
+
+    scenario 'DMCA form' do
+      sign_in(create(:user, :submitter))
+      visit '/notices/new?type=DMCA'
+
+      expect(page).to have_content 'Provide us with information about the DMCA takedown notice'
+      expect(page).to have_css '#notice_action_taken'
+      expect(page).to have_css '#notice_subject'
+      expect(page).to have_css '#notice_topic_ids'
+      expect(page).to have_css '#notice_tag_list'
+      expect(page).not_to have_css 'select#notice_body'
+      expect(page).to have_css('textarea#notice_body')
+      expect(page).to have_css('.notice_body label',
+                               text: 'Body')
+      expect(page).not_to have_css '#notice_request_type'
+      expect(page).not_to have_css '#notice_mark_registration_number'
+
+      check_all_sections_rendered(page)
+    end
+
+    scenario 'government request form' do
+      sign_in(create(:user, :submitter))
+      visit '/notices/new?type=GovernmentRequest'
+
+      expect(page).to have_content 'Provide us with information about the Government Request'
+      expect(page).to have_css '#notice_action_taken'
+      expect(page).to have_css '#notice_subject'
+      expect(page).to have_css '#notice_topic_ids'
+      expect(page).to have_css '#notice_tag_list'
+      expect(page).not_to have_css 'select#notice_body'
+      expect(page).to have_css('textarea#notice_body')
+      expect(page).to have_css('.notice_body label',
+                               text: 'Explanation of Government Request')
+      expect(page).to have_css '#notice_request_type'
+      expect(page).not_to have_css '#notice_mark_registration_number'
+
+      check_all_sections_rendered(page)
+    end
+
+    scenario 'law enforcement request form' do
+      sign_in(create(:user, :submitter))
+      visit '/notices/new?type=LawEnforcementRequest'
+
+      expect(page).to have_content 'Provide us with information about the Law Enforcement Request'
+      expect(page).to have_css '#notice_action_taken'
+      expect(page).to have_css '#notice_subject'
+      expect(page).to have_css '#notice_topic_ids'
+      expect(page).to have_css '#notice_tag_list'
+      expect(page).not_to have_css 'select#notice_body'
+      expect(page).to have_css('textarea#notice_body')
+      expect(page).to have_css('.notice_body label',
+                               text: 'Explanation of Law Enforcement Request')
+      expect(page).to have_css '#notice_request_type'
+      expect(page).not_to have_css '#notice_mark_registration_number'
+
+      check_all_sections_rendered(page)
+    end
+
+    scenario 'other notice type form' do
+      sign_in(create(:user, :submitter))
+      visit '/notices/new?type=Other'
+
+      expect(page).to have_content 'Provide us with information about the notice'
+      expect(page).to have_css '#notice_action_taken'
+      expect(page).to have_css '#notice_subject'
+      expect(page).to have_css '#notice_topic_ids'
+      expect(page).to have_css '#notice_tag_list'
+      expect(page).not_to have_css 'select#notice_body'
+      expect(page).to have_css('textarea#notice_body')
+      expect(page).to have_css('.notice_body label',
+                               text: 'Explanation of Complaint')
+      expect(page).not_to have_css '#notice_request_type'
+      expect(page).not_to have_css '#notice_mark_registration_number'
+
+      check_all_sections_rendered(page)
+    end
+
+    scenario 'private information form' do
+      sign_in(create(:user, :submitter))
+      visit '/notices/new?type=PrivateInformation'
+
+      expect(page).to have_content 'Provide us with information about the Private Information notice'
+      expect(page).to have_css '#notice_action_taken'
+      expect(page).to have_css '#notice_subject'
+      expect(page).to have_css '#notice_topic_ids'
+      expect(page).to have_css '#notice_tag_list'
+      expect(page).not_to have_css 'select#notice_body'
+      expect(page).to have_css('textarea#notice_body')
+      expect(page).to have_css('.notice_body label',
+                               text: 'Explanation of Complaint')
+      expect(page).not_to have_css '#notice_request_type'
+      expect(page).not_to have_css '#notice_mark_registration_number'
+
+      check_all_sections_rendered(page)
+    end
+
+    scenario 'trademark form' do
+      sign_in(create(:user, :submitter))
+      visit '/notices/new?type=Trademark'
+
+      expect(page).to have_content 'Provide us with information about the Trademark takedown notice'
+      expect(page).to have_css '#notice_action_taken'
+      expect(page).to have_css '#notice_subject'
+      expect(page).to have_css '#notice_topic_ids'
+      expect(page).to have_css '#notice_tag_list'
+      expect(page).not_to have_css 'select#notice_body'
+      expect(page).to have_css('textarea#notice_body')
+      expect(page).to have_css('.notice_body label',
+                               text: 'Describe the alleged infringement of trademark')
+      expect(page).not_to have_css '#notice_request_type'
+      expect(page).to have_css '#notice_mark_registration_number'
+
+      check_all_sections_rendered(page)
+    end
+  end
+
   private
 
   def works_copyrighted_url_id
@@ -270,5 +456,13 @@ feature 'notice submission' do
 
   def entity_name_class
     'notice_entity_notice_roles_entity_name'
+  end
+
+  def check_all_sections_rendered(page)
+    expect(page).to have_css '.body-wrapper.left.main'
+    expect(page).to have_css '.body-wrapper.right.attach'
+    expect(page).to have_css 'header'
+    expect(page).to have_css '.role'
+    expect(page).to have_css '.submit'
   end
 end

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -63,30 +63,41 @@ feature 'notice submission' do
     end
   end
 
-  scenario 'submitting a notice with an original attached' do
+  scenario 'attached documents default to type supporting' do
     submit_recent_notice { attach_notice }
 
     notice = Notice.last
-    expect(notice).to have(1).original_document
+    expect(notice).to have(0).original_documents
+    expect(notice).to have(1).supporting_document
   end
 
   scenario 'submitting a notice with a supporting document', js: true do
     submit_recent_notice do
-      add_supporting_document('Some supporting content')
+      add_document('supporting')
     end
 
-    open_recent_notice
+    notice = Notice.last
 
-    within('ol.attachments') do
-      expect(page).to have_link('Supporting Document')
+    expect(notice).to have(0).original_documents
+    expect(notice).to have(1).supporting_document
+  end
+
+  scenario 'submitting a notice with an original document', js: true do
+    submit_recent_notice do
+      add_document('original')
     end
+
+    notice = Notice.last
+
+    expect(notice).to have(1).original_documents
+    expect(notice).to have(0).supporting_documents
   end
 
   scenario 'submitting a notice with multiple supporting documents', js: true do
     submit_recent_notice do
-      add_supporting_document
-      add_supporting_document
-      add_supporting_document
+      add_document('supporting')
+      add_document('supporting')
+      add_document('supporting')
     end
 
     open_recent_notice

--- a/spec/integration/user_submits_typed_notices_spec.rb
+++ b/spec/integration/user_submits_typed_notices_spec.rb
@@ -1,37 +1,41 @@
 require 'rails_helper'
 
-feature "typed notice submissions" do
-  scenario "Non signed-in user cannot see new notice forms" do
+feature 'typed notice submissions' do
+  scenario 'Non signed-in user cannot see new notice forms' do
     visit '/notices/new'
 
     expect(page).to have_content('Direct submission to Lumen is no longer available. If you are interested in sharing with Lumen copies of takedown notices you have sent or received, please contact Lumen.')
   end
 
-  scenario "User submits and views a Trademark notice" do
-    submission = NoticeSubmissionOnPage.new(Trademark, create(:user, :submitter))
+  scenario 'User submits and views a Trademark notice' do
+    submission = NoticeSubmissionOnPage.new(
+      Trademark, create(:user, :submitter)
+    )
     submission.open_submission_form
 
-    submission.fill_in_form_with({
-      "Mark" => "My trademark (TM)",
-      "Infringing URL" => "http://example.com/infringing_url1",
-      "Describe the alleged infringement" => "They used my thing",
-      "Registration Number" => '1337'
-    })
+    submission.fill_in_form_with(
+      'Mark' => 'My trademark (TM)',
+      'Infringing URL' => 'http://example.com/infringing_url1',
+      'Describe the alleged infringement' => 'They used my thing',
+      'Registration Number' => '1337'
+    )
 
-    submission.fill_in_entity_form_with(:recipient, {
-      'Name' => 'Recipient',
-    })
-    submission.fill_in_entity_form_with(:sender, {
-      'Name' => 'Sender',
-    })
+    submission.fill_in_entity_form_with(
+      :recipient,
+      'Name' => 'Recipient'
+    )
+    submission.fill_in_entity_form_with(
+      :sender,
+      'Name' => 'Sender'
+    )
 
     submission.submit
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content("Trademark notice to Recipient")
+    expect(page).to have_content('Trademark notice to Recipient')
 
-    within("#works") do
+    within('#works') do
       expect(page).to have_content('Description of allegedly infringed mark')
       expect(page).to have_content('My trademark (TM)')
     end
@@ -43,97 +47,99 @@ feature "typed notice submissions" do
     end
   end
 
-  scenario "User submits and views a Defamation notice" do
-    submission = NoticeSubmissionOnPage.new(Defamation, create(:user, :submitter))
+  scenario 'User submits and views a Defamation notice' do
+    submission = NoticeSubmissionOnPage.new(
+      Defamation, create(:user, :submitter)
+    )
     submission.open_submission_form
 
-    submission.fill_in_form_with({
-      "Legal Complaint" => "They impuned upon my good character",
-      "Allegedly Defamatory URL" => "http://example.com/defamatory_url1",
-    })
+    submission.fill_in_form_with(
+      'Legal Complaint' => 'They impugned upon my good character',
+      'Allegedly Defamatory URL' => 'http://example.com/defamatory_url1'
+    )
 
-    submission.fill_in_entity_form_with(:recipient, {
-      'Name' => 'Recipient',
-    })
-    submission.fill_in_entity_form_with(:sender, {
-      'Name' => 'Sender',
-    })
+    submission.fill_in_entity_form_with(
+      :recipient,
+      'Name' => 'Recipient'
+    )
+    submission.fill_in_entity_form_with(
+      :sender,
+      'Name' => 'Sender'
+    )
 
     submission.submit
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content("Defamation notice to Recipient")
+    expect(page).to have_content('Defamation notice to Recipient')
 
-    within("#works") do
+    within('#works') do
       expect(page).to have_content('URLs of Allegedly Defamatory Material')
       expect(page).to have_content('http://example.com/defamatory_url1')
     end
 
     within('.notice-body') do
       expect(page).to have_content('Legal Complaint')
-      expect(page).to have_content('They impuned upon my good character')
+      expect(page).to have_content('They impugned upon my good character')
     end
   end
 
-  scenario "User submits and views a Data Protection notice" do
-    submission = NoticeSubmissionOnPage.new(DataProtection, create(:user, :submitter))
+  scenario 'User submits and views a Data Protection notice' do
+    submission = NoticeSubmissionOnPage.new(
+      DataProtection, create(:user, :submitter)
+    )
     submission.open_submission_form
 
-    submission.fill_in_form_with({
-      "Legal Complaint" => "I want to be forgotten",
-      "URL mentioned in request" => "http://example.com/defamatory_url1",
-    })
+    submission.fill_in_form_with(
+      'Legal Complaint' => 'I want to be forgotten',
+      'URL mentioned in request' => 'http://example.com/defamatory_url1'
+    )
 
-    submission.fill_in_entity_form_with(:recipient, {
-      'Name' => 'Recipient',
-    })
-    #submission.fill_in_entity_form_with(:sender, {
-    #  'Name' => 'Sender',
-    #})
+    submission.fill_in_entity_form_with(
+      :recipient,
+      'Name' => 'Recipient'
+    )
 
     submission.submit
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content("Data Protection notice to Recipient")
+    expect(page).to have_content('Data Protection notice to Recipient')
 
-    within("#works") do
+    within('#works') do
       expect(page).to have_content('Location of Some of the Material Requested for Removal')
       expect(page).to have_content('http://example.com/defamatory_url1')
     end
-
-    #within('.notice-body') do
-    #  expect(page).to have_content('Legal Complaint')
-    #  expect(page).to have_content('I want to be forgotten')
-    #end
   end
 
-  scenario "User submits and views a CourtOrder notice" do
-    submission = NoticeSubmissionOnPage.new(CourtOrder, create(:user, :submitter))
+  scenario 'User submits and views a CourtOrder notice' do
+    submission = NoticeSubmissionOnPage.new(
+      CourtOrder, create(:user, :submitter)
+    )
     submission.open_submission_form
 
-    submission.fill_in_form_with({
-      "Subject of Court Order" => "My sweet website", # works.description
-      "Targeted URL" => "http://example.com/targeted_url", # infringing_urls
+    submission.fill_in_form_with(
+      'Subject of Court Order' => 'My sweet website', # works.description
+      'Targeted URL' => 'http://example.com/targeted_url', # infringing_urls
 
-      "Explanation of Court Order" => "I guess they don't like me", #notice.body
-      "Laws Referenced by Court Order" => "USC foo bar 21"
-    })
+      'Explanation of Court Order' => "I guess they don't like me", # notice.body
+      'Laws Referenced by Court Order' => 'USC foo bar 21'
+    )
 
-    %i|recipient sender principal issuing_court plaintiff defendant|.each do |role|
-      submission.fill_in_entity_form_with(role, {
+    %i[recipient sender principal issuing_court plaintiff defendant].each do |role|
+      submission.fill_in_entity_form_with(
+        role,
         'Name' => role.capitalize
-      })
+      )
     end
 
     submission.submit
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content("Court Order notice to Recipient")
+    expect(page).to have_content('Court Order notice to Recipient')
 
-    within("#works") do
+    within('#works') do
       expect(page).to have_content('Targeted URLs')
       expect(page).to have_content('http://example.com/targeted_url')
     end
@@ -145,43 +151,48 @@ feature "typed notice submissions" do
     end
   end
 
-  scenario "User submits and views a Law Enforcement Request notice" do
-    submission = NoticeSubmissionOnPage.new(LawEnforcementRequest, create(:user, :submitter))
+  scenario 'User submits and views a Law Enforcement Request notice' do
+    submission = NoticeSubmissionOnPage.new(
+      LawEnforcementRequest, create(:user, :submitter)
+    )
     submission.open_submission_form
 
-    submission.fill_in_form_with({
-      "Subject of Enforcement Request" => "My Tiny Tim fansite", # works.description
-      "URL of original work" => "http://example.com/original_object1", # copyrighted_urls
-      "URL mentioned in request" => "http://example.com/offending_url1", # infringing_urls
+    submission.fill_in_form_with(
+      'Subject of Enforcement Request' => 'My Tiny Tim fansite', # works.description
+      'URL of original work' => 'http://example.com/original_object1', # copyrighted_urls
+      'URL mentioned in request' => 'http://example.com/offending_url1', # infringing_urls
 
-      "Explanation of Law Enforcement Request" => "I don't get it. He made sick music.", #notice.body
-      "Relevant laws or regulations" => "USC foo bar 21",
-    })
+      'Explanation of Law Enforcement Request' => "I don't get it. He made sick music.", #notice.body
+      'Relevant laws or regulations' => 'USC foo bar 21'
+    )
 
     submission.choose('Civil Subpoena', :request_type)
 
-    submission.fill_in_entity_form_with(:recipient, {
-      'Name' => 'Recipient',
-    })
-    submission.fill_in_entity_form_with(:sender, {
-      'Name' => 'Sender',
-    })
-    submission.fill_in_entity_form_with(:principal, {
-      'Name' => 'Principal Issuing Authority',
-    })
+    submission.fill_in_entity_form_with(
+      :recipient,
+      'Name' => 'Recipient'
+    )
+    submission.fill_in_entity_form_with(
+      :sender,
+      'Name' => 'Sender'
+    )
+    submission.fill_in_entity_form_with(
+      :principal,
+      'Name' => 'Principal Issuing Authority'
+    )
 
     submission.submit
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content("Law Enforcement Request notice to Recipient")
+    expect(page).to have_content('Law Enforcement Request notice to Recipient')
 
-    within("#works") do
+    within('#works') do
       expect(page).to have_content('URLs mentioned in request')
       expect(page).to have_content('http://example.com/offending_url1')
       expect(page).to have_content('URLs of original work')
       expect(page).to have_content('http://example.com/original_object1')
-      expect(page).to have_content("My Tiny Tim fansite")
+      expect(page).to have_content('My Tiny Tim fansite')
     end
 
     within('.notice-body') do
@@ -196,31 +207,35 @@ feature "typed notice submissions" do
     end
   end
 
-  scenario "User submits and views a PrivateInformation notice" do
-    submission = NoticeSubmissionOnPage.new(PrivateInformation, create(:user, :submitter))
+  scenario 'User submits and views a PrivateInformation notice' do
+    submission = NoticeSubmissionOnPage.new(
+      PrivateInformation, create(:user, :submitter)
+    )
     submission.open_submission_form
 
-    submission.fill_in_form_with({
-      "Type of information" => "These URLs disclose my existence", # works.description
-      "URL with private information" => "http://example.com/offending_url1", # infringing_urls
+    submission.fill_in_form_with(
+      'Type of information' => 'These URLs disclose my existence', # works.description
+      'URL with private information' => 'http://example.com/offending_url1', # infringing_urls
 
-      "Explanation of Complaint" => "I am in witness protection", #notice.body
-    })
+      'Explanation of Complaint' => 'I am in witness protection' # notice.body
+    )
 
-    submission.fill_in_entity_form_with(:recipient, {
-      'Name' => 'Recipient',
-    })
-    submission.fill_in_entity_form_with(:sender, {
-      'Name' => 'Sender',
-    })
+    submission.fill_in_entity_form_with(
+      :recipient,
+      'Name' => 'Recipient'
+    )
+    submission.fill_in_entity_form_with(
+      :sender,
+      'Name' => 'Sender'
+    )
 
     submission.submit
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content("Private Information notice to Recipient")
+    expect(page).to have_content('Private Information notice to Recipient')
 
-    within("#works") do
+    within('#works') do
       expect(page).to have_content('URLs with private information')
       expect(page).to have_content('http://example.com/offending_url1')
       expect(page).to have_content('URLs of original work')
@@ -233,32 +248,34 @@ feature "typed notice submissions" do
     end
   end
 
-  scenario "User submits and views an Other notice" do
+  scenario 'User submits and views an Other notice' do
     submission = NoticeSubmissionOnPage.new(Other, create(:user, :submitter))
     submission.open_submission_form
 
-    submission.fill_in_form_with({
-      "Complaint" => "These URLs are a serious problem", # works.description
-      "Original Work URL" => "http://example.com/original_object1", # copyrighted_urls
-      "Problematic URL" => "http://example.com/offending_url1", # infringing_urls
+    submission.fill_in_form_with(
+      'Complaint' => 'These URLs are a serious problem', # works.description
+      'Original Work URL' => 'http://example.com/original_object1', # copyrighted_urls
+      'Problematic URL' => 'http://example.com/offending_url1', # infringing_urls
 
-      "Explanation of Complaint" => "I am complaining", # notice.body
-    })
+      'Explanation of Complaint' => 'I am complaining' # notice.body
+    )
 
-    submission.fill_in_entity_form_with(:recipient, {
-      'Name' => 'Recipient',
-    })
-    submission.fill_in_entity_form_with(:sender, {
-      'Name' => 'Sender',
-    })
+    submission.fill_in_entity_form_with(
+      :recipient,
+      'Name' => 'Recipient'
+    )
+    submission.fill_in_entity_form_with(
+      :sender,
+      'Name' => 'Sender'
+    )
 
     submission.submit
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content("Other notice to Recipient")
+    expect(page).to have_content('Other notice to Recipient')
 
-    within("#works") do
+    within('#works') do
       expect(page).to have_content('Problematic URLs')
       expect(page).to have_content('http://example.com/offending_url1')
       expect(page).to have_content('URLs of original work')
@@ -272,17 +289,19 @@ feature "typed notice submissions" do
     end
   end
 
-  scenario "Entities can have different default types depending on role" do
-    submission = NoticeSubmissionOnPage.new(CourtOrder, create(:user, :submitter))
+  scenario 'Entities can have different default types depending on role' do
+    submission = NoticeSubmissionOnPage.new(
+      CourtOrder, create(:user, :submitter)
+    )
     submission.open_submission_form
 
     submission.within_entity_with_role('issuing_court') do
-      expect(page).to have_select('Issuing Court Type', selected: 'organization')
+      expect(page).to have_select('Issuing Court Type',
+                                  selected: 'organization')
     end
 
     submission.within_entity_with_role('sender') do
       expect(page).to have_select('Sender Type', selected: 'individual')
     end
   end
-
 end

--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -61,8 +61,6 @@ RSpec.configure do |config|
 
   # Stop elasticsearch cluster after test run
   config.after :suite do
-    if Elasticsearch::Extensions::Test::Cluster.running?(on: es_port)
-      Elasticsearch::Extensions::Test::Cluster.stop(**es_options)
-    end
+    Elasticsearch::Extensions::Test::Cluster.stop(**es_options)
   end
 end

--- a/spec/support/notice_actions.rb
+++ b/spec/support/notice_actions.rb
@@ -36,21 +36,25 @@ module NoticeActions
     within('#recent-notices li:nth-child(1)') { find('a').click }
   end
 
-  def attach_notice(content = 'Some content')
+  def attach_notice(content: 'Some content')
     with_file(content) { |file| attach_file 'Attach Notice', file.path }
   end
 
-  def add_supporting_document(content = 'Some content')
+  def add_document(kind = 'supporting')
     @field_index ||= 0
-    @field_index  += 1
 
-    click_on 'Attach another'
+    if @field_index > 0
+      click_on 'Attach another'
+      sleep 0.2
+    end
 
     field_name = "notice_file_uploads_attributes_#{@field_index}_file"
 
-    with_file(content) do |file|
+    with_file('some content') do |file|
       attach_file field_name, file.path
     end
+    select kind, from: "notice_file_uploads_attributes_#{@field_index}_kind"
+    @field_index += 1
   end
 
   def with_file(content)


### PR DESCRIPTION
## Ready for merge?
__YES__

## What does this PR do?
Fixes bug which caused the kind of document (original/supporting) not to be set correctly through the web form.

This work is preceded by a refactor of the forms templates so as to make the bugfix easy. We originally had entirely separate form templates for each type of Notice, even though the templates were broadly duplicative. This refactors those all into unified templates with some if conditions to allow for the slight differences, which makes it possible to apply the bugfix in ONE location rather than ten.

There's also some css tweaks and linting that arose along the way.

## Helpful background context (if appropriate)
Files attached through the webform were getting miscategorized as "original". (We actually had a client who would attach the same file twice so as to make the second come through as "supporting", which was their original intent.)

## How can a reviewer manually see the effects of these changes?
* Go to notices/new/type=Whatever
* You will see a dropdown for document kind which is not present on production
* Click 'attach another' - you will get a pair of additional fields for file + kind
* Set those dropdowns as you like - you will see that the document kinds you select are persisted in the db and reflected in the UI at notices/X

## What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/14893

## Screenshots (if appropriate)
Todo:
- [x] Tests
- ~~[  ]  Documentation~~
- [x] Stakeholder approval

## Requires Database Migrations?
__NO__

## Includes new or updated dependencies?
__NO__