### PR TITLE
15702 railsadmin edit perf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ config/database.yml
 .byebug_history
 .rubocop.yml
 rspec_examples.txt
+.reek.yml

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -50,6 +50,10 @@ RailsAdmin.config do |config|
     config.model notice_type do
       label { abstract_model.model.label }
       list do
+        # SELECT COUNT is slow when the number of instances is large; let's
+        # avoid calling it for Notice and its subclasses.
+        limited_pagination true
+
         field :id
         field :title
         field(:date_sent)     { label 'Sent' }

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -142,11 +142,9 @@ RailsAdmin.config do |config|
       end
     end
     edit do
-      # This improves performance by preventing a SELECT COUNT (*) on Notice.
-      # This is especially important on the edit page for a *notice*, which
-      # has a nested edit form for Topic. SELECT COUNT is very slow when the
-      # number of records is high, as is the case for Notice.
-      exclude_fields :notices
+      # exclude_fields :notices might be a better performance option than hide,
+      # but it prevents topics with null ancestries from being saved.
+      configure(:notices) { hide }
       configure(:topic_assignments) { hide }
 
       configure(:blog_entries) { hide }

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -100,15 +100,13 @@ RailsAdmin.config do |config|
           label 'Type'
           required true
         end
-        configure(:topic_assignments) { hide }
-        configure(:topic_relevant_questions) { hide }
-
-        configure(:related_blog_entries) { hide }
-
-        configure(:blog_topic_assignments) { hide }
-        configure(:entities) { hide }
-        configure(:infringing_urls) { hide }
-        configure(:copyrighted_urls) { hide }
+        exclude_fields :topic_assignments,
+                       :topic_relevant_questions,
+                       :related_blog_entries,
+                       :blog_topic_assignments,
+                       :entities,
+                       :infringing_urls,
+                       :copyrighted_urls
 
         configure :review_required do
           visible do

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -139,7 +139,11 @@ RailsAdmin.config do |config|
       end
     end
     edit do
-      configure(:notices) { hide }
+      # This improves performance by preventing a SELECT COUNT (*) on Notice.
+      # This is especially important on the edit page for a *notice*, which
+      # has a nested edit form for Topic. SELECT COUNT is very slow when the
+      # number of records is high, as is the case for Notice.
+      exclude_fields :notices
       configure(:topic_assignments) { hide }
 
       configure(:blog_entries) { hide }
@@ -160,7 +164,8 @@ RailsAdmin.config do |config|
 
   config.model 'Entity' do
     list do
-      configure(:notices) { hide }
+      # See exclude_fields comment for Topic.
+      exclude_fields :notices
       configure(:entity_notice_roles) { hide }
       configure :parent do
         formatted_value do

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -86,6 +86,11 @@ RailsAdmin.config do |config|
       end
 
       edit do
+        # This dramatically speeds up the admin page.
+        configure :works do
+          nested_form false
+        end
+
         configure :action_taken, :enum do
           enum do
             %w[Yes No Partial Unspecified]
@@ -100,11 +105,11 @@ RailsAdmin.config do |config|
           label 'Type'
           required true
         end
+
         exclude_fields :topic_assignments,
                        :topic_relevant_questions,
                        :related_blog_entries,
                        :blog_topic_assignments,
-                       :entities,
                        :infringing_urls,
                        :copyrighted_urls
 
@@ -157,6 +162,9 @@ RailsAdmin.config do |config|
   config.model 'EntityNoticeRole' do
     edit do
       configure(:notice) { hide }
+      configure :entity do
+        nested_form false
+      end
     end
   end
 
@@ -207,6 +215,7 @@ RailsAdmin.config do |config|
       configure(:copyrighted_urls) { hide }
       configure(:infringing_urls) { hide }
     end
+
     nested do
       configure(:infringing_urls) { hide }
       configure(:copyrighted_urls) { hide }

--- a/spec/integration/user_authorizes_spec.rb
+++ b/spec/integration/user_authorizes_spec.rb
@@ -1,18 +1,18 @@
 require 'rails_helper'
 require 'support/contain_link'
 
-feature "User authorization" do
+feature 'User authorization' do
   include ContainLink
 
-  scenario "A non logged-in user is redirected to sign in" do
+  scenario 'A non logged-in user is redirected to sign in' do
     user = AdminOnPage.new(create(:user))
 
     user.visit_admin
 
-    expect(page).to have_text("You are not authorized to access this page.")
+    expect(page).to have_text('You are not authorized to access this page.')
   end
 
-  scenario "Submitters- cannot access admin" do
+  scenario 'Submitters - cannot access admin' do
     page_objects = [
       AdminOnPage.new(create(:user)),
       AdminOnPage.new(create(:user, :submitter))
@@ -25,7 +25,7 @@ feature "User authorization" do
     end
   end
 
-  scenario "Redactors+ are able to access admin" do
+  scenario 'Redactors+ are able to access admin' do
     page_objects = [
       AdminOnPage.new(create(:user, :redactor)),
       AdminOnPage.new(create(:user, :publisher)),
@@ -40,7 +40,7 @@ feature "User authorization" do
     end
   end
 
-  scenario "All levels can edit notices" do
+  scenario 'All levels can edit notices' do
     notice = create(:dmca)
     page_objects = [
       AdminOnPage.new(create(:user, :redactor)),
@@ -56,7 +56,7 @@ feature "User authorization" do
     end
   end
 
-  scenario "Redactors cannot publish (admin)" do
+  scenario 'Redactors cannot publish (admin)' do
     page_object = AdminOnPage.new(create(:user, :redactor))
     notice = create(:dmca, review_required: true)
 
@@ -65,7 +65,7 @@ feature "User authorization" do
     expect(page).to have_no_css('input#notice_review_required')
   end
 
-  scenario "Publishers+ can publish (admin)" do
+  scenario 'Publishers+ can publish (admin)' do
     notice = create(:dmca, review_required: true)
     page_objects = [
       AdminOnPage.new(create(:user, :publisher)),
@@ -80,7 +80,7 @@ feature "User authorization" do
     end
   end
 
-  scenario "Redactors cannot publish (redact tool)" do
+  scenario 'Redactors cannot publish (redact tool)' do
     notice = create(:dmca, review_required: true)
     page_object = AdminOnPage.new(create(:user, :redactor))
 
@@ -89,7 +89,7 @@ feature "User authorization" do
     expect(page).to have_no_css('input#notice_review_required')
   end
 
-  scenario "Publishers+ can publish (redact tool)" do
+  scenario 'Publishers+ can publish (redact tool)' do
     notice = create(:dmca, review_required: true)
     page_objects = [
       AdminOnPage.new(create(:user, :publisher)),
@@ -104,7 +104,7 @@ feature "User authorization" do
     end
   end
 
-  scenario "Redactors and Publishers cannot create/delete notices" do
+  scenario 'Redactors and Publishers cannot create/delete notices' do
     notice = create(:dmca)
     page_objects = [
       AdminOnPage.new(create(:user, :redactor)),
@@ -122,7 +122,7 @@ feature "User authorization" do
     end
   end
 
-  scenario "Redactors and Publishers cannot edit site data" do
+  scenario 'Redactors and Publishers cannot edit site data' do
     site_data = [
       create(:topic),
       create(:relevant_question),
@@ -146,7 +146,7 @@ feature "User authorization" do
     end
   end
 
-  scenario "Redactors and Publishers cannot rescind notices" do
+  scenario 'Redactors and Publishers cannot rescind notices' do
     notice = create(:dmca)
     page_objects = [
       AdminOnPage.new(create(:user, :redactor)),
@@ -160,8 +160,9 @@ feature "User authorization" do
     end
   end
 
-  scenario "Admins and Super admins can edit site data" do
+  scenario 'Admins and Super admins can edit site data' do
     topic = create(:topic)
+    topic.save
     page_objects = [
       AdminOnPage.new(create(:user, :admin)),
       AdminOnPage.new(create(:user, :super_admin))
@@ -174,7 +175,7 @@ feature "User authorization" do
     end
   end
 
-  scenario "Admins and Super admins can rescind notices" do
+  scenario 'Admins and Super admins can rescind notices' do
     notice = create(:dmca)
     page_objects = [
       AdminOnPage.new(create(:user, :admin)),
@@ -188,7 +189,7 @@ feature "User authorization" do
     end
   end
 
-  scenario "Admins cannot edit Users or Access levels" do
+  scenario 'Admins cannot edit Users or Access levels' do
     site_data = [
       create(:user),
       create(:role)
@@ -203,25 +204,25 @@ feature "User authorization" do
     end
   end
 
-  scenario "Super admins can edit other Users" do
+  scenario 'Super admins can edit other Users' do
     obj = AdminOnPage.new(create(:user, :super_admin))
     other_user = create(:user)
 
-    obj.sign_in_and_edit(other_user, user_email: "new-email@example.com")
+    obj.sign_in_and_edit(other_user, user_email: 'new-email@example.com')
 
-    expect(other_user.reload.email).to eq "new-email@example.com"
+    expect(other_user.reload.email).to eq 'new-email@example.com'
   end
 
-  scenario "Super admins can edit Roles" do
+  scenario 'Super admins can edit Roles' do
     obj = AdminOnPage.new(create(:user, :super_admin))
-    role = create(:role, name: "some_name")
+    role = create(:role, name: 'some_name')
 
-    obj.sign_in_and_edit(role, Name: "another_name")
+    obj.sign_in_and_edit(role, Name: 'another_name')
 
-    expect(role.reload.name).to eq "another_name"
+    expect(role.reload.name).to eq 'another_name'
   end
 
-  scenario "Visibility of notice administation links" do
+  scenario 'Visibility of notice administation links' do
     notice = create(:dmca)
     admin_path = rails_admin.show_path(model_name: 'dmca', id: notice.id)
 
@@ -236,7 +237,7 @@ feature "User authorization" do
 
     expect(page).to contain_link(admin_path)
 
-    click_on "Edit in Admin"
+    click_on 'Edit in Admin'
 
     expect(obj).to be_in_admin
   end

--- a/spec/support/page_object.rb
+++ b/spec/support/page_object.rb
@@ -8,5 +8,4 @@ class PageObject
       end
     end
   end
-
 end


### PR DESCRIPTION
## Ready for merge?
**YES**

I've talked to Adam about his usage of the admin page but I will want to put it on flutie before we merge - Peter, please tell me when I can do that without stepping on your tests.

#### What does this PR do?
The rails admin is exceptionally slow on prod. Skylight indicates that repeated database queries are a culprit; I can't trace down exactly where those queries are happening, but a lot of googling suggests they're in rendering nested forms, particularly in harvesting the data needed for associated entities represented in nested forms - we just have to traverse too much of our database. These changes reduce the amount of data we pull in to render `/admin/notice/X/edit`, and as a result on localhost this page loads about 6.5 times faster (I expect the difference will be even larger on prod where the volumes of data are much higher).

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Load a notice editing page on dev, see how long the rails server tells you it took, load the same page while running this branch, yay

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15702

#### Screenshots (if appropriate)

#### Todo:
- ~~[ ] Tests~~
- ~~[ ] Documentation~~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
