### PR TITLE
Redirect to pre-sign-in page after login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
 
   skip_before_action :verify_authenticity_token
 
+  after_filter :store_action
   after_action :include_auth_cookie
 
   private
@@ -68,5 +69,16 @@ class ApplicationController < ActionController::Base
 
   def include_auth_cookie
     cookies[:lumen_authenticated] = (current_user.present? ? 1 : 0)
+  end
+
+  def store_action
+    skip_paths = ['/users/sign_in', '/users/sign_up', '/users/password/new',
+                  '/users/password/edit', '/users/confirmation',
+                  '/users/sign_out']
+
+    return if !request.get? || skip_paths.include?(request.path) ||
+              request.xhr?
+
+    store_location_for(:user, request.fullpath)
   end
 end

--- a/spec/integration/user_authorizes_spec.rb
+++ b/spec/integration/user_authorizes_spec.rb
@@ -241,4 +241,25 @@ feature 'User authorization' do
 
     expect(obj).to be_in_admin
   end
+
+  scenario 'Users are redirected to pre-sign-in page after login' do
+    notice = create(:dmca)
+    notice_url = notice_url(notice)
+    create(
+      :user,
+      email: 'someone@example.com',
+      password: 'somepassword',
+      password_confirmation: 'somepassword'
+    )
+
+    visit notice_url
+
+    visit new_user_session_path
+
+    fill_in 'Email', with: 'someone@example.com'
+    fill_in 'Password', with: 'somepassword'
+    click_button 'Log in'
+
+    expect(current_url).to eq(notice_url)
+  end
 end

--- a/spec/support/sign_in.rb
+++ b/spec/support/sign_in.rb
@@ -1,10 +1,9 @@
 # See https://github.com/plataformatec/devise/wiki/How-To:-Test-with-Capybara
-include Warden::Test::Helpers
-
 RSpec.configure do |config|
+  include Warden::Test::Helpers
 
   def sign_in(user)
-    login_as(user, :scope => :user)
+    login_as(user, scope: :user)
   end
 
   config.after :each do


### PR DESCRIPTION
## Ready for merge?
**NO (Adam will need to test it first)**

#### What does this PR do?
Activates a redirection after user login to the pre-sign-in-screen page.

#### How can a reviewer manually see the effects of these changes?
Go to `/pages/about`, click `Sign in` on the bottom, sign in, it should redirect you back to the `/pages/about` page.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15850

#### Todo:
- [x] Tests
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
