### PR TITLE
Render different message for hidden than unpublished messages

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -32,7 +32,12 @@ class NoticesController < ApplicationController
       format.html do
         if @notice.rescinded?
           render :rescinded
-        elsif @notice.hidden || @notice.spam || !@notice.published
+        elsif @notice.hidden
+          render file: 'public/404_hidden',
+                 formats: [:html],
+                 status: :not_found,
+                 layout: false
+        elsif @notice.spam || !@notice.published
           render file: 'public/404_unavailable',
                  formats: [:html],
                  status: :not_found,

--- a/public/404_hidden.html
+++ b/public/404_hidden.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta charset="utf-8">
+  <meta name='ROBOTS' content='NOODP' />
+  <title>Lumen - 404 Error</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="/error_style.css" rel="stylesheet" type="text/css">
+</head>
+<body class="home">
+  <nav class="main-nav">&nbsp;</nav>
+  <section class="main home">
+    <section class="home-search-form">
+      <a href="/"><h1><img alt="Lumen Logo" src="/assets/logo_2x.png" height="52" width="340"></h1></a>
+    </section>
+
+      <div class="site-news">
+        <section>
+          <h2>Notice Unavailable</h2>
+          <ol>
+            <li>
+      			 <p>Thank you for visiting Lumen. Our apologies, but the notice you requested is not available.</p>
+            </li>
+          </ol>
+        </section>
+      </div>
+  </section>
+  <footer class="main">
+    <div class="inner-wrapper">
+      <span>© 2015 Lumen</span>
+    </div>
+  </footer>
+</body>
+</html>

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -29,6 +29,33 @@ describe NoticesController do
         expect(response).to be_successful
         expect(response).to render_template(:rescinded)
       end
+
+      it 'renders the unavailable template if the notice is spam' do
+        stub_find_notice(build(:dmca, spam: true))
+
+        get :show, id: 1
+
+        expect(response.status).to eq(404)
+        expect(response).to render_template(file: '404_unavailable.html')
+      end
+
+      it 'renders the unavailable template if the notice is unpublished' do
+        stub_find_notice(build(:dmca, published: false))
+
+        get :show, id: 1
+
+        expect(response.status).to eq(404)
+        expect(response).to render_template(file: '404_unavailable.html')
+      end
+
+      it 'renders the hidden template if the notice is hidden' do
+        stub_find_notice(build(:dmca, hidden: true))
+
+        get :show, id: 1
+
+        expect(response.status).to eq(404)
+        expect(response).to render_template(file: '404_hidden.html')
+      end
     end
 
     context 'as JSON' do


### PR DESCRIPTION
Some notices must be hidden due to e.g. ongoing legal proceedings and
it would be misleading to say that they will eventually become
available. Therefore we use a stripped-down 404 message for hidden
notices.

## Ready for merge?
**YES**

#### What does this PR do?
see above

#### Helpful background context (if appropriate)
see ticket

#### How can a reviewer manually see the effects of these changes?
compare /notices/X for a hidden notice on this branch vs dev

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15812

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- ~~[ ] Documentation~~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
