### PR TITLE
Add VCR to specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,4 +83,6 @@ group :test do
   gem 'shoulda-matchers', '~> 3.1', '>= 3.1.1'
   gem 'simplecov', require: false
   gem 'timecop'
+  gem 'vcr'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,8 +93,10 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    curb (0.9.3)
+    curb (0.9.6)
     database_cleaner (1.5.3)
     date_validator (0.8.1)
       activemodel
@@ -150,6 +152,7 @@ GEM
       activesupport (>= 4.2.0)
     haml (4.0.7)
       tilt
+    hashdiff (0.3.7)
     hashie (3.5.6)
     high_voltage (1.2.3)
     html2md (0.1.3)
@@ -316,6 +319,7 @@ GEM
     rspec-support (3.6.0)
     ruby-prof (0.13.0)
     ruby-progressbar (1.5.1)
+    safe_yaml (1.0.4)
     sass (3.5.7)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -386,8 +390,13 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
+    vcr (4.0.0)
     warden (1.2.6)
       rack (>= 1.0)
+    webmock (3.4.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -466,6 +475,8 @@ DEPENDENCIES
   twitter
   twitter-text
   uglifier
+  vcr
+  webmock
 
 BUNDLED WITH
    1.16.2

--- a/spec/integration/fielded_notice_search_spec.rb
+++ b/spec/integration/fielded_notice_search_spec.rb
@@ -265,10 +265,8 @@ feature 'Fielded searches of Notices' do
           search_on_page.add_fielded_search_for(field, 'test')
         end
 
-        sleep 0.2
-
         search_on_page.within_fielded_searches do
-          expect(page).to have_no_css('#duplicate-field')
+          expect(page).to have_no_css('#duplicate-field', wait: 5)
         end
       end
 

--- a/spec/models/searches_models_spec.rb
+++ b/spec/models/searches_models_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SearchesModels, type: :model do
+describe SearchesModels, type: :model, vcr: true do
   context 'visible_qualifiers' do
     it 'delegates to the @model_class' do
       expected = { expected_key: :expected_value }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,7 +52,3 @@ Shoulda::Matchers.configure do |config|
     #with.library :rails
   end
 end
-
-if ENV['LOG_ELASTICSEARCH'] == 'true'
-  Elasticsearch::Model.client = Elasticsearch::Client.new log: true, trace: true
-end

--- a/spec/support/curb_helpers.rb
+++ b/spec/support/curb_helpers.rb
@@ -2,7 +2,7 @@ module CurbHelpers
   def post_api(path, parameters)
     json = parameters.to_json
 
-    Curl.post("http://#{host}:#{port}#{path}", json) do |curl|
+    Curl::Easy.http_post("http://#{host}:#{port}#{path}", json) do |curl|
       set_default_headers(curl)
 
       yield curl if block_given?
@@ -10,7 +10,7 @@ module CurbHelpers
   end
 
   def post_broken_json_to_api_as(path, accepts, broken_json)
-    Curl.post("http://#{host}:#{port}#{path}", broken_json) do |curl|
+    Curl::Easy.http_post("http://#{host}:#{port}#{path}", broken_json) do |curl|
       curl.headers['Accept'] = accepts
       curl.headers['Content-Type'] = 'application/json'
     end
@@ -19,7 +19,9 @@ module CurbHelpers
   def with_curb_get_for_json(url, options)
     sleep (ENV['SEARCH_SLEEP'] && ENV['SEARCH_SLEEP'].to_i) || 1
 
-    curb = Curl.get("http://#{host}:#{port}/#{url}", options) do |curl|
+    curb = Curl::Easy.http_get(
+      "http://#{host}:#{port}/#{url}?#{Curl.postalize(options)}"
+    ) do |curl|
       set_default_headers(curl)
     end
 

--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -44,18 +44,20 @@ RSpec.configure do |config|
   # Deleting the index alone doesn't suffice; you'll be left with content from
   # prior tests, which will be reindexed when you refresh the index.
   # The rescue blocks suppress noisy but irrelevant error messages.
-  config.before :each, type: :feature do
-    searchable_models.each do |model|
-      begin
-        model.__elasticsearch__.client.delete_by_query(
-          index: model.__elasticsearch__.index_name
-        )
-        model.__elasticsearch__.delete_index!
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound; end
+  %i[feature controller].each do |type|
+    config.before :each, type: type do
+      searchable_models.each do |model|
+        begin
+          model.__elasticsearch__.client.delete_by_query(
+            index: model.__elasticsearch__.index_name
+          )
+          model.__elasticsearch__.delete_index!
+        rescue Elasticsearch::Transport::Transport::Errors::NotFound; end
 
-      begin
-        model.__elasticsearch__.create_index!
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound; end
+        begin
+          model.__elasticsearch__.create_index!
+        rescue Elasticsearch::Transport::Transport::Errors::NotFound; end
+      end
     end
   end
 

--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -44,7 +44,7 @@ RSpec.configure do |config|
   # Deleting the index alone doesn't suffice; you'll be left with content from
   # prior tests, which will be reindexed when you refresh the index.
   # The rescue blocks suppress noisy but irrelevant error messages.
-  %i[feature controller].each do |type|
+  %i[feature controller view].each do |type|
     config.before :each, type: type do
       searchable_models.each do |model|
         begin

--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -64,3 +64,19 @@ RSpec.configure do |config|
     Elasticsearch::Extensions::Test::Cluster.stop(**es_options)
   end
 end
+
+# Must be 127.0.0.1 to let VCR match recorded urls, elasticsearch-ruby has an
+# issue with reloading connections and even if we set it to localhost here on
+# reconnection it will use 127.0.0.1 instead, that's why we need to use
+# 127.0.0.1, at least for now, unless they fix the issue
+config = {
+  host: 'http://127.0.0.1:9250',
+  request_timeout: 20
+}
+
+if ENV['LOG_ELASTICSEARCH'] == 'true'
+  config[:log] = true
+  config[:trace] = true
+end
+
+Elasticsearch::Model.client = Elasticsearch::Client.new config

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,8 @@
+require 'vcr'
+
+VCR.configure do |c|
+  c.allow_http_connections_when_no_cassette = true
+  c.cassette_library_dir = 'spec/vcr'
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,3 @@
+require 'webmock/rspec'
+
+WebMock.allow_net_connect!

--- a/spec/vcr/SearchesModels/filters/asks_for_the_filter.yml
+++ b/spec/vcr/SearchesModels/filters/asks_for_the_filter.yml
@@ -1,0 +1,33 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:9250/chill_application_test_notice/_search?size=10
+    body:
+      encoding: UTF-8
+      string: '{"query":{"bool":{"must":[{"match":{"spam":{"query":false,"operator":"AND"}}},{"match":{"hidden":{"query":false,"operator":"AND"}}},{"match":{"published":{"query":true,"operator":"AND"}}},{"match":{"rescinded":{"query":false,"operator":"AND"}}}],"filter":[{"term":{"sender_name_facet":"Sender
+        name"}}]}},"aggregations":{"sender_name_facet":{"terms":{"field":"sender_name_facet"}}},"highlight":{"pre_tags":"\u003cem\u003e","post_tags":"\u003c/em\u003e","fields":{"title":{"type":"plain","require_field_match":false},"tag_list":{"type":"plain","require_field_match":false},"topics.name":{"type":"plain","require_field_match":false},"sender_name":{"type":"plain","require_field_match":false},"recipient_name":{"type":"plain","require_field_match":false},"works.description":{"type":"plain","require_field_match":false},"works.infringing_urls.url":{"type":"plain","require_field_match":false},"works.copyrighted_urls.url":{"type":"plain","require_field_match":false}}},"size":10,"from":0}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '186'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"took":10,"timed_out":false,"_shards":{"total":5,"successful":5,"skipped":0,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]},"aggregations":{"sender_name_facet":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 14:29:33 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr/SearchesModels/filters/correctly_configures_facets.yml
+++ b/spec/vcr/SearchesModels/filters/correctly_configures_facets.yml
@@ -1,0 +1,32 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:9250/chill_application_test_notice/_search?size=10
+    body:
+      encoding: UTF-8
+      string: '{"query":{"bool":{"must":[{"match":{"spam":{"query":false,"operator":"AND"}}},{"match":{"hidden":{"query":false,"operator":"AND"}}},{"match":{"published":{"query":true,"operator":"AND"}}},{"match":{"rescinded":{"query":false,"operator":"AND"}}}],"filter":[]}},"aggregations":{"sender_name_facet":{"terms":{"field":"sender_name_facet"}}},"highlight":{"pre_tags":"\u003cem\u003e","post_tags":"\u003c/em\u003e","fields":{"title":{"type":"plain","require_field_match":false},"tag_list":{"type":"plain","require_field_match":false},"topics.name":{"type":"plain","require_field_match":false},"sender_name":{"type":"plain","require_field_match":false},"recipient_name":{"type":"plain","require_field_match":false},"works.description":{"type":"plain","require_field_match":false},"works.infringing_urls.url":{"type":"plain","require_field_match":false},"works.copyrighted_urls.url":{"type":"plain","require_field_match":false}}},"size":10,"from":0}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '186'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"took":59,"timed_out":false,"_shards":{"total":5,"successful":5,"skipped":0,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]},"aggregations":{"sender_name_facet":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 14:29:33 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr/SearchesModels/finds_the_index_name_from_the_model_class.yml
+++ b/spec/vcr/SearchesModels/finds_the_index_name_from_the_model_class.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: http://127.0.0.1:9250/fake_models
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '160'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no
+        such index","resource.type":"index_or_alias","resource.id":"fake_models","index_uuid":"_na_","index":"fake_models"}],"type":"index_not_found_exception","reason":"no
+        such index","resource.type":"index_or_alias","resource.id":"fake_models","index_uuid":"_na_","index":"fake_models"},"status":404}'
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 14:29:33 GMT
+- request:
+    method: head
+    uri: http://127.0.0.1:9250/fake_models
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.9.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '367'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 14:29:33 GMT
+- request:
+    method: put
+    uri: http://127.0.0.1:9250/fake_models
+    body:
+      encoding: UTF-8
+      string: '{"settings":{},"mappings":{"fake_model":{"properties":{}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '78'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"acknowledged":true,"shards_acknowledged":true,"index":"fake_models"}'
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 14:29:33 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:9250/fake_models/_search?size=10
+    body:
+      encoding: UTF-8
+      string: '{"query":{"bool":{"must":[],"filter":[]}},"aggregations":{},"highlight":{"pre_tags":"\u003cem\u003e","post_tags":"\u003c/em\u003e","fields":{"foo":{"type":"plain","require_field_match":false},"bar":{"type":"plain","require_field_match":false}}},"size":10,"from":0}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '127'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"took":4,"timed_out":false,"_shards":{"total":5,"successful":5,"skipped":0,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 14:29:33 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr/SearchesModels/returns_an_elasticsearch_search_instance.yml
+++ b/spec/vcr/SearchesModels/returns_an_elasticsearch_search_instance.yml
@@ -1,0 +1,32 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:9250/chill_application_test_notice/_search?size=10
+    body:
+      encoding: UTF-8
+      string: '{"query":{"bool":{"must":[{"match":{"spam":{"query":false,"operator":"AND"}}},{"match":{"hidden":{"query":false,"operator":"AND"}}},{"match":{"published":{"query":true,"operator":"AND"}}},{"match":{"rescinded":{"query":false,"operator":"AND"}}}],"filter":[]}},"aggregations":{},"highlight":{"pre_tags":"\u003cem\u003e","post_tags":"\u003c/em\u003e","fields":{"title":{"type":"plain","require_field_match":false},"tag_list":{"type":"plain","require_field_match":false},"topics.name":{"type":"plain","require_field_match":false},"sender_name":{"type":"plain","require_field_match":false},"recipient_name":{"type":"plain","require_field_match":false},"works.description":{"type":"plain","require_field_match":false},"works.infringing_urls.url":{"type":"plain","require_field_match":false},"works.copyrighted_urls.url":{"type":"plain","require_field_match":false}}},"size":10,"from":0}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '128'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"took":23,"timed_out":false,"_shards":{"total":5,"successful":5,"skipped":0,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 14:29:33 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr/SearchesModels/searches/dispatches_to_a_registered_term_search.yml
+++ b/spec/vcr/SearchesModels/searches/dispatches_to_a_registered_term_search.yml
@@ -1,0 +1,32 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:9250/chill_application_test_notice/_search?size=10
+    body:
+      encoding: UTF-8
+      string: '{"query":{"bool":{"must":[{"match":{"spam":{"query":false,"operator":"AND"}}},{"match":{"hidden":{"query":false,"operator":"AND"}}},{"match":{"published":{"query":true,"operator":"AND"}}},{"match":{"rescinded":{"query":false,"operator":"AND"}}},{"match":{"_all":{"query":"foo","operator":"OR"}}}],"filter":[]}},"aggregations":{},"highlight":{"pre_tags":"\u003cem\u003e","post_tags":"\u003c/em\u003e","fields":{"title":{"type":"plain","require_field_match":false},"tag_list":{"type":"plain","require_field_match":false},"topics.name":{"type":"plain","require_field_match":false},"sender_name":{"type":"plain","require_field_match":false},"recipient_name":{"type":"plain","require_field_match":false},"works.description":{"type":"plain","require_field_match":false},"works.infringing_urls.url":{"type":"plain","require_field_match":false},"works.copyrighted_urls.url":{"type":"plain","require_field_match":false}}},"size":10,"from":0}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '127'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"took":6,"timed_out":false,"_shards":{"total":5,"successful":5,"skipped":0,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 14:29:33 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr/SearchesModels/searches/dispatches_with_an_operator.yml
+++ b/spec/vcr/SearchesModels/searches/dispatches_with_an_operator.yml
@@ -1,0 +1,32 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:9250/chill_application_test_notice/_search?size=10
+    body:
+      encoding: UTF-8
+      string: '{"query":{"bool":{"must":[{"match":{"spam":{"query":false,"operator":"AND"}}},{"match":{"hidden":{"query":false,"operator":"AND"}}},{"match":{"published":{"query":true,"operator":"AND"}}},{"match":{"rescinded":{"query":false,"operator":"AND"}}},{"match":{"_all":{"query":"foo","operator":"AND"}}}],"filter":[]}},"aggregations":{},"highlight":{"pre_tags":"\u003cem\u003e","post_tags":"\u003c/em\u003e","fields":{"title":{"type":"plain","require_field_match":false},"tag_list":{"type":"plain","require_field_match":false},"topics.name":{"type":"plain","require_field_match":false},"sender_name":{"type":"plain","require_field_match":false},"recipient_name":{"type":"plain","require_field_match":false},"works.description":{"type":"plain","require_field_match":false},"works.infringing_urls.url":{"type":"plain","require_field_match":false},"works.copyrighted_urls.url":{"type":"plain","require_field_match":false}}},"size":10,"from":0}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '128'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"took":53,"timed_out":false,"_shards":{"total":5,"successful":5,"skipped":0,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'
+    http_version: 
+  recorded_at: Fri, 02 Nov 2018 14:29:33 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
* Add and configure VCR and Webmock
* Upgrade Curb and use Curb::Easy (the other ones, Curb and Curb::Multi,
are not supported by VCR)
* Configure Elasticsearch to work nicely with VCR
* Add VCR recordings for the SearchModels model

## Ready for merge?
**YES**

#### What does this PR do?
Adding VCR so that non-integration tests don't depend on Elasticsearch.

#### How can a reviewer manually see the effects of these changes?

Run specs, it won't call Elasticsearch and will use VCR recordings instead in the SearchModels model spec.

#### What are the relevant tickets?

https://cyber.harvard.edu/projectmanagement/issues/15706

#### Todo:
- [x] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES