### PR TITLE
Bugfix Notice deletion

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -137,7 +137,11 @@ class Notice < ActiveRecord::Base
   end
 
   after_create :set_published!, if: :submitter
-  after_destroy :remove_from_index
+  # This may fail in the dev environment if you don't have ES up and running,
+  # but is works in other envs.
+  after_destroy do
+    __elasticsearch__.delete_document ignore: 404
+  end
 
   define_elasticsearch_mapping
 
@@ -348,9 +352,5 @@ class Notice < ActiveRecord::Base
 
   def attorneys
     entity_notice_roles.attorneys.map(&:entity)
-  end
-
-  def remove_from_index
-    self.index.remove self
   end
 end

--- a/spec/integration/rails_admin_dashboard_spec.rb
+++ b/spec/integration/rails_admin_dashboard_spec.rb
@@ -1,13 +1,11 @@
 require 'rails_helper'
 
-feature "Rails admin dashboard" do
+feature 'Rails admin dashboard' do
   before do
-    AdminOnPage.new(create(:user, :redactor)).tap do |page_object|
-      page_object.sign_into_admin
-    end
+    AdminOnPage.new(create(:user, :redactor)).tap(&:sign_into_admin)
   end
 
-  scenario "It displays proper labels for Notice subclasses in the sidebar" do
+  scenario 'It displays proper labels for Notice subclasses in the sidebar' do
     within('.sidebar-nav') do
       expect(page).to have_css('a', text: /^Notices$/, count: 1)
 
@@ -17,11 +15,24 @@ feature "Rails admin dashboard" do
     end
   end
 
-  scenario "it does not display the model counts" do
+  scenario 'it does not display the model counts' do
     within('.content') do
       expect(page).to have_no_css('.bar')
       expect(page).to have_no_content('Notice')
       expect(page).to have_no_content('Infringing url')
     end
+  end
+
+  scenario 'it can delete notices' do
+    notice = create(:dmca)
+    notice.save
+    orig_id = notice.id
+    sign_in(create(:user, :super_admin))
+    visit '/admin/notice'
+    find('li.delete_member_link a').click
+    find('button.btn-danger').click
+
+    expect(current_path).to eq '/admin/notice'
+    expect(Notice.where(id: orig_id)).to eq []
   end
 end

--- a/spec/support/page_objects/admin_on_page.rb
+++ b/spec/support/page_objects/admin_on_page.rb
@@ -28,10 +28,10 @@ class AdminOnPage < PageObject
   def edit(resource, edits = {})
     visit "#{model_path(resource)}/#{resource.id}/edit"
 
-    if edits.present?
-      edits.each { |k,v| fill_in k, with: v }
-      click_on 'Save'
-    end
+    return unless edits.present?
+
+    edits.each { |k, v| fill_in k, with: v }
+    click_on 'Save'
   end
 
   def redact(notice)


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Deleting notices through the admin interface was failing because the
self.index line threw an exception - possibly a holdover from an older
version of ElasticSearch?

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
log in as superadmin, go to `/admin/notice`, click the x to delete a notice, confirm on the next page, it should work

Note that you need to have ElasticSearch running and your env configured properly to talk to it - otherwise you'll get a 500.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15852

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation _(inline)_
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
