### PR TITLE
15439 more submitters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ config/database.yml
 .idea/*
 .byebug_history
 .rubocop.yml
+rspec_examples.txt

--- a/app/models/counternotice.rb
+++ b/app/models/counternotice.rb
@@ -1,10 +1,10 @@
 class Counternotice < Notice
-
   define_elasticsearch_mapping
 
-  DEFAULT_ENTITY_NOTICE_ROLES = %w|recipient sender principal submitter|
+  DEFAULT_ENTITY_NOTICE_ROLES = (BASE_ENTITY_NOTICE_ROLES |
+                                %w[recipient sender principal submitter]).freeze
 
-  REASONS = %w( owner authorized no_right fair_use removed not_used other )
+  REASONS = %w[owner authorized no_right fair_use removed not_used other].freeze
 
   validates :title, length: { maximum: 255 }
 

--- a/app/models/court_order.rb
+++ b/app/models/court_order.rb
@@ -1,6 +1,7 @@
 class CourtOrder < Notice
-
-  DEFAULT_ENTITY_NOTICE_ROLES = %w|recipient sender principal issuing_court plaintiff defendant|
+  DEFAULT_ENTITY_NOTICE_ROLES = (BASE_ENTITY_NOTICE_ROLES |
+                                %w[recipient sender principal issuing_court
+                                   plaintiff defendant]).freeze
   acts_as_taggable_on :regulations
 
   define_elasticsearch_mapping

--- a/app/models/data_protection.rb
+++ b/app/models/data_protection.rb
@@ -11,5 +11,4 @@ class DataProtection < Notice
   def to_partial_path
     'notices/notice'
   end
-
 end

--- a/app/models/data_protection.rb
+++ b/app/models/data_protection.rb
@@ -1,6 +1,7 @@
 class DataProtection < Notice
-  
-  DEFAULT_ENTITY_NOTICE_ROLES = %w|recipient|
+  DEFAULT_ENTITY_NOTICE_ROLES = (BASE_ENTITY_NOTICE_ROLES |
+                                 %w[recipient]).freeze
+
   define_elasticsearch_mapping
 
   def self.model_name
@@ -10,5 +11,5 @@ class DataProtection < Notice
   def to_partial_path
     'notices/notice'
   end
-  
+
 end

--- a/app/models/defamation.rb
+++ b/app/models/defamation.rb
@@ -1,6 +1,6 @@
 class Defamation < Notice
-	MASK = "REDACTED"
-	REDACTION_REGEX = /google/i
+  MASK = 'REDACTED'.freeze
+  REDACTION_REGEX = /google/i
 
   define_elasticsearch_mapping(works: [:description])
 
@@ -31,5 +31,4 @@ class Defamation < Notice
   def hide_identities?
     recipient_name =~ REDACTION_REGEX
   end
-
 end

--- a/app/models/dmca.rb
+++ b/app/models/dmca.rb
@@ -1,8 +1,8 @@
 class DMCA < Notice
-
   define_elasticsearch_mapping
 
-  DEFAULT_ENTITY_NOTICE_ROLES = %w|recipient sender principal submitter|
+  DEFAULT_ENTITY_NOTICE_ROLES = (BASE_ENTITY_NOTICE_ROLES |
+                                %w[recipient sender principal]).freeze
 
   validates :title, length: { maximum: 255 }
 

--- a/app/models/government_request.rb
+++ b/app/models/government_request.rb
@@ -1,5 +1,6 @@
 class GovernmentRequest < Notice
-  DEFAULT_ENTITY_NOTICE_ROLES = %w[recipient sender principal submitter].freeze
+  DEFAULT_ENTITY_NOTICE_ROLES = (BASE_ENTITY_NOTICE_ROLES |
+                                %w[recipient sender principal submitter]).freeze
   acts_as_taggable_on :regulations
 
   define_elasticsearch_mapping

--- a/app/models/law_enforcement_request.rb
+++ b/app/models/law_enforcement_request.rb
@@ -1,6 +1,6 @@
 class LawEnforcementRequest < Notice
-
-  DEFAULT_ENTITY_NOTICE_ROLES = %w|recipient sender principal|
+  DEFAULT_ENTITY_NOTICE_ROLES = (BASE_ENTITY_NOTICE_ROLES |
+                                %w[recipient sender principal]).freeze
   acts_as_taggable_on :regulations
 
   define_elasticsearch_mapping
@@ -11,11 +11,12 @@ class LawEnforcementRequest < Notice
     'Email',
     'Records Preservation',
     'Subpoena',
-    'Warrant',
-  ]
+    'Warrant'
+  ].freeze
 
   validates_inclusion_of :request_type,
-    in: VALID_REQUEST_TYPES, allow_blank: true
+                         in: VALID_REQUEST_TYPES,
+                         allow_blank: true
 
   def self.model_name
     Notice.model_name

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -55,7 +55,13 @@ class Notice < ActiveRecord::Base
   UNDER_REVIEW_VALUE = 'Under review'
   RANGE_SEPARATOR = '..'
 
-  DEFAULT_ENTITY_NOTICE_ROLES = %w|recipient sender|
+  # Base entity notice roles allow us to define additional roles on subclasses
+  # without having to keep track of what they are on notice. As long as
+  # subclasses define DEFAULT_ENTITY_NOTICE_ROLES =
+  # BASE_ENTITY_NOTICE_ROLES | local_roles, the OR will preserve all elements
+  # of both.
+  BASE_ENTITY_NOTICE_ROLES = %w[recipient sender submitter].freeze
+  DEFAULT_ENTITY_NOTICE_ROLES = BASE_ENTITY_NOTICE_ROLES
 
   VALID_ACTIONS = %w( Yes No Partial Unspecified )
 

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -8,10 +8,10 @@ class Notice < ActiveRecord::Base
 
   extend RecentScope
 
-  HIGHLIGHTS = %i(
+  HIGHLIGHTS = %i[
     title tag_list topics.name sender_name recipient_name
     works.description works.infringing_urls.url works.copyrighted_urls.url
-  )
+  ].freeze
 
   SEARCHABLE_FIELDS = [
     TermSearch.new(:term, :_all, 'All Fields'),
@@ -25,8 +25,8 @@ class Notice < ActiveRecord::Base
     TermSearch.new(:submitter_name, :submitter_name, 'Submitter Name'),
     TermSearch.new(:submitter_country_code, :submitter_country_code, 'Submitter Country'),
     TermSearch.new(:works, 'works.description', 'Works Descriptions'),
-    TermSearch.new(:action_taken, :action_taken, 'Action taken'),
-  ]
+    TermSearch.new(:action_taken, :action_taken, 'Action taken')
+  ].freeze
 
   FILTERABLE_FIELDS = [
     TermFilter.new(:topic_facet, 'Topic'),
@@ -40,20 +40,20 @@ class Notice < ActiveRecord::Base
     TermFilter.new(:submitter_country_code_facet, 'Submitter Country'),
     UnspecifiedTermFilter.new(:action_taken_facet, 'Action taken'),
     DateRangeFilter.new(:date_received_facet, :date_received, 'Date')
-  ]
+  ].freeze
 
   SORTINGS = [
     Sorting.new('relevancy desc', [:_score, :desc], 'Most Relevant'),
     Sorting.new('relevancy asc', [:_score, :asc], 'Least Relevant'),
-    Sorting.new('date_received desc', [:date_received, :desc],  'Newest'),
-    Sorting.new('date_received asc', [:date_received, :asc],  'Oldest'),
-  ]
+    Sorting.new('date_received desc', [:date_received, :desc], 'Newest'),
+    Sorting.new('date_received asc', [:date_received, :asc], 'Oldest')
+  ].freeze
 
-  REDACTABLE_FIELDS = %i( body )
+  REDACTABLE_FIELDS = %i[body].freeze
   PER_PAGE = 10
 
-  UNDER_REVIEW_VALUE = 'Under review'
-  RANGE_SEPARATOR = '..'
+  UNDER_REVIEW_VALUE = 'Under review'.freeze
+  RANGE_SEPARATOR = '..'.freeze
 
   # Base entity notice roles allow us to define additional roles on subclasses
   # without having to keep track of what they are on notice. As long as
@@ -63,22 +63,22 @@ class Notice < ActiveRecord::Base
   BASE_ENTITY_NOTICE_ROLES = %w[recipient sender submitter].freeze
   DEFAULT_ENTITY_NOTICE_ROLES = BASE_ENTITY_NOTICE_ROLES
 
-  VALID_ACTIONS = %w( Yes No Partial Unspecified )
+  VALID_ACTIONS = %w[Yes No Partial Unspecified].freeze
 
-  OTHER_TOPIC = "Uncategorized"
+  OTHER_TOPIC = 'Uncategorized'.freeze
 
   TYPES_TO_TOPICS = {
-    'DMCA'                  => "Copyright",
-    'Counternotice'         => "Copyright",
-    'Trademark'             => "Trademark",
-    'Defamation'            => "Defamation",
-    'CourtOrder'            => "Court Orders",
-    'LawEnforcementRequest' => "Law Enforcement Requests",
-    'PrivateInformation'    => "Right of Publicity",
-    'DataProtection'        => "EU - Right to Be Forgotten",
-    'GovernmentRequest'     => "Government Requests",
+    'DMCA'                  => 'Copyright',
+    'Counternotice'         => 'Copyright',
+    'Trademark'             => 'Trademark',
+    'Defamation'            => 'Defamation',
+    'CourtOrder'            => 'Court Orders',
+    'LawEnforcementRequest' => 'Law Enforcement Requests',
+    'PrivateInformation'    => 'Right of Publicity',
+    'DataProtection'        => 'EU - Right to Be Forgotten',
+    'GovernmentRequest'     => 'Government Requests',
     'Other'                 => OTHER_TOPIC
-  }
+  }.freeze
 
   TYPES = TYPES_TO_TOPICS.keys
   TOPICS = TYPES_TO_TOPICS.values
@@ -132,13 +132,13 @@ class Notice < ActiveRecord::Base
   accepts_nested_attributes_for :file_uploads,
     reject_if: ->(attributes) { [attributes['file'], attributes[:pdf_request_fulfilled]].all?(&:blank?) }
 
-  accepts_nested_attributes_for :entity_notice_roles, :allow_destroy => true
+  accepts_nested_attributes_for :entity_notice_roles, allow_destroy: true
 
-  accepts_nested_attributes_for :works, :allow_destroy => true
+  accepts_nested_attributes_for :works, allow_destroy: true
 
   delegate :country_code, to: :recipient, allow_nil: true
 
-  %i( sender principal recipient submitter attorney ).each do |entity|
+  %i[sender principal recipient submitter attorney] .each do |entity|
     delegate :name, :country_code, to: entity, prefix: true, allow_nil: true
   end
 
@@ -156,7 +156,7 @@ class Notice < ActiveRecord::Base
   end
 
   def self.type_models
-    ( TYPES - ['Counternotice'] ).map(&:constantize)
+    (TYPES - ['Counternotice']).map(&:constantize).freeze
   end
 
   def self.available_for_review
@@ -173,14 +173,15 @@ class Notice < ActiveRecord::Base
   end
 
   def self.in_topics(topics)
-    joins(topic_assignments: :topic).
-      where('topics.id' => topics).uniq
+    joins(topic_assignments: :topic)
+      .where('topics.id' => topics)
+      .uniq
   end
 
   def self.submitted_by(submitters)
-    joins(entity_notice_roles: :entity).
-      where('entity_notice_roles.name' => :submitter).
-      where('entities.id' => submitters)
+    joins(entity_notice_roles: :entity)
+      .where('entity_notice_roles.name' => :submitter)
+      .where('entities.id' => submitters)
   end
 
   def self.add_default_filter(search)
@@ -203,12 +204,10 @@ class Notice < ActiveRecord::Base
   end
 
   def self.find_unpublished(notice_id)
-    begin
-      self.where(spam: false, hidden: false, published: false).find(notice_id)
-      return true
-    rescue
-      return false
-    end
+    self.where(spam: false, hidden: false, published: false).find(notice_id)
+    true
+  rescue
+    false
   end
 
   def active_model_serializer
@@ -263,10 +262,10 @@ class Notice < ActiveRecord::Base
   end
 
   def next_requiring_review
-    self.class.
-      where('id > ? and review_required = ?', id, true).
-      order('id asc').
-      first
+    self.class
+      .where('id > ? and review_required = ?', id, true)
+      .order('id asc')
+      .first
   end
 
   def tag_list
@@ -279,11 +278,11 @@ class Notice < ActiveRecord::Base
 
   def tag_list=(tag_list_value = '')
     unless tag_list_value.nil?
-      if tag_list_value.respond_to?(:each)
-        tag_list_value = tag_list_value.flatten.map{|tag|tag.downcase}
-      else
-        tag_list_value = tag_list_value.downcase
-      end
+      tag_list_value = if tag_list_value.respond_to?(:each)
+                         tag_list_value.flatten.map(&:downcase)
+                       else
+                         tag_list_value.downcase
+                       end
     end
 
     super(tag_list_value)
@@ -298,9 +297,8 @@ class Notice < ActiveRecord::Base
   end
 
   def on_behalf_of_principal?
-    if sender_name.present?
-      principal_name.present? && principal_name != sender_name
-    end
+    return unless sender_name.present?
+    principal_name.present? && principal_name != sender_name
   end
 
   def publication_delay
@@ -322,7 +320,7 @@ class Notice < ActiveRecord::Base
 
   def notice_topic_map
     topic = TYPES_TO_TOPICS.key?(self.type) ? TYPES_TO_TOPICS[self.type] : OTHER_TOPIC
-    return Topic.find_or_create_by(name: topic)
+    Topic.find_or_create_by(name: topic)
   end
 
   def hide_identities?

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -60,8 +60,9 @@ class Notice < ActiveRecord::Base
   # subclasses define DEFAULT_ENTITY_NOTICE_ROLES =
   # BASE_ENTITY_NOTICE_ROLES | local_roles, the OR will preserve all elements
   # of both.
-  BASE_ENTITY_NOTICE_ROLES = %w[recipient sender submitter].freeze
-  DEFAULT_ENTITY_NOTICE_ROLES = BASE_ENTITY_NOTICE_ROLES
+  BASE_ENTITY_NOTICE_ROLES = %w[submitter].freeze
+  DEFAULT_ENTITY_NOTICE_ROLES = (BASE_ENTITY_NOTICE_ROLES |
+                                 %w[recipient sender]).freeze
 
   VALID_ACTIONS = %w[Yes No Partial Unspecified].freeze
 

--- a/app/models/other.rb
+++ b/app/models/other.rb
@@ -1,5 +1,5 @@
 class Other < Notice
-  MASK = "REDACTED"
+  MASK = 'REDACTED'.freeze
   REDACTION_REGEX = /google/i
 
   define_elasticsearch_mapping(works: [:description])

--- a/app/models/private_information.rb
+++ b/app/models/private_information.rb
@@ -1,5 +1,4 @@
 class PrivateInformation < Notice
-
   define_elasticsearch_mapping
 
   def self.model_name

--- a/app/models/trademark.rb
+++ b/app/models/trademark.rb
@@ -1,5 +1,4 @@
 class Trademark < Notice
-
   define_elasticsearch_mapping
 
   def self.model_name

--- a/spec/integration/user_submits_typed_notices_spec.rb
+++ b/spec/integration/user_submits_typed_notices_spec.rb
@@ -20,14 +20,12 @@ feature 'typed notice submissions' do
       'Registration Number' => '1337'
     )
 
-    submission.fill_in_entity_form_with(
-      :recipient,
-      'Name' => 'Recipient'
-    )
-    submission.fill_in_entity_form_with(
-      :sender,
-      'Name' => 'Sender'
-    )
+    Trademark::DEFAULT_ENTITY_NOTICE_ROLES.each do |role|
+      submission.fill_in_entity_form_with(
+        role,
+        'Name' => role.capitalize
+      )
+    end
 
     submission.submit
 
@@ -54,18 +52,16 @@ feature 'typed notice submissions' do
     submission.open_submission_form
 
     submission.fill_in_form_with(
-      'Legal Complaint' => 'They impugned upon my good character',
+      'Legal Complaint' => 'They impugned my good character',
       'Allegedly Defamatory URL' => 'http://example.com/defamatory_url1'
     )
 
-    submission.fill_in_entity_form_with(
-      :recipient,
-      'Name' => 'Recipient'
-    )
-    submission.fill_in_entity_form_with(
-      :sender,
-      'Name' => 'Sender'
-    )
+    Defamation::DEFAULT_ENTITY_NOTICE_ROLES.each do |role|
+      submission.fill_in_entity_form_with(
+        role,
+        'Name' => role.capitalize
+      )
+    end
 
     submission.submit
 
@@ -80,7 +76,7 @@ feature 'typed notice submissions' do
 
     within('.notice-body') do
       expect(page).to have_content('Legal Complaint')
-      expect(page).to have_content('They impugned upon my good character')
+      expect(page).to have_content('They impugned my good character')
     end
   end
 
@@ -95,10 +91,12 @@ feature 'typed notice submissions' do
       'URL mentioned in request' => 'http://example.com/defamatory_url1'
     )
 
-    submission.fill_in_entity_form_with(
-      :recipient,
-      'Name' => 'Recipient'
-    )
+    DataProtection::DEFAULT_ENTITY_NOTICE_ROLES.each do |role|
+      submission.fill_in_entity_form_with(
+        role,
+        'Name' => role.capitalize
+      )
+    end
 
     submission.submit
 
@@ -107,7 +105,9 @@ feature 'typed notice submissions' do
     expect(page).to have_content('Data Protection notice to Recipient')
 
     within('#works') do
-      expect(page).to have_content('Location of Some of the Material Requested for Removal')
+      expect(page).to have_content(
+        'Location of Some of the Material Requested for Removal'
+      )
       expect(page).to have_content('http://example.com/defamatory_url1')
     end
   end
@@ -121,12 +121,11 @@ feature 'typed notice submissions' do
     submission.fill_in_form_with(
       'Subject of Court Order' => 'My sweet website', # works.description
       'Targeted URL' => 'http://example.com/targeted_url', # infringing_urls
-
       'Explanation of Court Order' => "I guess they don't like me", # notice.body
       'Laws Referenced by Court Order' => 'USC foo bar 21'
     )
 
-    %i[recipient sender principal issuing_court plaintiff defendant].each do |role|
+    CourtOrder::DEFAULT_ENTITY_NOTICE_ROLES.each do |role|
       submission.fill_in_entity_form_with(
         role,
         'Name' => role.capitalize
@@ -161,25 +160,18 @@ feature 'typed notice submissions' do
       'Subject of Enforcement Request' => 'My Tiny Tim fansite', # works.description
       'URL of original work' => 'http://example.com/original_object1', # copyrighted_urls
       'URL mentioned in request' => 'http://example.com/offending_url1', # infringing_urls
-
       'Explanation of Law Enforcement Request' => "I don't get it. He made sick music.", #notice.body
       'Relevant laws or regulations' => 'USC foo bar 21'
     )
 
     submission.choose('Civil Subpoena', :request_type)
 
-    submission.fill_in_entity_form_with(
-      :recipient,
-      'Name' => 'Recipient'
-    )
-    submission.fill_in_entity_form_with(
-      :sender,
-      'Name' => 'Sender'
-    )
-    submission.fill_in_entity_form_with(
-      :principal,
-      'Name' => 'Principal Issuing Authority'
-    )
+    LawEnforcementRequest::DEFAULT_ENTITY_NOTICE_ROLES.each do |role|
+      submission.fill_in_entity_form_with(
+        role,
+        'Name' => role.capitalize
+      )
+    end
 
     submission.submit
 
@@ -203,7 +195,7 @@ feature 'typed notice submissions' do
     end
 
     within('#entities') do
-      expect(page).to have_content('Principal Issuing Authority')
+      expect(page).to have_content('Principal')
     end
   end
 
@@ -216,18 +208,15 @@ feature 'typed notice submissions' do
     submission.fill_in_form_with(
       'Type of information' => 'These URLs disclose my existence', # works.description
       'URL with private information' => 'http://example.com/offending_url1', # infringing_urls
-
-      'Explanation of Complaint' => 'I am in witness protection' # notice.body
+      'Explanation of Complaint' => 'I am in witness protection', #notice.body
     )
 
-    submission.fill_in_entity_form_with(
-      :recipient,
-      'Name' => 'Recipient'
-    )
-    submission.fill_in_entity_form_with(
-      :sender,
-      'Name' => 'Sender'
-    )
+    PrivateInformation::DEFAULT_ENTITY_NOTICE_ROLES.each do |role|
+      submission.fill_in_entity_form_with(
+        role,
+        'Name' => role.capitalize
+      )
+    end
 
     submission.submit
 
@@ -256,18 +245,15 @@ feature 'typed notice submissions' do
       'Complaint' => 'These URLs are a serious problem', # works.description
       'Original Work URL' => 'http://example.com/original_object1', # copyrighted_urls
       'Problematic URL' => 'http://example.com/offending_url1', # infringing_urls
-
-      'Explanation of Complaint' => 'I am complaining' # notice.body
+      'Explanation of Complaint' => 'I am complaining', # notice.body
     )
 
-    submission.fill_in_entity_form_with(
-      :recipient,
-      'Name' => 'Recipient'
-    )
-    submission.fill_in_entity_form_with(
-      :sender,
-      'Name' => 'Sender'
-    )
+    Other::DEFAULT_ENTITY_NOTICE_ROLES.each do |role|
+      submission.fill_in_entity_form_with(
+        role,
+        'Name' => role.capitalize
+      )
+    end
 
     submission.submit
 

--- a/spec/models/court_order_spec.rb
+++ b/spec/models/court_order_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
-RSpec.describe DataProtection, type: :model do
+RSpec.describe CourtOrder, type: :model do
   it 'has the expected entity notice roles' do
-    expected = %w[recipient submitter]
+    expected = %w[recipient sender principal issuing_court
+                  plaintiff defendant submitter]
     expect(described_class::DEFAULT_ENTITY_NOTICE_ROLES).to match_array expected
   end
 end

--- a/spec/models/defamation_spec.rb
+++ b/spec/models/defamation_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-RSpec.describe DataProtection, type: :model do
+RSpec.describe Defamation, type: :model do
   it 'has the expected entity notice roles' do
-    expected = %w[recipient submitter]
+    expected = %w[recipient sender submitter]
     expect(described_class::DEFAULT_ENTITY_NOTICE_ROLES).to match_array expected
   end
 end

--- a/spec/models/dmca_spec.rb
+++ b/spec/models/dmca_spec.rb
@@ -41,8 +41,13 @@ describe DMCA, type: :model do
   end
 
   context 'entity notice roles' do
+    it 'has the expected entity notice roles' do
+      expected = %w[recipient sender principal submitter]
+      expect(described_class::DEFAULT_ENTITY_NOTICE_ROLES).to match_array expected
+    end
+
     context 'with entities' do
-      %w[sender principal recipient].each do |role_name|
+      described_class::DEFAULT_ENTITY_NOTICE_ROLES.each do |role_name|
         context "##{role_name}" do
           it "returns entity of type #{role_name}" do
             # note: must use role names we're not testing in the factory

--- a/spec/models/government_request_spec.rb
+++ b/spec/models/government_request_spec.rb
@@ -1,8 +1,6 @@
-require 'rails_helper'
+require 'spec_helper'
 
-describe Counternotice, type: :model do
-  it { is_expected.to validate_presence_of :entity_notice_roles }
-
+RSpec.describe GovernmentRequest, type: :model do
   it 'has the expected entity notice roles' do
     expected = %w[recipient sender principal submitter]
     expect(described_class::DEFAULT_ENTITY_NOTICE_ROLES).to match_array expected

--- a/spec/models/law_enforcement_request_spec.rb
+++ b/spec/models/law_enforcement_request_spec.rb
@@ -1,16 +1,24 @@
 require 'spec_helper'
 
 describe LawEnforcementRequest, type: :model do
-  it { is_expected.to validate_inclusion_of(:request_type).
-    in_array(described_class::VALID_REQUEST_TYPES).allow_blank(true) }
+  it {
+    is_expected.to validate_inclusion_of(:request_type)
+      .in_array(described_class::VALID_REQUEST_TYPES).allow_blank(true)
+  }
 
-  it "has additional entities" do
+  it 'has additional entities' do
     notice = create(
       :court_order,
-      role_names: %w|recipient sender principal issuing_court plaintiff defendant|
+      role_names: %w[recipient sender principal issuing_court plaintiff
+                     defendant]
     )
     expect(notice.other_entity_notice_roles.map(&:name)).to match_array(
-      %w|defendant issuing_court plaintiff principal|
+      %w[defendant issuing_court plaintiff principal]
     )
+  end
+
+  it 'has the expected entity notice roles' do
+    expected = %w[recipient sender principal submitter]
+    expect(described_class::DEFAULT_ENTITY_NOTICE_ROLES).to match_array expected
   end
 end

--- a/spec/models/other_spec.rb
+++ b/spec/models/other_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-RSpec.describe DataProtection, type: :model do
+RSpec.describe Other, type: :model do
   it 'has the expected entity notice roles' do
-    expected = %w[recipient submitter]
+    expected = %w[recipient sender submitter]
     expect(described_class::DEFAULT_ENTITY_NOTICE_ROLES).to match_array expected
   end
 end

--- a/spec/models/private_information_spec.rb
+++ b/spec/models/private_information_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-RSpec.describe DataProtection, type: :model do
+RSpec.describe PrivateInformation, type: :model do
   it 'has the expected entity notice roles' do
-    expected = %w[recipient submitter]
+    expected = %w[recipient sender submitter]
     expect(described_class::DEFAULT_ENTITY_NOTICE_ROLES).to match_array expected
   end
 end

--- a/spec/models/trademark_spec.rb
+++ b/spec/models/trademark_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-RSpec.describe DataProtection, type: :model do
+RSpec.describe Trademark, type: :model do
   it 'has the expected entity notice roles' do
-    expected = %w[recipient submitter]
+    expected = %w[recipient sender submitter]
     expect(described_class::DEFAULT_ENTITY_NOTICE_ROLES).to match_array expected
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   config.order = 'random'
+  config.example_status_persistence_file_path = 'rspec_examples.txt'
 
   # If you need to see the order your specs are running in (i.e. to debug
   # order-dependent test failures), uncomment the following. But you may find


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Adds 'submitter' as a default on all `Notice` subclasses.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Look at the forms for Notice subclasses on localhost vs production - all Notice types should include a 
submitter metadata section on localhost, even though not all of them do on prod.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15439

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation _(inline)_
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
