### PR TITLE
15743 work redaction

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -150,6 +150,11 @@ class NoticesController < ApplicationController
     end
   end
 
+  # In theory the calls to fetch and delete cause memory leaks per
+  # https://tenderlovemaking.com/2014/06/02/yagni-methods-are-killing-me.html ,
+  # but with benchmarking on localhost I'm unable to find a meaningful memory
+  # usage difference between this version and a version that avoids these calls.
+  # --ay, 11 December 2018
   def get_notice_type(params)
     type_string = params.fetch(:type, 'DMCA')
     type_string = 'DMCA' if type_string == 'Dmca'

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -52,6 +52,9 @@ class Ability
     can :access, :original_files
   end
 
+  # Note that this only covers Notice, because it governs use of the admin
+  # interface, and redaction of other models in the admin has not been
+  # implemented.
   def grant_redact
     can :edit, Notice
     can :redact_notice, Notice

--- a/app/models/instance_redactor.rb
+++ b/app/models/instance_redactor.rb
@@ -1,7 +1,7 @@
-class RedactsNotices
-  def initialize(redactors = [RedactsPhoneNumbers.new,
-                              RedactsSSNs.new,
-                              RedactsEmail.new])
+class InstanceRedactor
+  def initialize(redactors = [PhoneNumberRedactor.new,
+                              SSNRedactor.new,
+                              EmailRedactor.new])
     @redactors = redactors
   end
 
@@ -38,7 +38,7 @@ class RedactsNotices
     notice.send(:"#{field}_original=", text)
   end
 
-  class RedactsContent
+  class ContentRedactor
     STOP_WORDS = %w[
       a about above across after again against all almost alone along already
       also although always among an and another any anybody anyone anything
@@ -90,9 +90,9 @@ class RedactsNotices
     end
   end
 
-  class RedactsPhoneNumbers
+  class PhoneNumberRedactor
     def redact(text)
-      redactor = RedactsContent.new(
+      redactor = ContentRedactor.new(
         /(\(?\d{3}\)?.?)?     # optional area code
          (\d{3}[^\d]?\d{4})|  # phone number, optional single-char separator
          (\d+[\d ]{10,16}\d+) # turkish phone number
@@ -103,9 +103,9 @@ class RedactsNotices
     end
   end
 
-  class RedactsSSNs
+  class SSNRedactor
     def redact(text)
-      redactor = RedactsContent.new(
+      redactor = ContentRedactor.new(
         /\b(\d{3})\D?(\d{2})\D?(\d{4})\b/x
       )
 
@@ -113,9 +113,9 @@ class RedactsNotices
     end
   end
 
-  class RedactsEmail
+  class EmailRedactor
     def redact(text)
-      redactor = RedactsContent.new(
+      redactor = ContentRedactor.new(
         /\S+@\S+\.\S+[^.\s]/i
       )
 
@@ -123,7 +123,7 @@ class RedactsNotices
     end
   end
 
-  class RedactsEntityName
+  class EntityNameRedactor
     def initialize(name)
       match = name.gsub(/[-*+?\d]/, ' ').strip.split(/\s+/)
       separator = (name =~ /[a-z]/mi ? '[^a-z]' : '\s')
@@ -133,7 +133,7 @@ class RedactsNotices
 
     def redact(text)
       return text if @regex_base.blank?
-      redactor = RedactsContent.new(@regex)
+      redactor = ContentRedactor.new(@regex)
 
       redactor.redact(text)
     end

--- a/app/models/instance_redactor.rb
+++ b/app/models/instance_redactor.rb
@@ -32,6 +32,7 @@ class InstanceRedactor
       redactor.redact(result)
     end
 
+    return unless new_text != text
     instance.send(:"#{field}=", new_text)
   end
 

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -247,7 +247,7 @@ class Notice < ActiveRecord::Base
   end
 
   def auto_redact
-    RedactsNotices.new.redact(self)
+    InstanceRedactor.new.redact(self)
   end
 
   def mark_for_review

--- a/app/models/redacts_notices.rb
+++ b/app/models/redacts_notices.rb
@@ -1,10 +1,17 @@
 class RedactsNotices
-  def initialize(redactors = [RedactsPhoneNumbers.new, RedactsSSNs.new, RedactsEmail.new])
+  def initialize(redactors = [RedactsPhoneNumbers.new,
+                              RedactsSSNs.new,
+                              RedactsEmail.new])
     @redactors = redactors
   end
 
   def redact(notice, field_or_fields = Notice::REDACTABLE_FIELDS)
-    Array(field_or_fields).each { |field| redact_field(notice, field) }
+    Array(field_or_fields).each do |field|
+      next unless (text = notice.send(field)).present?
+
+      redact_field(notice, field, text)
+      update_original(notice, field, text)
+    end
   end
 
   def redact_all(notice_ids, field_or_fields = Notice::REDACTABLE_FIELDS)
@@ -18,41 +25,58 @@ class RedactsNotices
 
   attr_reader :redactors
 
-  def redact_field(notice, field)
-    if (text = notice.send(field)).present?
-      new_text = redactors.inject(text) do |result, redactor|
-        redactor.redact(result)
-      end
-
-      notice.send(:"#{field}=", new_text)
-
-      if notice.send(:"#{field}_original").blank?
-        notice.send(:"#{field}_original=", text)
-      end
+  def redact_field(notice, field, text)
+    new_text = redactors.inject(text) do |result, redactor|
+      redactor.redact(result)
     end
+
+    notice.send(:"#{field}=", new_text)
+  end
+
+  def update_original(notice, field, text)
+    return unless notice.send(:"#{field}_original").blank?
+    notice.send(:"#{field}_original=", text)
   end
 
   class RedactsContent
-    STOP_WORDS = %w(
-      a about above across after again against all almost alone along already also although always among an and another any anybody anyone anything
-      anywhere are area areas around as ask asked asking asks at away b back backed backing backs be became because become becomes been before began
-      behind being beings best better between big both but by c came can cannot case cases certain certainly clear clearly come could d did differ 
-      different differently do does done down down downed downing downs during e each early either end ended ending ends enough even evenly ever 
-      every everybody everyone everything everywhere f face faces fact facts far felt few find finds first for four from full fully further furthered 
-      furthering furthers g gave general generally get gets give given gives go going good goods got great greater greatest group grouped grouping 
-      groups h had has have having he her here herself high high high higher highest him himself his how however i if important in interest interested
-      nteresting interests into is it its itself j just k keep keeps kind knew know known knows l large largely last later latest least less let lets
-      like likely long longer longest m made make making man many may me member members men might more most mostly mr mrs much must my myself n necessary
-      need needed needing needs never new new newer newest next no nobody non noone not nothing now nowhere number numbers o of off often old older
-      oldest on once one only open opened opening opens or order ordered ordering orders other others our out over p part parted parting parts per
-      perhaps place places point pointed pointing points possible present presented presenting presents problem problems put puts q quite r rather
-      really right right room rooms s said same saw say says second seconds see seem seemed seeming seems sees several shall she should show showed
-      showing shows side sides since small smaller smallest so some somebody someone something somewhere state states still still such sure t take
-      taken than that the their them then there therefore these they thing things think thinks this those though thought thoughts three through thus
-      to today together too took toward turn turned turning turns two u under until up upon us use used uses v very w want wanted wanting wants was
-      way ways we well wells went were what when where whether which while who whole whose why will with within without work worked working works
-      would x y year years yet you young younger youngest your yours z
-    )
+    STOP_WORDS = %w[
+      a about above across after again against all almost alone along already
+      also although always among an and another any anybody anyone anything
+      anywhere are area areas around as ask asked asking asks at away b back
+      backed backing backs be became because become becomes been before began
+      behind being beings best better between big both but by c came can cannot
+      case cases certain certainly clear clearly come could d did differ
+      different differently do does done down down downed downing downs during e
+      each early either end ended ending ends enough even evenly ever every
+      everybody everyone everything everywhere f face faces fact facts far felt
+      few find finds first for four from full fully further furthered furthering
+      furthers g gave general generally get gets give given gives go going good
+      goods got great greater greatest group grouped grouping groups h had has
+      have having he her here herself high high high higher highest him himself
+      his how however i if important in interest interested nteresting interests
+      into is it its itself j just k keep keeps kind knew know known knows l
+      large largely last later latest least less let lets like likely long
+      longer longest m made make making man many may me member members men might
+      more most mostly mr mrs much must my myself n necessary need needed
+      needing needs never new new newer newest next no nobody non noone not
+      nothing now nowhere number numbers o of off often old older oldest on once
+      one only open opened opening opens or order ordered ordering orders other
+      others our out over p part parted parting parts per perhaps place places
+      point pointed pointing points possible present presented presenting
+      presents problem problems put puts q quite r rather really right right
+      room rooms s said same saw say says second seconds see seem seemed seeming
+      seems sees several shall she should show showed showing shows side sides
+      since small smaller smallest so some somebody someone something somewhere
+      state states still still such sure t take taken than that the their them
+      then there therefore these they thing things think thinks this those
+      though thought thoughts three through thus to today together too took
+      toward turn turned turning turns two u under until up upon us use used
+      uses v very w want wanted wanting wants was way ways we well wells went
+      were what when where whether which while who whole whose why will with
+      within without work worked working works would x y year years yet you
+      young younger youngest your yours z
+    ].freeze
+
     def initialize(string_or_regex)
       @string_or_regex = string_or_regex
     end
@@ -69,8 +93,8 @@ class RedactsNotices
   class RedactsPhoneNumbers
     def redact(text)
       redactor = RedactsContent.new(
-        /(\(?\d{3}\)?.?)? # optional area code
-         (\d{3}[^\d]?\d{4})| # phone number, optional single-char separator
+        /(\(?\d{3}\)?.?)?     # optional area code
+         (\d{3}[^\d]?\d{4})|  # phone number, optional single-char separator
          (\d+[\d ]{10,16}\d+) # turkish phone number
         /x
       )

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -70,9 +70,10 @@ class Work < ActiveRecord::Base
     # DeterminesWorkKind is intended for use here but disabled due to confusion
     # caused by mis-classified works.
     self.kind = 'Unspecified' if kind.blank?
-  end
 
-  before_save on: :create do
-    self.description_original = description if description_original.nil?
+    # Force associated notices to be reindexed if the description has been
+    # updated (presumably redacted). This will keep redacted text out of the
+    # Elasticsearch index.
+    notices.update_all(updated_at: Time.now) if description_changed?
   end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -12,7 +12,9 @@ class Work < ActiveRecord::Base
 
   accepts_nested_attributes_for :infringing_urls,
                                 :copyrighted_urls,
-                                :reject_if => proc { |attributes| attributes['url'].blank? }
+                                reject_if: proc { |attributes|
+                                  attributes['url'].blank?
+                                }
   validates_associated :infringing_urls, :copyrighted_urls
   validates :kind, length: { maximum: 255 }
 
@@ -71,6 +73,6 @@ class Work < ActiveRecord::Base
   end
 
   before_save on: :create do
-    self.description_original = description if self.description_original.nil?
+    self.description_original = description if description_original.nil?
   end
 end

--- a/app/views/pages/researchers.html.erb
+++ b/app/views/pages/researchers.html.erb
@@ -33,9 +33,9 @@
 <p>Businesses that receive notices (like Google, Twitter, Wordpress, Reddit and others) have partnered with Lumen to automatically send us all of the removal requests they receive.  For more information about these bulk notice submitters' submissions to Lumen, please refer to each company's own website and information pages.</p>
 
 
-<a id="missing"><h2>A notice contains "[redacted]" – what is missing?</h2></a>
+<a id="missing"><h2>A notice or work contains "[redacted]" – what is missing?</h2></a>
 
-<p>Lumen staff make a good faith effort to review and redact any potentially sensitive notices that the project receives in order to remove sensitive or personal information from the text of notices.  Such information might include phone numbers, email addresses, or allegedly defamatory content.   Further, an individual or company submitting a notice directly to the Lumen database may have decided not to share with Lumen, or to keep private, certain pieces of information in the notice.</p>
+<p>Lumen staff make a good faith effort to review and redact any potentially sensitive notices that the project receives in order to remove sensitive or personal information from the text of notices. Such information might include phone numbers, email addresses, or allegedly defamatory content. Further, an individual or company submitting a notice directly to the Lumen database may have decided not to share with Lumen, or to keep private, certain pieces of information in the notice. Finally, Lumen runs automated processes to remove certain sensitive information from notices and descriptions of their associated works where possible.</p>
 <p>Please note that for DMCA notices, Lumen does <b>not</b> redact the name of the rightsholder making the request or the URL(s) of the material complained of. Without the location of the complained-of material and the complainant, the notices are meaningless from a public transparency or research perspective, to say nothing of offering no insight as to possible misuse of takedown notices as a vehicle for censorship.</p>
 
 <a id="clearinghouse"><h2>Who is Lumen for?</h2></a>

--- a/doc/release.md
+++ b/doc/release.md
@@ -5,6 +5,8 @@ Maintenance windows are Wednesday and Saturday nights (after 5pm Eastern).
 ## Special instructions
 If any deploys have special instructions, write them here, with a date and PR number. When that PR has been deployed, you can erase the special instructions.
 
+PR #512 - add cron job for work redaction rake task, running every 2 hours with lockrun to avoid duplicating db queries.
+
 ## Hotfix
 * Write code, code-review, and merge into `dev` via the normal process.
 * Give Adam a heads-up: what you're doing, what it fixes, why it needs to be pushed out ASAP.

--- a/lib/rails_admin/config/actions/redact_notice.rb
+++ b/lib/rails_admin/config/actions/redact_notice.rb
@@ -6,8 +6,8 @@ ActionResponder = Struct.new(:context, :abstract_model, :object)
 class PostResponder < ActionResponder
   def handle(params)
     if params[:selected_text].present?
-      redactor = RedactsNotices.new([
-        RedactsNotices::RedactsContent.new(params[:selected_text])
+      redactor = InstanceRedactor.new([
+        InstanceRedactor::ContentRedactor.new(params[:selected_text])
                                     ])
 
       review_required_ids = Notice.where(review_required: true).pluck(:id)

--- a/lib/rails_admin/config/actions/redact_notice.rb
+++ b/lib/rails_admin/config/actions/redact_notice.rb
@@ -6,9 +6,9 @@ ActionResponder = Struct.new(:context, :abstract_model, :object)
 class PostResponder < ActionResponder
   def handle(params)
     if params[:selected_text].present?
-      redactor = InstanceRedactor.new([
-        InstanceRedactor::ContentRedactor.new(params[:selected_text])
-                                    ])
+      redactor = InstanceRedactor.new(
+        [InstanceRedactor::ContentRedactor.new(params[:selected_text])]
+      )
 
       review_required_ids = Notice.where(review_required: true).pluck(:id)
 
@@ -21,9 +21,11 @@ class PostResponder < ActionResponder
   private
 
   def redirect_to_current(params)
-    context.redirect_to(context.redact_notice_path(
-      abstract_model, object.id, next_notices: params[:next_notices]
-    ))
+    context.redirect_to(
+      context.redact_notice_path(
+        abstract_model, object.id, next_notices: params[:next_notices]
+      )
+    )
   end
 end
 
@@ -59,7 +61,7 @@ class PutResponder < ActionResponder
   end
 
   def respond_json
-    context.render json: { id: object.id.to_s, label: "Redact notice" }
+    context.render json: { id: object.id.to_s, label: 'Redact notice' }
   end
 
   def handle_error
@@ -69,13 +71,15 @@ class PutResponder < ActionResponder
   def save_and_next(params)
     next_notice, *next_notices = params[:next_notices]
 
-    context.redirect_to(context.redact_notice_path(
-      abstract_model, next_notice, next_notices: next_notices
-    ))
+    context.redirect_to(
+      context.redact_notice_path(
+        abstract_model, next_notice, next_notices: next_notices
+      )
+    )
   end
 end
 
-RedactNoticeProc = Proc.new do
+RedactNoticeProc = proc do
   if request.post?
     post_responder = PostResponder.new(self, @abstract_model, @object)
     post_responder.handle(params)
@@ -99,7 +103,7 @@ RedactNoticeProc = Proc.new do
 
     respond_to do |format|
       format.html { render @action.template_name }
-      format.js   { render @action.template_name, :layout => false }
+      format.js   { render @action.template_name, layout: false }
     end
   end
 end
@@ -112,7 +116,7 @@ module RailsAdmin
         register_instance_option(:link_icon) { 'icon-adjust' }
         register_instance_option(:action_name) { :redact_notice }
         register_instance_option(:member) { true }
-        register_instance_option(:http_methods) { %i( get post put ) }
+        register_instance_option(:http_methods) { %i[get post put] }
         register_instance_option(:controller) { RedactNoticeProc }
         register_instance_option :visible? do
           bindings && (object = bindings[:object]) &&

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -381,6 +381,31 @@ namespace :lumen do
     end
   end
 
+  desc 'Redact and reindex works'
+  task redact_and_reindex_works: :environment do
+    # This is a one-time task to redact sensitive information from all existing
+    # work descriptions. We only look at works before a certain date (shortly
+    # after our deploy date for this feature) because anything after that date
+    # will be auto_redacted as part of the save process.
+    works = Work.where('updated_at < (?)', Date.new(2018, 12, 31)).limit(1000)
+    works.each do |work|
+      # Make sure that updated_at changes, so we don't re-redact this work.
+      work.touch
+      work.save # calls auto_redact
+    end
+
+    # Works aren't directly indexed in ES; they're indexed as columns on Notice.
+    # Therefore we need to reindex the associated notices in order to update
+    # Elasticsearch entries. Changing the updated_at column on the associated
+    # notices will force them to update the next time
+    # index_changed_model_instances runs. This also keeps all reindexing inside
+    # that task, so this task can't step on its toes.
+    notices = Notice.joins(:works)
+                    .where('works.id IN (?)', works.pluck(:id))
+                    .distinct
+    notices.update_all(updated_at: Time.now)
+  end
+
   desc 'Publish notices whose publication delay has expired'
   task publish_embargoed: :environment do
     Notice.where(published: false).each do |notice|

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -65,7 +65,7 @@ namespace :lumen do
   end
 
   desc 'Index notices by csv'
-  task :index_notices_by_csv, [:input_csv, :id_column] => :environment do |t, args|
+  task :index_notices_by_csv, %i[input_csv id_column] => :environment do |_t, args|
     index_notices_by_csv args[:input_csv], args[:id_column]
   end
 
@@ -105,7 +105,7 @@ namespace :lumen do
   end
 
   desc 'Recreate elasticsearch index for notices with a given recipient entity_id'
-  task :index_notices_by_entity_id, [:entity_id] => :environment do |t, args|
+  task :index_notices_by_entity_id, [:entity_id] => :environment do |_t, args|
     begin
       batch_size = (ENV['BATCH_SIZE'] || 192).to_i
 
@@ -128,11 +128,11 @@ namespace :lumen do
   end
 
   desc 'Recreate elasticsearch index for notices of a given date'
-  task :index_notices_by_date, [:date] => :environment do |t, args|
+  task :index_notices_by_date, [:date] => :environment do |_t, args|
     begin
       batch_size = (ENV['BATCH_SIZE'] || 192).to_i
 
-      notices = Notice.where("created_at::date = '#{args[ :date ]}'")
+      notices = Notice.where("created_at::date = '#{args[:date]}'")
       Rails.logger.info "index_notices date: #{args[:date]}, total: #{notices.count}"
 
       count = 0
@@ -151,7 +151,7 @@ namespace :lumen do
   end
 
   desc 'Recreate elasticsearch index for notices of a given month'
-  task :index_notices_by_month, [:month, :year] => :environment do |t, args|
+  task :index_notices_by_month, [:month, :year] => :environment do |_t, args|
     begin
       batch_size = (ENV['BATCH_SIZE'] || 192).to_i
 
@@ -174,7 +174,7 @@ namespace :lumen do
   end
 
   desc 'Recreate elasticsearch index for notices of a given year'
-  task :index_notices_by_year, [:year] => :environment do |t, args|
+  task :index_notices_by_year, [:year] => :environment do |_t, args|
     begin
       batch_size = (ENV['BATCH_SIZE'] || 192).to_i
 
@@ -283,7 +283,7 @@ namespace :lumen do
   end
 
   desc 'Hide notices by submission_id'
-  task :hide_notices_by_sid, [:input_csv, :sid_column] => :environment do |t, args|
+  task :hide_notices_by_sid, %i[input_csv sid_column] => :environment do |_t, args|
     hide_notices_by_sid args[:input_csv], args[:sid_column]
   end
 
@@ -324,7 +324,7 @@ namespace :lumen do
   end
 
   desc 'Change incorrect notice type'
-  task :change_incorrect_notice_type, [:input_csv] => :environment do |t, args|
+  task :change_incorrect_notice_type, [:input_csv] => :environment do |_t, args|
     incorrect_ids_file = args[:input_csv] || Rails.root.join('tmp', 'incorrect_ids.csv')
     incorrect_notice_ids = []
     incorrect_notice_id_type = {}
@@ -408,9 +408,7 @@ namespace :lumen do
 
   desc 'Publish notices whose publication delay has expired'
   task publish_embargoed: :environment do
-    Notice.where(published: false).each do |notice|
-      notice.set_published!
-    end
+    Notice.where(published: false).each(&:set_published!)
   end
 
   def with_file_name
@@ -423,7 +421,7 @@ namespace :lumen do
 
   desc 'Assign blank action_taken to Google notices'
   task blank_action_taken: :environment do
-    ActiveRecord::Base.connection.execute %Q{
+    ActiveRecord::Base.connection.execute %{
 update notices
 set action_taken = '',
   updated_at = now()
@@ -436,10 +434,10 @@ where notices.id in (
   end
 
   desc 'Redact content in a single notice by id'
-  task :redact_lr_legalother_single, [:notice_id] => :environment do |t, args|
+  task :redact_lr_legalother_single, [:notice_id] => :environment do |_t, args|
     begin
       notices = Notice.includes(
-        works: [:infringing_urls, :copyrighted_urls]
+        works: %i[infringing_urls copyrighted_urls]
       ).where(
         id: args[:notice_id]
       )
@@ -475,7 +473,7 @@ where notices.id in (
       total = entities.count
       entities.each.with_index(1) do |e, i|
         notices = e.notices.includes(
-          works: [:infringing_urls, :copyrighted_urls]
+          works: %i[infringing_urls copyrighted_urls]
         ).where(
           entity_notice_roles: { name: 'recipient' }
         ).where(
@@ -493,7 +491,8 @@ where notices.id in (
             redactor = InstanceRedactor::EntityNameRedactor.new(notice.sender.name)
             notice.works.each do |work|
               work.update_attributes(
-                description: redactor.redact(work.description))
+                description: redactor.redact(work.description)
+              )
               work.infringing_urls.each do |iu|
                 iu.update_attributes(url: redactor.redact(iu.url))
               end
@@ -531,7 +530,7 @@ where notices.id in (
   end
 
   desc "Given a work, for every notice having that work: replace the notice's work with a new blank work"
-  task :blank_work_notices_works, [:work_id] => :environment do |t, args|
+  task :blank_work_notices_works, [:work_id] => :environment do |_t, args|
     blank_work_notices_works args[:work_id]
   end
 
@@ -561,7 +560,7 @@ where notices.id in (
 
   desc 'Remove kinds from Google notices'
   task remove_google_kinds: :environment do
-    ActiveRecord::Base.connection.execute %Q{
+    ActiveRecord::Base.connection.execute %{
 update works
 set kind = 'Unspecified'
 where works.id in (
@@ -608,7 +607,7 @@ where works.id in (
                                           'google, inc', 'google inc',
                                           'google inc.'])
                             .pluck(:id)
-    google_entities - [1]
+    google_entities.delete(1)
     EntityNoticeRole.where(entity_id: google_entities).update_all(entity_id: 1)
   end
 
@@ -623,7 +622,7 @@ where works.id in (
                                            'TWITTER, INC.', 'twitter.com',
                                            'Twitter Trust and Safety'])
                              .pluck(:id)
-    twitter_entities - [447_642]
+    twitter_entities.delete(447_642)
     EntityNoticeRole.where(entity_id: twitter_entities)
                     .update_all(entity_id: 447_642)
   end

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -367,7 +367,7 @@ namespace :lumen do
       [Notice, Entity].each do |klass|
         ids = klass.pluck(:id)
         ids.each do |id|
-          if ReindexRun.is_indexed?(klass, id)
+          if ReindexRun.indexed?(klass, id)
             puts "Skipping #{klass}, #{id}"
           else
             puts "Indexing #{klass}, #{id}"

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -424,7 +424,7 @@ where notices.id in (
       notices.find_in_batches do |group|
         group.each do |notice|
           next unless notice.sender.present?
-          redactor = RedactsNotices::RedactsEntityName.new(notice.sender.name)
+          redactor = InstanceRedactor::EntityNameRedactor.new(notice.sender.name)
           notice.works.each do |work|
             work.update_attributes(
               description: redactor.redact(work.description)
@@ -465,7 +465,7 @@ where notices.id in (
         notices.find_in_batches do |group|
           group.each do |notice|
             next unless notice.sender.present?
-            redactor = RedactsNotices::RedactsEntityName.new(notice.sender.name)
+            redactor = InstanceRedactor::EntityNameRedactor.new(notice.sender.name)
             notice.works.each do |work|
               work.update_attributes(
                 description: redactor.redact(work.description))

--- a/spec/integration/notice_search_spec.rb
+++ b/spec/integration/notice_search_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 require 'yaml'
 require 'support/contain_link'
 
-feature "Searching Notices", type: :feature do
+feature 'Searching Notices', type: :feature do
   include SearchHelpers
   include ContainLink
 
-  scenario "displays the results" do
+  scenario 'displays the results' do
     create_list(:dmca, 5, title: 'Boy howdy')
     index_changed_instances
 
@@ -83,8 +83,9 @@ feature "Searching Notices", type: :feature do
 
     submit_search 'foo'
 
-    expect(page).not_to have_css('li.excerpt',
-      text:'<strong>foo</strong> and <em>bar</em>'
+    expect(page).not_to have_css(
+      'li.excerpt',
+      text: '<strong>foo</strong> and <em>bar</em>'
     )
   end
 
@@ -106,8 +107,8 @@ feature "Searching Notices", type: :feature do
     expect(first_page).not_to eq second_page
   end
 
-  scenario "displays search terms", search: true do
-    create(:dmca, title: "The Lion King on Youtube")
+  scenario 'displays search terms', search: true do
+    create(:dmca, title: 'The Lion King on Youtube')
     index_changed_instances
 
     submit_search 'awesome blossom'
@@ -115,12 +116,12 @@ feature "Searching Notices", type: :feature do
     expect(page).to have_css("input#search[value='awesome blossom']")
   end
 
-  scenario "for full-text on a single model", search: true do
-    notice = create(:dmca, title: "The Lion King on Youtube")
+  scenario 'for full-text on a single model', search: true do
+    notice = create(:dmca, title: 'The Lion King on Youtube')
     trademark = create(:trademark, title: "Coke - it's the King thing")
     index_changed_instances
 
-    within_search_results_for("king") do
+    within_search_results_for('king') do
       expect(page).to have_n_results(2)
       expect(page).to have_content(notice.title)
       expect(page).to have_content(trademark.title)
@@ -128,11 +129,11 @@ feature "Searching Notices", type: :feature do
     end
   end
 
-  scenario "based on action taken", search: true do
+  scenario 'based on action taken', search: true do
     notices = [
       create(:dmca, action_taken: 'No'),
       create(:dmca, action_taken: 'Yes'),
-      create(:dmca, action_taken: 'Partial'),
+      create(:dmca, action_taken: 'Partial')
     ]
     index_changed_instances
 
@@ -144,9 +145,9 @@ feature "Searching Notices", type: :feature do
     end
   end
 
-  scenario "paginates properly", search: true do
+  scenario 'paginates properly', search: true do
     3.times do
-      create(:dmca, title: "The Lion King on Youtube")
+      create(:dmca, title: 'The Lion King on Youtube')
     end
     index_changed_instances
 
@@ -159,47 +160,47 @@ feature "Searching Notices", type: :feature do
     end
   end
 
-  scenario "it does not include rescinded notices", search: true do
-    notice = create(:dmca, title: "arbitrary", rescinded: true)
+  scenario 'it does not include rescinded notices', search: true do
+    notice = create(:dmca, title: 'arbitrary', rescinded: true)
     index_changed_instances
 
-    expect_search_to_not_find("arbitrary", notice)
+    expect_search_to_not_find('arbitrary', notice)
   end
 
-  scenario "it does not include spam notices", search: true do
-    notice = create(:dmca, title: "arbitrary", spam: true)
+  scenario 'it does not include spam notices', search: true do
+    notice = create(:dmca, title: 'arbitrary', spam: true)
     index_changed_instances
 
-    expect_search_to_not_find("arbitrary", notice)
+    expect_search_to_not_find('arbitrary', notice)
   end
 
-  scenario "it does not include hidden notices", search: true do
-    notice = create(:dmca, title: "arbitrary", hidden: true)
+  scenario 'it does not include hidden notices', search: true do
+    notice = create(:dmca, title: 'arbitrary', hidden: true)
     index_changed_instances
 
-    expect_search_to_not_find("arbitrary", notice)
+    expect_search_to_not_find('arbitrary', notice)
   end
 
-  scenario "it does not include unpublished notices", search: true do
-    notice = create(:dmca, title: "fanciest pants", published: false)
-    found_notice = create(:dmca, title: "fancy pants")
+  scenario 'it does not include unpublished notices', search: true do
+    notice = create(:dmca, title: 'fanciest pants', published: false)
+    found_notice = create(:dmca, title: 'fancy pants')
     index_changed_instances
 
-    within_search_results_for("pants") do
+    within_search_results_for('pants') do
       expect(page).to have_n_results(1)
       expect(page).to have_content(found_notice.title)
     end
 
-    expect_search_to_not_find("fanciest pants", notice)
+    expect_search_to_not_find('fanciest pants', notice)
   end
 
-  context "within associated models" do
-    scenario "for topic names", search: true do
-      topic = create(:topic, name: "Lion King")
+  context 'within associated models' do
+    scenario 'for topic names', search: true do
+      topic = create(:topic, name: 'Lion King')
       notice = create(:dmca, topics: [topic])
       index_changed_instances
 
-      within_search_results_for("king") do
+      within_search_results_for('king') do
         expect(page).to have_n_results(1)
         expect(page).to have_content(notice.title)
         expect(page).to have_content(topic.name)
@@ -208,19 +209,19 @@ feature "Searching Notices", type: :feature do
       end
     end
 
-    scenario "for tags", search: true do
+    scenario 'for tags', search: true do
       notice = create(:dmca, tag_list: 'foo, bar')
       index_changed_instances
 
-      within_search_results_for("bar") do
+      within_search_results_for('bar') do
         expect(page).to have_n_results(1)
         expect(page).to have_content(notice.title)
-        expect(page.html).to have_excerpt("bar")
+        expect(page.html).to have_excerpt('bar')
       end
     end
 
-    scenario "for entities", search: true do
-      notice = create(:dmca, role_names: %w( sender principal recipient))
+    scenario 'for entities', search: true do
+      notice = create(:dmca, role_names: %w[sender principal recipient])
       index_changed_instances
 
       within_search_results_for(notice.recipient_name) do
@@ -245,19 +246,19 @@ feature "Searching Notices", type: :feature do
       end
     end
 
-    scenario "for works", search: true do
+    scenario 'for works', search: true do
       work = create(
-        :work, description: "An arbitrary description"
+        :work, description: 'An arbitrary description'
       )
 
       notice = create(:dmca, works: [work])
       index_changed_instances
 
-      within_search_results_for("arbitrary") do
+      within_search_results_for('arbitrary') do
         expect(page).to have_n_results(1)
         expect(page).to have_content(notice.title)
         expect(page).to have_content(work.description)
-        expect(page.html).to have_excerpt("arbitrary", "An", "description")
+        expect(page.html).to have_excerpt('arbitrary', 'An', 'description')
       end
     end
 
@@ -309,7 +310,7 @@ feature "Searching Notices", type: :feature do
       end
     end
 
-    scenario "for urls associated through works", search: true do
+    scenario 'for urls associated through works', search: true do
       work = create(
         :work,
         infringing_urls: [
@@ -337,54 +338,54 @@ feature "Searching Notices", type: :feature do
     end
   end
 
-  context "changes to associated models" do
-    scenario "a topic is created", search: true do
+  context 'changes to associated models' do
+    scenario 'a topic is created', search: true do
       notice = create(:dmca)
-      notice.topics.create!(name: "arbitrary")
+      notice.topics.create!(name: 'arbitrary')
       index_changed_instances
 
-      within_search_results_for("arbitrary") do
+      within_search_results_for('arbitrary') do
         expect(page).to have_n_results(1)
         expect(page).to have_content(notice.title)
       end
     end
 
-    scenario "a topic is destroyed", search: true do
-      topic = create(:topic, name: "arbitrary")
+    scenario 'a topic is destroyed', search: true do
+      topic = create(:topic, name: 'arbitrary')
       notice = create(:dmca, topics: [topic])
       topic.destroy
       index_changed_instances
 
-      expect_search_to_not_find("arbitrary", notice)
+      expect_search_to_not_find('arbitrary', notice)
     end
 
-    scenario "a topic updates its name", search: true do
-      topic = create(:topic, name: "something")
+    scenario 'a topic updates its name', search: true do
+      topic = create(:topic, name: 'something')
       notice = create(:dmca, topics: [topic])
-      topic.update_attributes!(name: "arbitrary")
+      topic.update_attributes!(name: 'arbitrary')
       index_changed_instances
 
-      within_search_results_for("arbitrary") do
+      within_search_results_for('arbitrary') do
         expect(page).to have_n_results(1)
         expect(page).to have_content(notice.title)
       end
     end
   end
 
-  scenario "advanced search on multiple fields", search: true do
-    create_notice_with_entities("Jim & Jon's", "Jim", "Jon")
-    create_notice_with_entities("Jim & Dan's", "Jim", "Dan")
-    create_notice_with_entities("Dan & Jon's", "Dan", "Jon")
+  scenario 'advanced search on multiple fields', search: true do
+    create_notice_with_entities("Jim & Jon's", 'Jim', 'Jon')
+    create_notice_with_entities("Jim & Dan's", 'Jim', 'Dan')
+    create_notice_with_entities("Dan & Jon's", 'Dan', 'Jon')
     index_changed_instances
 
-    search_for(sender_name: "Jim", recipient_name: "Jon")
+    search_for(sender_name: 'Jim', recipient_name: 'Jon')
 
     expect(page).to have_content("Jim & Jon's")
     expect(page).to have_no_content("Jim & Dan's")
     expect(page).to have_no_content("Dan & Jon's")
   end
 
-  scenario "searching with a blank parameter", search: true do
+  scenario 'searching with a blank parameter', search: true do
     expect { submit_search('') }.not_to raise_error
   end
 

--- a/spec/models/dmca_spec.rb
+++ b/spec/models/dmca_spec.rb
@@ -91,11 +91,11 @@ describe DMCA, type: :model do
   end
 
   context '#auto_redact' do
-    it 'calls RedactsNotices#redact on itself' do
+    it 'calls InstanceRedactor#redact on itself' do
       notice = DMCA.new
-      redactor = RedactsNotices.new
+      redactor = InstanceRedactor.new
       expect(redactor).to receive(:redact).with(notice)
-      expect(RedactsNotices).to receive(:new).and_return(redactor)
+      expect(InstanceRedactor).to receive(:new).and_return(redactor)
 
       notice.auto_redact
     end

--- a/spec/models/instance_redactor_spec.rb
+++ b/spec/models/instance_redactor_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe RedactsNotices::RedactsContent do
+describe InstanceRedactor::ContentRedactor do
   it "redacts a literal string" do
     redactor = described_class.new('sens[itive]')
 
@@ -18,7 +18,7 @@ describe RedactsNotices::RedactsContent do
   end
 end
 
-describe RedactsNotices::RedactsPhoneNumbers do
+describe InstanceRedactor::PhoneNumberRedactor do
   PHONE_NUMBERS = %w(
     123-456-7890
     123.456.7890
@@ -43,7 +43,7 @@ describe RedactsNotices::RedactsPhoneNumbers do
   end
 end
 
-describe RedactsNotices::RedactsSSNs do
+describe InstanceRedactor::SSNRedactor do
   SSNS = %w(
     123-45-6789
     123.45.6789
@@ -62,7 +62,7 @@ describe RedactsNotices::RedactsSSNs do
   end
 end
 
-describe RedactsNotices::RedactsEmail do
+describe InstanceRedactor::EmailRedactor do
   EMAILS = %w(
     test@example.com
     someone@cyber.law.harvard.edu
@@ -82,13 +82,13 @@ describe RedactsNotices::RedactsEmail do
   end
 end
 
-describe RedactsNotices do
+describe InstanceRedactor do
   context "#redact" do
     it "passes the field's text through all redactors" do
       notice = build(:dmca, body: 'sensitive-a and sensitive-b')
-      redactor = RedactsNotices.new([
-        RedactsNotices::RedactsContent.new('sensitive-a'),
-        RedactsNotices::RedactsContent.new('sensitive-b')
+      redactor = InstanceRedactor.new([
+        InstanceRedactor::ContentRedactor.new('sensitive-a'),
+        InstanceRedactor::ContentRedactor.new('sensitive-b')
       ])
 
       redactor.redact(notice, :body)
@@ -98,8 +98,8 @@ describe RedactsNotices do
 
     it "preserves the original text" do
       notice = build(:dmca, body: 'Some sensitive text')
-      redactor = RedactsNotices.new([
-        RedactsNotices::RedactsContent.new('sensitive')
+      redactor = InstanceRedactor.new([
+        InstanceRedactor::ContentRedactor.new('sensitive')
       ])
 
       redactor.redact(notice, :body)
@@ -113,8 +113,8 @@ describe RedactsNotices do
         body: "Some [REDACTED] text",
         body_original: "Some sensitive text"
       )
-      redactor = RedactsNotices.new([
-        RedactsNotices::RedactsContent.new('sensitive')
+      redactor = InstanceRedactor.new([
+        InstanceRedactor::ContentRedactor.new('sensitive')
       ])
 
       redactor.redact(notice, :body)
@@ -127,7 +127,7 @@ describe RedactsNotices do
       notice = build(
         :dmca,
         body: "Text with the stopwords")
-      redactor = RedactsNotices.new([RedactsNotices::RedactsContent.new('the')])
+      redactor = InstanceRedactor.new([InstanceRedactor::ContentRedactor.new('the')])
 
       redactor.redact(notice, :body)
 
@@ -140,8 +140,8 @@ describe RedactsNotices do
       notice_one = create(:dmca, body: 'One sensitive thing')
       notice_two = create(:dmca, body: 'Two sensitive thing')
       unaffected = create(:dmca, body: 'Three sensitive thing')
-      redactor = RedactsNotices.new([
-        RedactsNotices::RedactsContent.new('sensitive')
+      redactor = InstanceRedactor.new([
+        InstanceRedactor::ContentRedactor.new('sensitive')
       ])
 
       redactor.redact_all([notice_one.id, notice_two.id], :body)
@@ -153,7 +153,7 @@ describe RedactsNotices do
   end
 
   def simple_redactor(from, to)
-    redactor = RedactsNotices::RedactsContent.new(from)
+    redactor = InstanceRedactor::ContentRedactor.new(from)
     allow(redactor).to receive(:mask).and_return(to)
 
     redactor

--- a/spec/models/reindex_run_spec.rb
+++ b/spec/models/reindex_run_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ReindexRun, type: :model do
-  it "tracks run information when no exceptions are thrown" do
+  it 'tracks run information when no exceptions are thrown' do
     reindex_run = create(:reindex_run)
     expect(ReindexRun).to receive(:create!).and_return(reindex_run)
     now = Time.now
@@ -17,15 +17,17 @@ describe ReindexRun, type: :model do
     expect(reindex_run.updated_at.to_s).to eq now.utc.to_s
   end
 
-  it "does not track run information when exceptions are thrown" do
-    expect(ReindexRun).not_to receive(:create!).with(entity_count: 0, notice_count: 0)
+  it 'does not track run information when exceptions are thrown' do
+    expect(ReindexRun)
+      .not_to receive(:create!)
+      .with(entity_count: 0, notice_count: 0)
     allow(Notice).to receive(:where).and_raise(StandardError)
 
     described_class.index_changed_model_instances
   end
 
-  context ".last_run" do
-    it "equals the last run" do
+  context '.last_run' do
+    it 'equals the last run' do
       earliest_run = create(:reindex_run)
       latest_run = Timecop.travel(1.hour) { create(:reindex_run) }
 
@@ -33,8 +35,8 @@ describe ReindexRun, type: :model do
     end
   end
 
-  context "entities" do
-    it "only reindexes changed entities" do
+  context 'entities' do
+    it 'only reindexes changed entities' do
       create(:reindex_run)
 
       old_entity = Timecop.travel(1.hour.ago) { create(:entity, name: 'Old') }
@@ -47,8 +49,8 @@ describe ReindexRun, type: :model do
     end
   end
 
-  context "notices" do
-    it "only reindexes changed notices" do
+  context 'notices' do
+    it 'only reindexes changed notices' do
       create(:reindex_run)
 
       old_entity = Timecop.travel(1.hour.ago) { create(:dmca, title: 'Old') }

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -10,23 +10,23 @@ RSpec.describe Work, type: :model do
   end
 
   context '.unknown' do
-    it "provides an unknown work" do
+    it 'provides an unknown work' do
       work = Work.unknown
 
       expect(work.kind).to eq 'unknown'
       expect(work.description).to eq Work::UNKNOWN_WORK_DESCRIPTION
     end
 
-    it "caches the unknown work" do
-      work_1 = Work.unknown
-      work_2 = Work.unknown
+    it 'caches the unknown work' do
+      work1 = Work.unknown
+      work2 = Work.unknown
 
-      expect(work_1).to eq work_2
+      expect(work1).to eq work2
     end
   end
 
   context '#infringing_urls' do
-    it "does not create duplicate infringing_urls" do
+    it 'does not create duplicate infringing_urls' do
       existing_infringing_url = create(
         :infringing_url, url: 'http://www.example.com/infringe'
       )
@@ -44,7 +44,7 @@ RSpec.describe Work, type: :model do
   end
 
   context '#copyrighted_urls' do
-    it "does not create duplicate copyrighted_urls" do
+    it 'does not create duplicate copyrighted_urls' do
       existing_copyrighted_url = create(
         :copyrighted_url, url: 'http://www.example.com/copyrighted'
       )
@@ -63,14 +63,14 @@ RSpec.describe Work, type: :model do
   end
 
   context '#kind' do
-    it "auto classifies before saving if kind is not set" do
+    it 'auto classifies before saving if kind is not set' do
       work = build(:work)
 
       work.save
       expect(work.kind).to eq 'Unspecified'
     end
 
-    it "does not auto classify if kind is set" do
+    it 'does not auto classify if kind is set' do
       expect_any_instance_of(DeterminesWorkKind).not_to receive(:kind)
       work = build(:work, kind: 'foo')
 
@@ -78,27 +78,31 @@ RSpec.describe Work, type: :model do
     end
   end
 
-  it "validates infringing urls correctly when multiple are used at once" do
-    notice = notice_with_works_attributes([
-      { infringing_urls_attributes: [{ url: "this is not a url" }] },
-      { infringing_urls_attributes: [{ url: "this is also not a url" }] }
-    ])
+  it 'validates infringing urls correctly when multiple are used at once' do
+    notice = notice_with_works_attributes(
+      [
+        { infringing_urls_attributes: [{ url: 'this is not a url' }] },
+        { infringing_urls_attributes: [{ url: 'this is also not a url' }] }
+      ]
+    )
 
     expect(notice).not_to be_valid
     expect(notice.errors.messages).to eq(
-      { :"works.infringing_urls" => ["is invalid"] }
+      'works.infringing_urls': ['is invalid']
     )
   end
 
-  it "validates copyrighted urls correctly when multiple are used at once" do
-    notice = notice_with_works_attributes([
-      { copyrighted_urls_attributes: [{ url: "this is not a url" }] },
-      { copyrighted_urls_attributes: [{ url: "this is also not a url" }] }
-    ])
+  it 'validates copyrighted urls correctly when multiple are used at once' do
+    notice = notice_with_works_attributes(
+      [
+        { copyrighted_urls_attributes: [{ url: 'this is not a url' }] },
+        { copyrighted_urls_attributes: [{ url: 'this is also not a url' }] }
+      ]
+    )
 
     expect(notice).not_to be_valid
     expect(notice.errors.messages).to eq(
-      { :"works.copyrighted_urls" => ["is invalid"] }
+      'works.copyrighted_urls': ['is invalid']
     )
   end
 

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -102,6 +102,30 @@ RSpec.describe Work, type: :model do
     )
   end
 
+  context 'redaction' do
+    it 'redacts phone numbers with auto_redact' do
+      content = '(617) 867-5309'
+      test_redaction(content)
+    end
+
+    it 'redacts emails with auto_redact' do
+      content = 'me@example.com'
+      test_redaction(content)
+    end
+
+    it 'redacts SSNs with auto_redact' do
+      content = '123-45-6789'
+      test_redaction(content)
+    end
+
+    it 'redacts automatically on save' do
+      params = { description: 'Test' }
+      work = Work.new(params)
+      expect(work).to receive(:auto_redact)
+      work.save
+    end
+  end
+
   private
 
   def notice_with_works_attributes(attributes)
@@ -112,5 +136,21 @@ RSpec.describe Work, type: :model do
         entity_attributes: { name: 'Recipient' }
       }]
     )
+  end
+
+  def work_for_redaction_testing(redact_me)
+    params = { description: "Test if we redact #{redact_me}" }
+    work = Work.new(params)
+    work.auto_redact
+    work.save
+    work.reload
+    work
+  end
+
+  def test_redaction(content)
+    work = work_for_redaction_testing(content)
+
+    expect(work.description).not_to include content
+    expect(work.description_original).to include content
   end
 end

--- a/spec/rails_admin/config/actions/redact_notice_spec.rb
+++ b/spec/rails_admin/config/actions/redact_notice_spec.rb
@@ -161,9 +161,9 @@ describe "RedactNoticeProc" do
       it "redacts this and all next notices" do
         params[:selected_text] = "Sensitive thing"
         params[:next_notices]  = %w( 2 3 4 )
-        redactor = expect_new(RedactsNotices,
+        redactor = expect_new(InstanceRedactor,
                               [
-                                expect_new(RedactsNotices::RedactsContent,
+                                expect_new(InstanceRedactor::ContentRedactor,
                                            'Sensitive thing')
                               ])
         review_required_ids = [@object.id] + redactable_notices.map(&:id)

--- a/spec/rails_admin/config/actions/redact_notice_spec.rb
+++ b/spec/rails_admin/config/actions/redact_notice_spec.rb
@@ -1,15 +1,15 @@
 require 'spec_helper'
 require 'rails_admin/config/actions/redact_notice'
 
-describe "RedactNoticeProc" do
+describe 'RedactNoticeProc' do
   include RailsAdminActionContext
 
   before { setup_action_context }
 
-  context "Handling GET requests" do
+  context 'Handling GET requests' do
     before { allow(request).to receive(:get?).and_return(true) }
 
-    it "sets the correct redactable fields" do
+    it 'sets the correct redactable fields' do
       instance_eval(&RedactNoticeProc)
 
       expect(@redactable_fields).to eq Notice::REDACTABLE_FIELDS
@@ -21,18 +21,18 @@ describe "RedactNoticeProc" do
       expect(@next_notice_path).to be_nil
     end
 
-    it "sets next notice path when param is present" do
-      params[:next_notices] = %w( 1 2 3 )
-      should_receive(:redact_notice_path).
-        with(@abstract_model, '1', next_notices: %w( 2 3 )).
-        and_return(:some_path)
+    it 'sets next notice path when param is present' do
+      params[:next_notices] = %w[1 2 3]
+      should_receive(:redact_notice_path)
+        .with(@abstract_model, '1', next_notices: %w[2 3])
+        .and_return(:some_path)
 
       instance_eval(&RedactNoticeProc)
 
       expect(@next_notice_path).to eq :some_path
     end
 
-    it "renders the action template for html" do
+    it 'renders the action template for html' do
       allow(format).to receive(:html).and_yield
       allow(@action).to receive(:template_name).and_return('template_name')
       should_receive(:render).with('template_name')
@@ -40,7 +40,7 @@ describe "RedactNoticeProc" do
       instance_eval(&RedactNoticeProc)
     end
 
-    it "renders with layout false for js" do
+    it 'renders with layout false for js' do
       allow(format).to receive(:js).and_yield
       allow(@action).to receive(:template_name).and_return('template_name')
       should_receive(:render).with('template_name', layout: false)
@@ -49,28 +49,29 @@ describe "RedactNoticeProc" do
     end
   end
 
-  context "Handling PUT requests" do
+  context 'Handling PUT requests' do
     before { allow(request).to receive(:put?).and_return(true) }
 
-    it "delegates to the PutResponder" do
-      responder = double("Put responder")
+    it 'delegates to the PutResponder' do
+      responder = double('Put responder')
       expect(responder).to receive(:handle).with(params)
-      expect(PutResponder).to receive(:new).
-        with(self, @abstract_model, @object).and_return(responder)
+      expect(PutResponder).to receive(:new)
+        .with(self, @abstract_model, @object)
+        .and_return(responder)
 
       instance_eval(&RedactNoticeProc)
     end
 
-    context "PutResponder#handler" do
-      it "updates the objects attributes" do
+    context 'PutResponder#handler' do
+      it 'updates the objects attributes' do
         stub_notice_params(
-          body: "A",
-          body_original: "B",
-          review_required: "1"
+          body: 'A',
+          body_original: 'B',
+          review_required: '1'
         )
-        expect(@object).to receive(:body=).with("A")
-        expect(@object).to receive(:body_original=).with("B")
-        expect(@object).to receive(:review_required=).with("1")
+        expect(@object).to receive(:body=).with('A')
+        expect(@object).to receive(:body_original=).with('B')
+        expect(@object).to receive(:review_required=).with('1')
         expect(@object).to receive(:save)
 
         put_responder.handle(params)
@@ -78,19 +79,19 @@ describe "RedactNoticeProc" do
 
       it "updates the object's attributes" do
         stub_notice_params(
-          body: "A",
-          body_original: "B",
-          review_required: "1"
+          body: 'A',
+          body_original: 'B',
+          review_required: '1'
         )
-        expect(@object).to receive(:body=).with("A")
-        expect(@object).to receive(:body_original=).with("B")
-        expect(@object).to receive(:review_required=).with("1")
+        expect(@object).to receive(:body=).with('A')
+        expect(@object).to receive(:body_original=).with('B')
+        expect(@object).to receive(:review_required=).with('1')
         expect(@object).to receive(:save)
 
         put_responder.handle(params)
       end
 
-      it "calls handle_save_error on failure" do
+      it 'calls handle_save_error on failure' do
         stub_notice_params
         allow(@object).to receive(:save).and_return(false)
         should_receive(:handle_save_error).with(:redact_notice)
@@ -98,37 +99,40 @@ describe "RedactNoticeProc" do
         put_responder.handle(params)
       end
 
-      context "successful save" do
+      context 'successful save' do
         before do
           stub_notice_params
           allow(@object).to receive(:save).and_return(true)
         end
 
-        it "redirects to the queue path" do
+        it 'redirects to the queue path' do
           allow(format).to receive(:html).and_yield
-          should_receive(:redact_queue_path).
-            with(@abstract_model).and_return(:some_path)
+          should_receive(:redact_queue_path)
+            .with(@abstract_model)
+            .and_return(:some_path)
           should_receive(:redirect_to).with(:some_path)
 
           put_responder.handle(params)
         end
 
-        it "redirects to next when appropriate" do
+        it 'redirects to next when appropriate' do
           params[:save_and_next] = true
-          params[:next_notices] = %w( 1 2 3 )
+          params[:next_notices] = %w[1 2 3]
           allow(format).to receive(:html).and_yield
-          should_receive(:redact_notice_path).
-            with(@abstract_model, '1', next_notices: %w( 2 3 )).
-            and_return(:some_path)
+          should_receive(:redact_notice_path)
+            .with(@abstract_model, '1', next_notices: %w[2 3])
+            .and_return(:some_path)
           should_receive(:redirect_to).with(:some_path)
 
           put_responder.handle(params)
         end
 
-        it "renders JSON for js requests" do
+        it 'renders JSON for js requests' do
           allow(format).to receive(:js).and_yield
           allow(@object).to receive(:id).and_return(1)
-          should_receive(:render).with(json: { id: "1", label: "Redact notice" })
+          should_receive(:render).with(
+            json: { id: '1', label: 'Redact notice' }
+          )
 
           put_responder.handle(params)
         end
@@ -140,36 +144,37 @@ describe "RedactNoticeProc" do
       params[:notice] = notice_params
     end
 
-    def handle_save_error(*)
-    end
+    def handle_save_error(*); end
   end
 
-  context "Handling POST requests" do
+  context 'Handling POST requests' do
     before { allow(request).to receive(:post?).and_return(true) }
     let!(:redactable_notices) { create_list(:dmca, 3, :redactable) }
 
-    it "delegates to the PostResponder" do
-      responder = double("Post responder")
+    it 'delegates to the PostResponder' do
+      responder = double('Post responder')
       expect(responder).to receive(:handle).with(params)
-      expect(PostResponder).to receive(:new).
-        with(self, @abstract_model, @object).and_return(responder)
+      expect(PostResponder).to receive(:new)
+        .with(self, @abstract_model, @object)
+        .and_return(responder)
 
       instance_eval(&RedactNoticeProc)
     end
 
-    context "PostResponder#handle" do
-      it "redacts this and all next notices" do
-        params[:selected_text] = "Sensitive thing"
-        params[:next_notices]  = %w( 2 3 4 )
+    context 'PostResponder#handle' do
+      it 'redacts this and all next notices' do
+        params[:selected_text] = 'Sensitive thing'
+        params[:next_notices]  = %w[2 3 4]
         redactor = expect_new(InstanceRedactor,
                               [
                                 expect_new(InstanceRedactor::ContentRedactor,
                                            'Sensitive thing')
                               ])
         review_required_ids = [@object.id] + redactable_notices.map(&:id)
-        expect(redactor).to receive(:redact_all).with(contain_exactly(*review_required_ids))
+        expect(redactor).to receive(:redact_all)
+          .with(contain_exactly(*review_required_ids))
         should_receive(:redact_notice_path)
-          .with(@abstract_model, 1, next_notices: %w( 2 3 4 ))
+          .with(@abstract_model, 1, next_notices: %w[2 3 4])
           .and_return(:some_path)
         should_receive(:redirect_to).with(:some_path)
 

--- a/spec/support/tasks.rb
+++ b/spec/support/tasks.rb
@@ -1,0 +1,37 @@
+# Copied from https://www.eliotsykes.com/test-rails-rake-tasks-with-rspec .
+require 'rake'
+
+# Task names should be used in the top-level describe, with an optional
+# "rake "-prefix for better documentation. Both of these will work:
+#
+# 1) describe "foo:bar" do ... end
+#
+# 2) describe "rake foo:bar" do ... end
+#
+# Favor including "rake "-prefix as in the 2nd example above as it produces
+# doc output that makes it clear a rake task is under test and how it is
+# invoked.
+module TaskExampleGroup
+  extend ActiveSupport::Concern
+
+  included do
+    let(:task_name) { self.class.top_level_description.sub(/\Arake /, '') }
+    let(:tasks) { Rake::Task }
+
+    # Make the Rake task available as `task` in your examples:
+    subject(:task) { tasks[task_name] }
+  end
+end
+
+RSpec.configure do |config|
+  # Tag Rake specs with `:task` metadata or put them in the spec/tasks dir
+  config.define_derived_metadata(file_path: %r{/spec/tasks/}) do |metadata|
+    metadata[:type] = :task
+  end
+
+  config.include TaskExampleGroup, type: :task
+
+  config.before(:suite) do
+    Rails.application.load_tasks
+  end
+end

--- a/spec/tasks/redact_and_reindex_works_spec.rb
+++ b/spec/tasks/redact_and_reindex_works_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe 'rake lumen:redact_and_reindex_works', type: :task, search: true do
+  it 'redacts the works' do
+    w = sensitive_work
+    expect(Work.where(description: '123-45-6789').present?).to be true
+    task.execute
+
+    w.reload
+    expect(w.description).to eq '[REDACTED]'
+  end
+
+  it 'marks notices as updated' do
+    w = sensitive_work
+    n = create(:dmca)
+    w.notices << n
+    original_updated_at = n.updated_at
+    task.execute
+
+    n.reload
+    expect(n.updated_at).to be > original_updated_at
+  end
+
+  def sensitive_work
+    w = create(:work)
+    # Use update_columns because it doesn't trigger the before_save callback -
+    # we want to make sure this isn't auto-redacted.
+    w.update_columns(
+      description: '123-45-6789',      # triggers SSN validation
+      updated_at: Date.new(2008, 1, 1) # before the rake task's limit
+    )
+    w
+  end
+end
+
+# task.execute


### PR DESCRIPTION
## Ready for merge?
**NO**

I have one more commit that's just linting that I'll push after your review.

#### What does this PR do?

1. auto-redacts work descriptions on work save
2. adds a rake task to let us go through all existing works to redact their descriptions

The rake task just does a thousand works at a time because reindexing all the things could be overwhelming. We'll put it in a cron job to slowly munch through the backlog.

#### Helpful background context (if appropriate)

We thought people wouldn't put sensitive information into work descriptions, but it turns out they do. We're going to suppress them from display. It turns out `description_original` is already suppressed from search, so once we redact `description`, this will keep sensitive info out of the search as well.

#### How can a reviewer manually see the effects of these changes?
* make a work that contains a phone number, US social security number, or email address; save it; and look at it again - you should see a [REDACTED] in the work description field
* force-reindex its associated notices and then search for your phone/SSN/email - you won't get results
* searching for non-sensitive text in the work should still work
* alternately, make some dodgy works (using `update_columns` to persist dodgy descriptions to the database without triggering the `before_save` callback on work, so that they don't get autoredacted); run the new rake task; and then run the task to reindex changed models

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15743

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
