### PR TITLE
Make sure entity type gets set properly on notice submission

### DIFF
--- a/spec/integration/submit_notice_via_api_spec.rb
+++ b/spec/integration/submit_notice_via_api_spec.rb
@@ -36,7 +36,11 @@ feature 'notice submission' do
     curb = post_api('/notices', parameters)
 
     expect(curb.response_code).to eq 201
-    expect(Notice.last.title).to eq 'A superduper title'
+
+    notice = Notice.last
+
+    expect(notice.title).to eq 'A superduper title'
+    expect(notice.recipient.kind).to eq 'individual'
   end
 
   scenario 'submitting a notice with token in header', js: true do

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -134,10 +134,12 @@ feature 'notice submission' do
         fill_in 'City', with: 'Recipient City'
         fill_in 'State', with: 'MA'
         select 'United States', from: 'Country'
+        select 'organization', from: 'Recipient Type'
       end
 
       within('section.sender') do
         fill_in 'Name', with: 'Sender the first'
+        select 'organization', from: 'Sender Type'
       end
     end
 
@@ -152,6 +154,12 @@ feature 'notice submission' do
 
       expect(page).to have_content 'Sender the first'
     end
+
+    notice = Notice.last
+
+    expect(notice.recipient.kind).to eq('organization')
+    expect(notice.sender.kind).to eq('organization')
+    expect(notice.submitter.kind).to eq('individual')
   end
 
   scenario 'entity addresses are partially private' do

--- a/spec/models/dmca_spec.rb
+++ b/spec/models/dmca_spec.rb
@@ -387,4 +387,13 @@ describe DMCA, type: :model do
       expect(notice.published).to be false
     end
   end
+
+  context '#entity_notice_roles' do
+    it 'sets the default kind of entities' do
+      notice = create(:dmca, role_names: %w[sender principal])
+
+      expect(notice.principal.kind).to eq('individual')
+      expect(notice.sender.kind).to eq('individual')
+    end
+  end
 end


### PR DESCRIPTION
#### Ready for merge?

YES

#### What does this PR do?
Adds some tests to make sure the entity type gets set properly on notice submission.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15786

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
