### PR TITLE
14893 webform doc type

### DIFF
--- a/app/assets/javascripts/notices_new.js.coffee
+++ b/app/assets/javascripts/notices_new.js.coffee
@@ -1,8 +1,6 @@
 addFileUploadInput = (field, parent, updateContainer) ->
   containers = parent.find(".notice_file_uploads_#{field}")
 
-  containers.find('select').select2('destroy')
-
   nextId = "notice_file_uploads_attributes_#{containers.length}_#{field}"
   nextName =  "notice[file_uploads_attributes][#{containers.length}][#{field}]"
 
@@ -12,11 +10,6 @@ addFileUploadInput = (field, parent, updateContainer) ->
   updateContainer(newContainer, nextId, nextName)
 
   newContainer.appendTo($('#file_uploads_inputs'))
-
-  $('#file_uploads_inputs').find('select').each ->
-    $(this).select2
-      placeholder: ''
-      width: 'off'
 
 $('.new_notice select').each ->
   $(this).select2
@@ -35,10 +28,6 @@ $('.attach #add-another').click ->
   addFileUploadInput 'file', parent, (newContainer, nextId, nextName) ->
     newContainer.find('input').attr('id', nextId).attr('name', nextName).val('')
     newContainer.find('label').attr('for', nextId).html('Additional document')
-
-  addFileUploadInput 'kind', parent, (newContainer, nextId, nextName) ->
-    newContainer.find('select').attr('id', nextId).attr('name', nextName).attr('value', 'supporting')
-    newContainer.find('label').attr('for', nextId).html('Document type')
 
 $(document).on 'click', '.add-another-url', ->
   anchor = $(this)

--- a/app/assets/stylesheets/notices/_new.scss
+++ b/app/assets/stylesheets/notices/_new.scss
@@ -6,6 +6,10 @@ body.notices-new {
       line-height: 1.2em;
     }
   }
+
+  #file_uploads_inputs {
+    margin-bottom: 10px;
+  }
 }
 
 section.notices-list {

--- a/app/models/notice_submission_initializer.rb
+++ b/app/models/notice_submission_initializer.rb
@@ -18,7 +18,7 @@ class NoticeSubmissionInitializer
   def submit(user = nil)
     set_all_entities(user)
 
-    notice = add_notice_defaults(notice)
+    add_notice_defaults
 
     return false unless notice.save
 
@@ -26,15 +26,13 @@ class NoticeSubmissionInitializer
     true
   end
 
-  def add_notice_defaults(notice)
+  def add_notice_defaults
     notice.title = generic_title unless notice.title.present?
     notice.works = PLACEHOLDER_WORKS
     notice.file_uploads.map do |file|
       file.kind = 'supporting' if file.kind.nil?
     end
     notice.auto_redact
-
-    notice
   end
 
   def notice

--- a/app/models/notice_submission_initializer.rb
+++ b/app/models/notice_submission_initializer.rb
@@ -17,6 +17,16 @@ class NoticeSubmissionInitializer
 
   def submit(user = nil)
     set_all_entities(user)
+
+    notice = add_notice_defaults(notice)
+
+    return false unless notice.save
+
+    notice.mark_for_review
+    true
+  end
+
+  def add_notice_defaults(notice)
     notice.title = generic_title unless notice.title.present?
     notice.works = PLACEHOLDER_WORKS
     notice.file_uploads.map do |file|
@@ -24,10 +34,7 @@ class NoticeSubmissionInitializer
     end
     notice.auto_redact
 
-    return false unless notice.save
-
-    notice.mark_for_review
-    true
+    notice
   end
 
   def notice

--- a/app/models/notice_submission_initializer.rb
+++ b/app/models/notice_submission_initializer.rb
@@ -19,6 +19,9 @@ class NoticeSubmissionInitializer
     set_all_entities(user)
     notice.title = generic_title unless notice.title.present?
     notice.works = PLACEHOLDER_WORKS
+    notice.file_uploads.map do |file|
+      file.kind = 'supporting' if file.kind.nil?
+    end
     notice.auto_redact
 
     return false unless notice.save

--- a/app/views/notices/form_components/_additional_metadata.html.erb
+++ b/app/views/notices/form_components/_additional_metadata.html.erb
@@ -23,7 +23,7 @@
   <p>Any file you attach to this notice will be viewable by the public in the form in which you have attached it. It will not be reviewed by Lumen staff prior to being available to download.</p>
   <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
     <div id="file_uploads_inputs">
-      <%= file_uploads_form.input :file, label: 'Attach Notice' %>
+      <%= file_uploads_form.input :file, label: 'Attach file' %>
     </div>
     <a href="javascript:void(0);" id="add-another" class="button">Attach another</a>
   <% end %>

--- a/app/views/notices/form_components/_additional_metadata.html.erb
+++ b/app/views/notices/form_components/_additional_metadata.html.erb
@@ -20,13 +20,10 @@
   <% if mark_reg %>
     <%= form.input :mark_registration_number, label: "Registration Number" %>
   <% end %>
+  <p>Any file you attach to this notice will be viewable by the public in the form in which you have attached it. It will not be reviewed by Lumen staff prior to being available to download.</p>
   <%= form.simple_fields_for(:file_uploads) do |file_uploads_form| %>
     <div id="file_uploads_inputs">
       <%= file_uploads_form.input :file, label: 'Attach Notice' %>
-      <%= file_uploads_form.input :kind,
-          label: 'Document type',
-          prompt: nil,
-          collection: FileUpload::ALLOWED_KINDS %>
     </div>
     <a href="javascript:void(0);" id="add-another" class="button">Attach another</a>
   <% end %>

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -71,33 +71,21 @@ feature 'notice submission' do
     expect(notice).to have(1).supporting_document
   end
 
-  scenario 'submitting a notice with a supporting document', js: true do
+  scenario 'submitting a notice with a document', js: true do
     submit_recent_notice do
-      add_document('supporting')
+      add_document
     end
 
     notice = Notice.last
 
-    expect(notice).to have(0).original_documents
     expect(notice).to have(1).supporting_document
   end
 
-  scenario 'submitting a notice with an original document', js: true do
+  scenario 'submitting a notice with multiple documents', js: true do
     submit_recent_notice do
-      add_document('original')
-    end
-
-    notice = Notice.last
-
-    expect(notice).to have(1).original_documents
-    expect(notice).to have(0).supporting_documents
-  end
-
-  scenario 'submitting a notice with multiple supporting documents', js: true do
-    submit_recent_notice do
-      add_document('supporting')
-      add_document('supporting')
-      add_document('supporting')
+      add_document
+      add_document
+      add_document
     end
 
     open_recent_notice

--- a/spec/support/notice_actions.rb
+++ b/spec/support/notice_actions.rb
@@ -40,7 +40,7 @@ module NoticeActions
     with_file(content) { |file| attach_file 'Attach Notice', file.path }
   end
 
-  def add_document(kind = 'supporting')
+  def add_document
     @field_index ||= 0
 
     if @field_index > 0
@@ -53,7 +53,6 @@ module NoticeActions
     with_file('some content') do |file|
       attach_file field_name, file.path
     end
-    select kind, from: "notice_file_uploads_attributes_#{@field_index}_kind"
     @field_index += 1
   end
 

--- a/spec/support/notice_actions.rb
+++ b/spec/support/notice_actions.rb
@@ -37,7 +37,7 @@ module NoticeActions
   end
 
   def attach_notice(content: 'Some content')
-    with_file(content) { |file| attach_file 'Attach Notice', file.path }
+    with_file(content) { |file| attach_file 'Attach file', file.path }
   end
 
   def add_document


### PR DESCRIPTION
## Ready for merge?
__YES__

## What does this PR do?
Removes the file category select from the notice web form.

## Helpful background context (if appropriate)
See https://github.com/berkmancenter/lumendatabase/pull/494

## How can a reviewer manually see the effects of these changes?
* Go to notices/new/type=Whatever
* File category select shouldn't be there

## What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/14893

## Screenshots (if appropriate)
Todo:
- [x] Tests
- ~~[  ]  Documentation~~
- [x] Stakeholder approval

## Requires Database Migrations?
__NO__

## Includes new or updated dependencies?
__NO__