### PR TITLE
Update capybara and poltergeist

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,7 @@
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - '**/*.rake'
+    - 'spec/**/*.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ group :test do
   gem 'elasticsearch-extensions'
   gem 'fakeweb'
   gem 'launchy'
-  gem 'poltergeist', '~> 1.10'
+  gem 'poltergeist'
   gem 'shoulda-matchers', '~> 3.1', '>= 3.1.1'
   gem 'simplecov', require: false
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,8 @@ GEM
       tzinfo (~> 1.1)
     acts-as-taggable-on (3.5.0)
       activerecord (>= 3.2, < 5)
-    addressable (2.4.0)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     ancestry (2.0.0)
       activerecord (>= 3.0.0)
     ansi (1.5.0)
@@ -71,13 +72,14 @@ GEM
       uniform_notifier (~> 1.11)
     byebug (9.0.5)
     cancancan (1.15.0)
-    capybara (2.14.3)
+    capybara (3.12.0)
       addressable
-      mime-types (>= 1.16)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (~> 2.0)
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
     climate_control (0.2.0)
     cliver (0.3.2)
     coderay (1.1.1)
@@ -228,8 +230,8 @@ GEM
       terrapin (~> 0.6.0)
     pg (0.20.0)
     phantomjs (2.1.1.0)
-    poltergeist (1.15.0)
-      capybara (~> 2.1)
+    poltergeist (1.18.1)
+      capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     pry (0.10.4)
@@ -241,6 +243,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.1)
       pry (>= 0.9.10)
+    public_suffix (3.0.3)
     rack (1.6.11)
     rack-attack (4.3.0)
       rack
@@ -296,6 +299,7 @@ GEM
       mail
     redcarpet (2.3.0)
     ref (2.0.0)
+    regexp_parser (1.3.0)
     remotipart (1.4.2)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -405,11 +409,11 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket-driver (0.6.5)
+    websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
-    xpath (2.1.0)
-      nokogiri (~> 1.3)
+    websocket-extensions (0.1.3)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -456,7 +460,7 @@ DEPENDENCIES
   paperclip (~> 5)
   pg (= 0.20.0)
   phantomjs
-  poltergeist (~> 1.10)
+  poltergeist
   pry (~> 0.10.4)
   pry-byebug
   pry-rails

--- a/spec/integration/faceted_notice_search_spec.rb
+++ b/spec/integration/faceted_notice_search_spec.rb
@@ -36,7 +36,7 @@ feature "Faceted search of Notices", search: true do
           expect(page).to have_active_facet_dropdown(facet_type)
           expect(page).to have_active_facet(facet_type, facet)
           expect(page).to have_n_results 1
-          expect(page).to have_content(inside_facet.title)
+          expect(page).to have_words(inside_facet.title)
         end
 
         expect(page).to have_css("input#search[value='king']")
@@ -62,7 +62,7 @@ feature "Faceted search of Notices", search: true do
       within_faceted_search_results_for("title", :date_received_facet, facet) do
         expect(page).to have_active_facet_dropdown(:date_received_facet)
         expect(page).to have_n_results 1
-        expect(page).to have_content(inside_facet.title)
+        expect(page).to have_words(inside_facet.title)
       end
     end
   end
@@ -82,7 +82,7 @@ feature "Faceted search of Notices", search: true do
 
       expect(page).to have_active_facet_dropdown(:date_received_facet)
       expect(page).to have_n_results 1
-      expect(page).to have_content(notice.title)
+      expect(page).to have_words(notice.title)
     end
   end
 

--- a/spec/integration/faceted_notice_search_spec.rb
+++ b/spec/integration/faceted_notice_search_spec.rb
@@ -1,38 +1,37 @@
 require 'rails_helper'
 
-feature "Faceted search of Notices", search: true do
+feature 'Faceted search of Notices', search: true do
   include SearchHelpers
 
-  context "filtering with a full-text search term" do
-    [
-      :topic_facet,
-      :sender_name_facet,
-      :principal_name_facet,
-      :recipient_name_facet,
-      :tag_list_facet,
-      :country_code_facet,
-      :language_facet,
-      :action_taken_facet,
+  context 'filtering with a full-text search term' do
+    %i[
+      topic_facet
+      sender_name_facet
+      principal_name_facet
+      recipient_name_facet
+      tag_list_facet
+      country_code_facet
+      language_facet
+      action_taken_facet
     ].each do |facet_type|
       it "on #{facet_type}", js: true, search: true do
-        outside_facet = create(:dmca, title: "King of New York")
-        inside_facet = create(:dmca, :with_facet_data, title: "Lion King two")
+        _outside_facet = create(:dmca, title: 'King of New York')
+        inside_facet = create(:dmca, :with_facet_data, title: 'Lion King two')
         index_changed_instances
 
         within_search_results_for('king') do
           expect(page).to have_n_results 2
         end
 
-        facet = ''
-        if facet_type == :topic_facet
-          facet = inside_facet.topics.first.name
-        elsif facet_type == :tag_list_facet
-          facet = inside_facet.tags.first
-        else
-          facet = inside_facet.send(facet_type.to_s.gsub(/_facet/, '').to_sym)
-        end
+        facet = if facet_type == :topic_facet
+                  inside_facet.topics.first.name
+                elsif facet_type == :tag_list_facet
+                  inside_facet.tags.first
+                else
+                  inside_facet.send(facet_type.to_s.gsub(/_facet/, '').to_sym)
+                end
 
-        within_faceted_search_results_for("king", facet_type, facet) do
+        within_faceted_search_results_for('king', facet_type, facet) do
           expect(page).to have_active_facet_dropdown(facet_type)
           expect(page).to have_active_facet(facet_type, facet)
           expect(page).to have_n_results 1
@@ -43,8 +42,8 @@ feature "Faceted search of Notices", search: true do
       end
     end
 
-    it "on date ranges", js: true, search: true do
-      outside_facet = create(
+    it 'on date ranges', js: true, search: true do
+      _outside_facet = create(
         :dmca, title: 'A title', date_received: Time.now - 10.months
       )
       inside_facet = create(
@@ -59,7 +58,7 @@ feature "Faceted search of Notices", search: true do
       open_dropdown_for_facet('date_received_facet')
       facet = page.find('ol.date_received_facet li:nth-child(3)').text
 
-      within_faceted_search_results_for("title", :date_received_facet, facet) do
+      within_faceted_search_results_for('title', :date_received_facet, facet) do
         expect(page).to have_active_facet_dropdown(:date_received_facet)
         expect(page).to have_n_results 1
         expect(page).to have_words(inside_facet.title)
@@ -67,10 +66,10 @@ feature "Faceted search of Notices", search: true do
     end
   end
 
-  context "facet auto-submission" do
-    scenario "a user selects a facet", js: true, search: true do
-      create(:dmca, title: "Lion King", date_received: 10.months.ago)
-      notice = create(:dmca, title: "King Leon", date_received: 1.day.ago)
+  context 'facet auto-submission' do
+    scenario 'a user selects a facet', js: true, search: true do
+      create(:dmca, title: 'Lion King', date_received: 10.months.ago)
+      notice = create(:dmca, title: 'King Leon', date_received: 1.day.ago)
       index_changed_instances
 
       within_search_results_for('king') do
@@ -87,7 +86,7 @@ feature "Faceted search of Notices", search: true do
   end
 
   def with_a_faceted_search(facet_name, facet_attribute_name)
-    sleep (ENV["SEARCH_SLEEP"] && ENV["SEARCH_SLEEP"].to_i) || 1
+    sleep((ENV['SEARCH_SLEEP'] && ENV['SEARCH_SLEEP'].to_i) || 1)
     results = Notice.search do
       query { match(:_all, 'title') }
       facet facet_name do

--- a/spec/integration/fielded_notice_search_spec.rb
+++ b/spec/integration/fielded_notice_search_spec.rb
@@ -81,7 +81,7 @@ feature 'Fielded searches of Notices' do
 
     scenario 'by newest date_received', search: true, js: true do
       search_on_page = FieldedSearchOnPage.new
-      search_on_page.set_sort_order('date_received desc')
+      search_on_page.define_sort_order('date_received desc')
 
       expect(page).to have_sort_order_selection_of('Newest')
       search_on_page.within_results do
@@ -92,7 +92,7 @@ feature 'Fielded searches of Notices' do
 
     scenario 'by oldest date_received', search: true, js: true do
       search_on_page = FieldedSearchOnPage.new
-      search_on_page.set_sort_order('date_received asc')
+      search_on_page.define_sort_order('date_received asc')
 
       expect(page).to have_sort_order_selection_of('Oldest')
       search_on_page.within_results do

--- a/spec/integration/fielded_notice_search_spec.rb
+++ b/spec/integration/fielded_notice_search_spec.rb
@@ -17,7 +17,7 @@ feature 'Fielded searches of Notices' do
         search_on_page.parameterized_search_for(field.parameter, generator.query)
 
         search_on_page.within_results do
-          expect(page).to have_content(generator.matched_notice.title)
+          expect(page).to have_words(generator.matched_notice.title)
           expect(page).to have_no_content(generator.unmatched_notice.title)
         end
       end
@@ -37,7 +37,7 @@ feature 'Fielded searches of Notices' do
         search_on_page.run_search
 
         search_on_page.within_results do
-          expect(page).to have_content(generator.matched_notice.title)
+          expect(page).to have_words(generator.matched_notice.title)
           expect(page).to have_no_content(generator.unmatched_notice.title)
         end
       end
@@ -59,7 +59,7 @@ feature 'Fielded searches of Notices' do
     search_on_page.run_search
 
     search_on_page.within_results do
-      expect(page).to have_content(inside_search.title)
+      expect(page).to have_words(inside_search.title)
       expect(page).to have_no_content(outside_search.title)
     end
 

--- a/spec/integration/notice_search_spec.rb
+++ b/spec/integration/notice_search_spec.rb
@@ -62,7 +62,7 @@ feature 'Searching Notices', type: :feature do
     expect(page).to have_css(
       '.result .date-received', text: notice.date_received.to_s(:simple)
     )
-    expect(page).to have_content(on_behalf_of)
+    expect(page).to have_words(on_behalf_of)
     notice.topics.each do |topic|
       expect(page).to have_css('.result .topic', text: topic.name)
     end
@@ -74,7 +74,7 @@ feature 'Searching Notices', type: :feature do
 
     submit_search 'foo'
 
-    expect(page).to have_content('foo bar baz')
+    expect(page).to have_words('foo bar baz')
   end
 
   scenario 'sanitizes excerpts' do
@@ -123,8 +123,8 @@ feature 'Searching Notices', type: :feature do
 
     within_search_results_for('king') do
       expect(page).to have_n_results(2)
-      expect(page).to have_content(notice.title)
-      expect(page).to have_content(trademark.title)
+      expect(page).to have_words(notice.title)
+      expect(page).to have_words(trademark.title)
       expect(page.html).to have_excerpt('King', 'The Lion', 'on Youtube')
     end
   end
@@ -141,7 +141,7 @@ feature 'Searching Notices', type: :feature do
       search_for(action_taken: notice.action_taken)
 
       expect(page).to have_n_results(1)
-      expect(page).to have_content(notice.title)
+      expect(page).to have_words(notice.title)
     end
   end
 
@@ -188,7 +188,7 @@ feature 'Searching Notices', type: :feature do
 
     within_search_results_for('pants') do
       expect(page).to have_n_results(1)
-      expect(page).to have_content(found_notice.title)
+      expect(page).to have_words(found_notice.title)
     end
 
     expect_search_to_not_find('fanciest pants', notice)
@@ -202,8 +202,8 @@ feature 'Searching Notices', type: :feature do
 
       within_search_results_for('king') do
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
-        expect(page).to have_content(topic.name)
+        expect(page).to have_words(notice.title)
+        expect(page).to have_words(topic.name)
         expect(page).to contain_link(topic_path(topic))
         expect(page.html).to have_excerpt('King', 'Lion')
       end
@@ -215,7 +215,7 @@ feature 'Searching Notices', type: :feature do
 
       within_search_results_for('bar') do
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
+        expect(page).to have_words(notice.title)
         expect(page.html).to have_excerpt('bar')
       end
     end
@@ -226,22 +226,22 @@ feature 'Searching Notices', type: :feature do
 
       within_search_results_for(notice.recipient_name) do
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
-        expect(page).to have_content(notice.recipient_name)
+        expect(page).to have_words(notice.title)
+        expect(page).to have_words(notice.recipient_name)
         expect(page.html).to have_excerpt('Entity')
       end
 
       within_search_results_for(notice.sender_name) do
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
-        expect(page).to have_content(notice.sender_name)
+        expect(page).to have_words(notice.title)
+        expect(page).to have_words(notice.sender_name)
         expect(page.html).to have_excerpt('Entity')
       end
 
       within_search_results_for(notice.principal_name) do
         # note: principal name not shown in results
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
+        expect(page).to have_words(notice.title)
         expect(page.html).to have_excerpt('Entity')
       end
     end
@@ -256,8 +256,8 @@ feature 'Searching Notices', type: :feature do
 
       within_search_results_for('arbitrary') do
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
-        expect(page).to have_content(work.description)
+        expect(page).to have_words(notice.title)
+        expect(page).to have_words(work.description)
         expect(page.html).to have_excerpt('arbitrary', 'An', 'description')
       end
     end
@@ -278,9 +278,9 @@ feature 'Searching Notices', type: :feature do
 
       within_search_results_for('My SSN') do
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
-        expect(page).to have_content('[REDACTED]')
-        expect(page).not_to have_content('123-45-6789')
+        expect(page).to have_words(notice.title)
+        expect(page).to have_words('[REDACTED]')
+        expect(page).not_to have_words('123-45-6789')
       end
 
       within_search_results_for('123-45-6789') do
@@ -289,9 +289,9 @@ feature 'Searching Notices', type: :feature do
 
       within_search_results_for('My phone number') do
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
-        expect(page).to have_content('[REDACTED]')
-        expect(page).not_to have_content('(123) 456-7890')
+        expect(page).to have_words(notice.title)
+        expect(page).to have_words('[REDACTED]')
+        expect(page).not_to have_words('(123) 456-7890')
       end
 
       within_search_results_for('(123) 456-7890') do
@@ -300,9 +300,9 @@ feature 'Searching Notices', type: :feature do
 
       within_search_results_for('My email') do
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
-        expect(page).to have_content('[REDACTED]')
-        expect(page).not_to have_content('me@example.com')
+        expect(page).to have_words(notice.title)
+        expect(page).to have_words('[REDACTED]')
+        expect(page).not_to have_words('me@example.com')
       end
 
       within_search_results_for('me@example.com') do
@@ -326,13 +326,13 @@ feature 'Searching Notices', type: :feature do
 
       within_search_results_for('infringing_url') do
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
+        expect(page).to have_words(notice.title)
         expect(page.html).to have_excerpt('infringing_url')
       end
 
       within_search_results_for('copyrighted_url') do
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
+        expect(page).to have_words(notice.title)
         expect(page.html).to have_excerpt('copyrighted_url')
       end
     end
@@ -346,7 +346,7 @@ feature 'Searching Notices', type: :feature do
 
       within_search_results_for('arbitrary') do
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
+        expect(page).to have_words(notice.title)
       end
     end
 
@@ -367,7 +367,7 @@ feature 'Searching Notices', type: :feature do
 
       within_search_results_for('arbitrary') do
         expect(page).to have_n_results(1)
-        expect(page).to have_content(notice.title)
+        expect(page).to have_words(notice.title)
       end
     end
   end
@@ -380,7 +380,7 @@ feature 'Searching Notices', type: :feature do
 
     search_for(sender_name: 'Jim', recipient_name: 'Jon')
 
-    expect(page).to have_content("Jim & Jon's")
+    expect(page).to have_words("Jim & Jon's")
     expect(page).to have_no_content("Jim & Dan's")
     expect(page).to have_no_content("Dan & Jon's")
   end

--- a/spec/integration/redaction_spec.rb
+++ b/spec/integration/redaction_spec.rb
@@ -24,7 +24,7 @@ feature 'Redactable fields' do
       end
 
       open_recent_notice
-      expect(page).to have_content(redacted_text)
+      expect(page).to have_words(redacted_text)
       expect(page).to have_no_content(original_text)
     end
 

--- a/spec/integration/reviewable_notice_spec.rb
+++ b/spec/integration/reviewable_notice_spec.rb
@@ -14,7 +14,7 @@ feature "Publishing high risk notices" do
 
     open_recent_notice
     within('.notice-body') do
-      expect(page).to have_content Notice::UNDER_REVIEW_VALUE
+      expect(page).to have_words Notice::UNDER_REVIEW_VALUE
     end
   end
 
@@ -27,7 +27,7 @@ feature "Publishing high risk notices" do
 
     open_recent_notice
     within('.notice-body') do
-      expect(page).to have_content harmless_text
+      expect(page).to have_words harmless_text
     end
   end
 

--- a/spec/integration/reviewable_notice_spec.rb
+++ b/spec/integration/reviewable_notice_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-feature "Publishing high risk notices" do
+feature 'Publishing high risk notices' do
   include NoticeActions
 
-  let(:harmless_text) { "Some harmless text" }
+  let(:harmless_text) { 'Some harmless text' }
 
-  scenario "A non-US notice with Body text" do
+  scenario 'A non-US notice with Body text' do
     create_non_us_risk_trigger
 
     submit_notice_from('Spain') do
-      fill_in "Body", with: harmless_text
+      fill_in 'Body', with: harmless_text
     end
 
     open_recent_notice
@@ -18,11 +18,11 @@ feature "Publishing high risk notices" do
     end
   end
 
-  scenario "A US notice with Body text" do
+  scenario 'A US notice with Body text' do
     create_non_us_risk_trigger
 
     submit_notice_from('United States') do
-      fill_in "Body", with: harmless_text
+      fill_in 'Body', with: harmless_text
     end
 
     open_recent_notice
@@ -45,7 +45,7 @@ feature "Publishing high risk notices" do
   def submit_notice_from(country)
     submit_recent_notice do
       within('section.recipient') do
-        select country, from: "Country"
+        select country, from: 'Country'
       end
 
       yield if block_given?

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -7,7 +7,7 @@ feature 'notice submission' do
   scenario 'non signed-in user cannot submit notices' do
     visit '/notices/new?type=DMCA'
 
-    expect(page).to have_content('Direct submission to Lumen is no longer available. If you are interested in sharing with Lumen copies of takedown notices you have sent or received, please contact Lumen.')
+    expect(page).to have_words('Direct submission to Lumen is no longer available. If you are interested in sharing with Lumen copies of takedown notices you have sent or received, please contact Lumen.')
   end
 
   scenario 'submitting a notice with title' do
@@ -34,7 +34,7 @@ feature 'notice submission' do
 
     open_recent_notice
 
-    expect(page).to have_content('Action taken: Yes')
+    expect(page).to have_words('Action taken: Yes')
   end
 
   scenario 'submitting a notice with a jurisdiction' do
@@ -55,11 +55,11 @@ feature 'notice submission' do
     open_recent_notice
 
     within('.recipient .date') do
-      expect(page).to have_content('May 05, 2013')
+      expect(page).to have_words('May 05, 2013')
     end
 
     within('.sender .date') do
-      expect(page).to have_content('May 04, 2013')
+      expect(page).to have_words('May 04, 2013')
     end
   end
 
@@ -103,7 +103,7 @@ feature 'notice submission' do
     open_recent_notice
 
     within('#tags') do
-      expect(page).to have_content 'tag_1'
+      expect(page).to have_words 'tag_1'
     end
   end
 
@@ -120,8 +120,8 @@ feature 'notice submission' do
     open_recent_notice
 
     within('#topics') do
-      expect(page).to have_content 'Topic 1'
-      expect(page).to have_content 'Topic 3'
+      expect(page).to have_words 'Topic 1'
+      expect(page).to have_words 'Topic 3'
     end
   end
 
@@ -146,13 +146,13 @@ feature 'notice submission' do
     open_recent_notice
 
     within('#entities') do
-      expect(page).to have_content 'Recipient the first'
-      expect(page).to have_content '[Private]'
-      expect(page).to have_content 'Recipient City'
-      expect(page).to have_content 'MA'
-      expect(page).to have_content 'US'
+      expect(page).to have_words 'Recipient the first'
+      expect(page).to have_words '[Private]'
+      expect(page).to have_words 'Recipient City'
+      expect(page).to have_words 'MA'
+      expect(page).to have_words 'US'
 
-      expect(page).to have_content 'Sender the first'
+      expect(page).to have_words 'Sender the first'
     end
 
     notice = Notice.last
@@ -209,9 +209,9 @@ feature 'notice submission' do
     open_recent_notice
 
     within('#works') do
-      expect(page).to have_content 'http://www.example.com/original_work.pdf'
-      expect(page).to have_content 'movie'
-      expect(page).to have_content 'A series of videos and still images'
+      expect(page).to have_words 'http://www.example.com/original_work.pdf'
+      expect(page).to have_words 'movie'
+      expect(page).to have_words 'A series of videos and still images'
       expect(page).to have_css(
         %{.infringing_url:contains("http://example.com/infringing_url1")}
       )
@@ -225,7 +225,7 @@ feature 'notice submission' do
 
     open_recent_notice
 
-    expect(page).to have_content 'Sent via: Arbitrary source'
+    expect(page).to have_words 'Sent via: Arbitrary source'
   end
 
   scenario 'submitting a notice with a subject' do
@@ -235,7 +235,7 @@ feature 'notice submission' do
 
     open_recent_notice
 
-    expect(page).to have_content 'Re: Some subject'
+    expect(page).to have_words 'Re: Some subject'
   end
 
   scenario 'a form articulates its required fields correctly' do
@@ -274,7 +274,7 @@ feature 'notice submission' do
       sign_in(create(:user, :submitter))
       visit '/notices/new?type=Counternotice'
 
-      expect(page).to have_content 'Provide us with information about the DMCA counternotice'
+      expect(page).to have_words 'Provide us with information about the DMCA counternotice'
       expect(page).to have_css '#notice_counternotice_for_id'
       expect(page).not_to have_css '#notice_action_taken'
       expect(page).not_to have_css 'textarea#notice_body'
@@ -287,7 +287,7 @@ feature 'notice submission' do
       sign_in(create(:user, :submitter))
       visit '/notices/new?type=CourtOrder'
 
-      expect(page).to have_content 'Provide us with information about the Court Order'
+      expect(page).to have_words 'Provide us with information about the Court Order'
       expect(page).to have_css '#notice_action_taken'
       expect(page).to have_css '#notice_subject'
       expect(page).to have_css '#notice_topic_ids'
@@ -306,7 +306,7 @@ feature 'notice submission' do
       sign_in(create(:user, :submitter))
       visit '/notices/new?type=DataProtection'
 
-      expect(page).to have_content 'Provide us with information about the Data Protection takedown notice'
+      expect(page).to have_words 'Provide us with information about the Data Protection takedown notice'
       expect(page).to have_css '#notice_action_taken'
       expect(page).not_to have_css '#notice_subject'
       expect(page).not_to have_css '#notice_topic_ids'
@@ -325,7 +325,7 @@ feature 'notice submission' do
       sign_in(create(:user, :submitter))
       visit '/notices/new?type=Defamation'
 
-      expect(page).to have_content 'Provide us with information about the Defamation takedown notice'
+      expect(page).to have_words 'Provide us with information about the Defamation takedown notice'
       expect(page).to have_css '#notice_action_taken'
       expect(page).to have_css '#notice_subject'
       expect(page).to have_css '#notice_topic_ids'
@@ -344,7 +344,7 @@ feature 'notice submission' do
       sign_in(create(:user, :submitter))
       visit '/notices/new?type=DMCA'
 
-      expect(page).to have_content 'Provide us with information about the DMCA takedown notice'
+      expect(page).to have_words 'Provide us with information about the DMCA takedown notice'
       expect(page).to have_css '#notice_action_taken'
       expect(page).to have_css '#notice_subject'
       expect(page).to have_css '#notice_topic_ids'
@@ -363,7 +363,7 @@ feature 'notice submission' do
       sign_in(create(:user, :submitter))
       visit '/notices/new?type=GovernmentRequest'
 
-      expect(page).to have_content 'Provide us with information about the Government Request'
+      expect(page).to have_words 'Provide us with information about the Government Request'
       expect(page).to have_css '#notice_action_taken'
       expect(page).to have_css '#notice_subject'
       expect(page).to have_css '#notice_topic_ids'
@@ -382,7 +382,7 @@ feature 'notice submission' do
       sign_in(create(:user, :submitter))
       visit '/notices/new?type=LawEnforcementRequest'
 
-      expect(page).to have_content 'Provide us with information about the Law Enforcement Request'
+      expect(page).to have_words 'Provide us with information about the Law Enforcement Request'
       expect(page).to have_css '#notice_action_taken'
       expect(page).to have_css '#notice_subject'
       expect(page).to have_css '#notice_topic_ids'
@@ -401,7 +401,7 @@ feature 'notice submission' do
       sign_in(create(:user, :submitter))
       visit '/notices/new?type=Other'
 
-      expect(page).to have_content 'Provide us with information about the notice'
+      expect(page).to have_words 'Provide us with information about the notice'
       expect(page).to have_css '#notice_action_taken'
       expect(page).to have_css '#notice_subject'
       expect(page).to have_css '#notice_topic_ids'
@@ -420,7 +420,7 @@ feature 'notice submission' do
       sign_in(create(:user, :submitter))
       visit '/notices/new?type=PrivateInformation'
 
-      expect(page).to have_content 'Provide us with information about the Private Information notice'
+      expect(page).to have_words 'Provide us with information about the Private Information notice'
       expect(page).to have_css '#notice_action_taken'
       expect(page).to have_css '#notice_subject'
       expect(page).to have_css '#notice_topic_ids'
@@ -439,7 +439,7 @@ feature 'notice submission' do
       sign_in(create(:user, :submitter))
       visit '/notices/new?type=Trademark'
 
-      expect(page).to have_content 'Provide us with information about the Trademark takedown notice'
+      expect(page).to have_words 'Provide us with information about the Trademark takedown notice'
       expect(page).to have_css '#notice_action_taken'
       expect(page).to have_css '#notice_subject'
       expect(page).to have_css '#notice_topic_ids'

--- a/spec/integration/user_submits_typed_notices_spec.rb
+++ b/spec/integration/user_submits_typed_notices_spec.rb
@@ -4,7 +4,7 @@ feature 'typed notice submissions' do
   scenario 'Non signed-in user cannot see new notice forms' do
     visit '/notices/new'
 
-    expect(page).to have_content('Direct submission to Lumen is no longer available. If you are interested in sharing with Lumen copies of takedown notices you have sent or received, please contact Lumen.')
+    expect(page).to have_words('Direct submission to Lumen is no longer available. If you are interested in sharing with Lumen copies of takedown notices you have sent or received, please contact Lumen.')
   end
 
   scenario 'User submits and views a Trademark notice' do
@@ -31,17 +31,17 @@ feature 'typed notice submissions' do
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content('Trademark notice to Recipient')
+    expect(page).to have_words('Trademark notice to Recipient')
 
     within('#works') do
-      expect(page).to have_content('Description of allegedly infringed mark')
-      expect(page).to have_content('My trademark (TM)')
+      expect(page).to have_words('Description of allegedly infringed mark')
+      expect(page).to have_words('My trademark (TM)')
     end
 
     within('.notice-body') do
-      expect(page).to have_content('Alleged Infringement')
-      expect(page).to have_content('They used my thing')
-      expect(page).to have_content('1337')
+      expect(page).to have_words('Alleged Infringement')
+      expect(page).to have_words('They used my thing')
+      expect(page).to have_words('1337')
     end
   end
 
@@ -67,16 +67,16 @@ feature 'typed notice submissions' do
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content('Defamation notice to Recipient')
+    expect(page).to have_words('Defamation notice to Recipient')
 
     within('#works') do
-      expect(page).to have_content('URLs of Allegedly Defamatory Material')
-      expect(page).to have_content('http://example.com/defamatory_url1')
+      expect(page).to have_words('URLs of Allegedly Defamatory Material')
+      expect(page).to have_words('http://example.com/defamatory_url1')
     end
 
     within('.notice-body') do
-      expect(page).to have_content('Legal Complaint')
-      expect(page).to have_content('They impugned my good character')
+      expect(page).to have_words('Legal Complaint')
+      expect(page).to have_words('They impugned my good character')
     end
   end
 
@@ -102,13 +102,13 @@ feature 'typed notice submissions' do
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content('Data Protection notice to Recipient')
+    expect(page).to have_words('Data Protection notice to Recipient')
 
     within('#works') do
-      expect(page).to have_content(
+      expect(page).to have_words(
         'Location of Some of the Material Requested for Removal'
       )
-      expect(page).to have_content('http://example.com/defamatory_url1')
+      expect(page).to have_words('http://example.com/defamatory_url1')
     end
   end
 
@@ -136,17 +136,17 @@ feature 'typed notice submissions' do
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content('Court Order notice to Recipient')
+    expect(page).to have_words('Court Order notice to Recipient')
 
     within('#works') do
-      expect(page).to have_content('Targeted URLs')
-      expect(page).to have_content('http://example.com/targeted_url')
+      expect(page).to have_words('Targeted URLs')
+      expect(page).to have_words('http://example.com/targeted_url')
     end
 
     within('.notice-body') do
-      expect(page).to have_content('Explanation of Court Order')
-      expect(page).to have_content("I guess they don't like me")
-      expect(page).to have_content('USC foo bar 21')
+      expect(page).to have_words('Explanation of Court Order')
+      expect(page).to have_words("I guess they don't like me")
+      expect(page).to have_words('USC foo bar 21')
     end
   end
 
@@ -177,25 +177,25 @@ feature 'typed notice submissions' do
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content('Law Enforcement Request notice to Recipient')
+    expect(page).to have_words('Law Enforcement Request notice to Recipient')
 
     within('#works') do
-      expect(page).to have_content('URLs mentioned in request')
-      expect(page).to have_content('http://example.com/offending_url1')
-      expect(page).to have_content('URLs of original work')
-      expect(page).to have_content('http://example.com/original_object1')
-      expect(page).to have_content('My Tiny Tim fansite')
+      expect(page).to have_words('URLs mentioned in request')
+      expect(page).to have_words('http://example.com/offending_url1')
+      expect(page).to have_words('URLs of original work')
+      expect(page).to have_words('http://example.com/original_object1')
+      expect(page).to have_words('My Tiny Tim fansite')
     end
 
     within('.notice-body') do
-      expect(page).to have_content('Explanation of Request')
-      expect(page).to have_content("I don't get it. He made sick music.")
-      expect(page).to have_content('USC foo bar 21')
-      expect(page).to have_content('Civil Subpoena')
+      expect(page).to have_words('Explanation of Request')
+      expect(page).to have_words("I don't get it. He made sick music.")
+      expect(page).to have_words('USC foo bar 21')
+      expect(page).to have_words('Civil Subpoena')
     end
 
     within('#entities') do
-      expect(page).to have_content('Principal')
+      expect(page).to have_words('Principal')
     end
   end
 
@@ -222,18 +222,18 @@ feature 'typed notice submissions' do
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content('Private Information notice to Recipient')
+    expect(page).to have_words('Private Information notice to Recipient')
 
     within('#works') do
-      expect(page).to have_content('URLs with private information')
-      expect(page).to have_content('http://example.com/offending_url1')
-      expect(page).to have_content('URLs of original work')
-      expect(page).to have_content('These URLs disclose my existence')
+      expect(page).to have_words('URLs with private information')
+      expect(page).to have_words('http://example.com/offending_url1')
+      expect(page).to have_words('URLs of original work')
+      expect(page).to have_words('These URLs disclose my existence')
     end
 
     within('.notice-body') do
-      expect(page).to have_content('Explanation of complaint')
-      expect(page).to have_content('I am in witness protection')
+      expect(page).to have_words('Explanation of complaint')
+      expect(page).to have_words('I am in witness protection')
     end
   end
 
@@ -259,19 +259,19 @@ feature 'typed notice submissions' do
 
     within('#recent-notices li:nth-child(1)') { find('a').click }
 
-    expect(page).to have_content('Other notice to Recipient')
+    expect(page).to have_words('Other notice to Recipient')
 
     within('#works') do
-      expect(page).to have_content('Problematic URLs')
-      expect(page).to have_content('http://example.com/offending_url1')
-      expect(page).to have_content('URLs of original work')
-      expect(page).to have_content('http://example.com/original_object1')
-      expect(page).to have_content('These URLs are a serious problem')
+      expect(page).to have_words('Problematic URLs')
+      expect(page).to have_words('http://example.com/offending_url1')
+      expect(page).to have_words('URLs of original work')
+      expect(page).to have_words('http://example.com/original_object1')
+      expect(page).to have_words('These URLs are a serious problem')
     end
 
     within('.notice-body') do
-      expect(page).to have_content('Explanation of complaint')
-      expect(page).to have_content('I am complaining')
+      expect(page).to have_words('Explanation of complaint')
+      expect(page).to have_words('I am complaining')
     end
   end
 

--- a/spec/integration/viewing_topics_spec.rb
+++ b/spec/integration/viewing_topics_spec.rb
@@ -12,7 +12,7 @@ feature 'Topics' do
     visit "/topics/#{@topic.id}"
 
     within('section.topic-notices') do
-      expect(page).to have_content Notice.first.title
+      expect(page).to have_words Notice.first.title
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,23 +1,28 @@
 ENV['RAILS_ENV'] ||= 'test'
 
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+if Rails.env.production?
+  abort('The Rails environment is running in production mode!')
+end
 
 require 'rubygems'
 require 'rspec/rails'
 require 'capybara/poltergeist'
+require 'capybara/rspec'
 
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, {
-    phantomjs_logger: File.open("#{Rails.root}/log/test_phantomjs.log", "a")
-  })
+  Capybara::Poltergeist::Driver.new(
+    app,
+    phantomjs_logger: File.open("#{Rails.root}/log/test_phantomjs.log", 'a')
+  )
 end
 
 Capybara.javascript_driver = :poltergeist
+Capybara.server = :webrick
 
 ActiveRecord::Migration.maintain_test_schema!
 
@@ -34,21 +39,24 @@ RSpec.configure do |config|
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
+
+  # Enables --only-failures.
+  config.example_status_persistence_file_path = 'rspec_examples.txt'
 end
 
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     # Choose a test framework:
     with.test_framework :rspec
-    #with.test_framework :minitest
-    #with.test_framework :minitest_4
-    #ith.test_framework :test_unit
+    # with.test_framework :minitest
+    # with.test_framework :minitest_4
+    # with.test_framework :test_unit
 
     # Choose one or more libraries:
     with.library :active_record
     with.library :active_model
     with.library :action_controller
     # Or, choose the following (which implies all of the above):
-    #with.library :rails
+    # with.library :rails
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,6 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   config.order = 'random'
-  config.example_status_persistence_file_path = 'rspec_examples.txt'
 
   # If you need to see the order your specs are running in (i.e. to debug
   # order-dependent test failures), uncomment the following. But you may find

--- a/spec/support/curb_helpers.rb
+++ b/spec/support/curb_helpers.rb
@@ -17,7 +17,7 @@ module CurbHelpers
   end
 
   def with_curb_get_for_json(url, options)
-    sleep (ENV['SEARCH_SLEEP'] && ENV['SEARCH_SLEEP'].to_i) || 1
+    sleep((ENV['SEARCH_SLEEP'] && ENV['SEARCH_SLEEP'].to_i) || 1)
 
     curb = Curl::Easy.http_get(
       "http://#{host}:#{port}/#{url}?#{Curl.postalize(options)}"

--- a/spec/support/matchers/have_heading.rb
+++ b/spec/support/matchers/have_heading.rb
@@ -7,7 +7,7 @@ RSpec::Matchers.define :have_heading do |heading|
   failure_message do |_|
     message = "expected page to have heading #{heading}"
 
-    if element = @page.first('h2')
+    if element = @page.first('h2', minimum: 0).present?
       message << ", actual heading was #{element.text}."
     else
       message << ", no element found."

--- a/spec/support/matchers/have_heading.rb
+++ b/spec/support/matchers/have_heading.rb
@@ -7,11 +7,11 @@ RSpec::Matchers.define :have_heading do |heading|
   failure_message do |_|
     message = "expected page to have heading #{heading}"
 
-    if element = @page.first('h2', minimum: 0).present?
-      message << ", actual heading was #{element.text}."
-    else
-      message << ", no element found."
-    end
+    message << if (element = @page.first('h2', minimum: 0)).present?
+                 ", actual heading was #{element.text}."
+               else
+                 ', no element found.'
+               end
 
     message
   end

--- a/spec/support/matchers/have_words.rb
+++ b/spec/support/matchers/have_words.rb
@@ -1,0 +1,24 @@
+# have_words is like have_content but it removes whitespace (which was ignored
+# by Capybara 2, hence by our tests, but is preserved by Capybara 3). It only
+# accepts a String, not a Regexp or Fixnum. Adapted from
+# https://groups.google.com/d/msg/ruby-capybara/o-IKGJNSInA/MHp_1mKkBQAJ .
+RSpec::Matchers.define :have_words do |string|
+  match do |page|
+    string = string.gsub(/\s+/, ' ').strip
+    re = Regexp.new(
+      Regexp.escape(string)
+            .gsub('\ ', '(?:\s+)')
+            .gsub("'", "(?:'|&#39;)"), # in case of html entities
+      Regexp::MULTILINE
+    )
+    have_content(re).matches?(page)
+  end
+
+  failure_message do |actual|
+    "expected to find #{string.inspect} in:\n#{actual.text}"
+  end
+
+  failure_message_when_negated do |actual|
+    "expected not to find #{string.inspect} in:\n#{actual.text}"
+  end
+end

--- a/spec/support/page_objects/fielded_search_on_page.rb
+++ b/spec/support/page_objects/fielded_search_on_page.rb
@@ -2,10 +2,9 @@ require_relative '../page_object'
 
 class FieldedSearchOnPage < PageObject
   def open_advanced_search
-    unless advanced_search_visible?
-      sleep ENV["SEARCH_SLEEP"].to_i if ENV["SEARCH_SLEEP"]
-      find("a#toggle-advanced-search").click
-    end
+    return if advanced_search_visible?
+    sleep ENV['SEARCH_SLEEP'].to_i if ENV['SEARCH_SLEEP']
+    find('a#toggle-advanced-search').click
   end
 
   def add_more
@@ -42,15 +41,14 @@ class FieldedSearchOnPage < PageObject
     end
   end
 
-  def set_sort_order(sort_order)
+  def define_sort_order(sort_order)
     open_sort_order_menu
     find("a[data-value='#{sort_order}']").click
   end
 
   def open_sort_order_menu
-    unless sort_order_visible?
-      find(".sort-order a.dropdown-toggle").click
-    end
+    return if sort_order_visible?
+    find('.sort-order a.dropdown-toggle').click
   end
 
   def change_field(from, to)
@@ -63,26 +61,30 @@ class FieldedSearchOnPage < PageObject
     open_advanced_search
 
     within(".field-group.#{field}") do
-      find(".remove-group").click
+      find('.remove-group').click
     end
   end
 
   def run_search(wait_for_index = true)
-    wait_for_index and sleep((ENV["SEARCH_SLEEP"] && ENV["SEARCH_SLEEP"].to_i) || 1)
+    if wait_for_index
+      sleep((ENV['SEARCH_SLEEP'] && ENV['SEARCH_SLEEP'].to_i) || 1)
+    end
 
     find('.advanced-search .resubmit .button').click
   end
 
   def visit_search_page(wait_for_index = false)
-    wait_for_index and sleep((ENV["SEARCH_SLEEP"] && ENV["SEARCH_SLEEP"].to_i) || 1)
+    if wait_for_index
+      sleep((ENV['SEARCH_SLEEP'] && ENV['SEARCH_SLEEP'].to_i) || 1)
+    end
 
     visit '/notices/search'
   end
 
   def parameterized_search_for(field, term)
-    sleep (ENV["SEARCH_SLEEP"] && ENV["SEARCH_SLEEP"].to_i) || 1
+    sleep((ENV['SEARCH_SLEEP'] && ENV['SEARCH_SLEEP'].to_i) || 1)
 
-    visit "/notices/search?#{field}=#{URI.escape(term)}"
+    visit "/notices/search?#{field}=#{CGI.escape(term)}"
   end
 
   def within_results(&block)

--- a/spec/support/page_objects/fielded_search_on_page.rb
+++ b/spec/support/page_objects/fielded_search_on_page.rb
@@ -92,10 +92,10 @@ class FieldedSearchOnPage < PageObject
   private
 
   def advanced_search_visible?
-    first('.container.advanced-search')
+    first('.container.advanced-search', minimum: 0)
   end
 
   def sort_order_visible?
-    first('.sort-order ol.dropdown-menu')
+    first('.sort-order ol.dropdown-menu', minimum: 0)
   end
 end

--- a/spec/views/blog_entries/index.html.erb_spec.rb
+++ b/spec/views/blog_entries/index.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'blog_entries/index.html.erb' do
-  it "shows the publishing info for each entry" do
+  it 'shows the publishing info for each entry' do
     blog_entries = mock_blog_entries
 
     render
@@ -12,7 +12,7 @@ describe 'blog_entries/index.html.erb' do
     end
   end
 
-  it "has titles which are links to each entry" do
+  it 'has titles which are links to each entry' do
     blog_entries = mock_blog_entries
 
     render
@@ -34,10 +34,10 @@ describe 'blog_entries/index.html.erb' do
     end
   end
 
-  it "renders abstracts via markdown" do
+  it 'renders abstracts via markdown' do
     blog_entries = mock_blog_entries do |blog_entries|
       blog_entries << create(
-        :blog_entry, :published, abstract: "[A link](http://www.example.com)"
+        :blog_entry, :published, abstract: '[A link](http://www.example.com)'
       )
     end
 
@@ -46,7 +46,7 @@ describe 'blog_entries/index.html.erb' do
     expect(rendered).to contain_link('http://www.example.com')
   end
 
-  it "displays the URL for an entry that has a URL defined" do
+  it 'displays the URL for an entry that has a URL defined' do
     url = 'http://www.example.com'
     blog_entries = mock_blog_entries do |blog_entries|
       blog_entries << create(
@@ -59,7 +59,7 @@ describe 'blog_entries/index.html.erb' do
     expect(rendered).to contain_link(url)
   end
 
-  it "does not embed the custom search engine when not configured" do
+  it 'does not embed the custom search engine when not configured' do
     blog_entries = mock_blog_entries
 
     render
@@ -67,7 +67,7 @@ describe 'blog_entries/index.html.erb' do
     expect(rendered).not_to have_custom_search_engine_embed
   end
 
-  it "has a custom search engine" do
+  it 'has a custom search engine' do
     allow(Chill::Application.config).to receive(:google_custom_blog_search_id).and_return('yep')
     blog_entries = mock_blog_entries
 
@@ -79,7 +79,8 @@ describe 'blog_entries/index.html.erb' do
   def mock_blog_entries
     blog_entries = create_list(:blog_entry, 3, :with_abstract, :published)
     yield blog_entries if block_given?
-    allow(blog_entries).to receive(:total_entries).and_return(blog_entries.length)
+    allow(blog_entries).to receive(:total_entries)
+      .and_return(blog_entries.length)
     allow(blog_entries).to receive(:total_pages).and_return(1)
     allow(blog_entries).to receive(:current_page).and_return(1)
     allow(blog_entries).to receive(:limit_value).and_return(1)

--- a/spec/views/blog_entries/index.html.erb_spec.rb
+++ b/spec/views/blog_entries/index.html.erb_spec.rb
@@ -7,8 +7,8 @@ describe 'blog_entries/index.html.erb' do
     render
 
     blog_entries.each do |blog_entry|
-      expect(rendered).to have_content(blog_entry.author)
-      expect(rendered).to have_content(blog_entry.published_at.to_s(:simple))
+      expect(rendered).to have_words(blog_entry.author)
+      expect(rendered).to have_words(blog_entry.published_at.to_s(:simple))
     end
   end
 
@@ -30,7 +30,7 @@ describe 'blog_entries/index.html.erb' do
     render
 
     blog_entries.each do |blog_entry|
-      expect(rendered).to have_content(blog_entry.abstract)
+      expect(rendered).to have_words(blog_entry.abstract)
     end
   end
 

--- a/spec/views/blog_entries/show.html.erb_spec.rb
+++ b/spec/views/blog_entries/show.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe 'blog_entries/show.html.erb' do
 
     render
 
-    expect(rendered).to have_content(blog_entry.title)
+    expect(rendered).to have_words(blog_entry.title)
   end
 
   it "shows the entry's publishing info" do
@@ -14,8 +14,8 @@ describe 'blog_entries/show.html.erb' do
 
     render
 
-    expect(rendered).to have_content(blog_entry.author)
-    expect(rendered).to have_content(blog_entry.published_at.to_s(:simple))
+    expect(rendered).to have_words(blog_entry.author)
+    expect(rendered).to have_words(blog_entry.published_at.to_s(:simple))
   end
 
   it "shows the entry's html content" do

--- a/spec/views/blog_entries/show.html.erb_spec.rb
+++ b/spec/views/blog_entries/show.html.erb_spec.rb
@@ -26,7 +26,7 @@ describe 'blog_entries/show.html.erb' do
     expect(rendered).to include(blog_entry.content_html)
   end
 
-  it "assigns the correct imagery class" do
+  it 'assigns the correct imagery class' do
     blog_entry = assign_blog_entry(image: 'rain')
 
     render

--- a/spec/views/notices/new.html.erb_spec.rb
+++ b/spec/views/notices/new.html.erb_spec.rb
@@ -102,7 +102,7 @@ describe 'notices/new.html.erb' do
 
     render
 
-    expect(rendered).to have_content('Original Work URL')
+    expect(rendered).to have_words('Original Work URL')
   end
 
   it 'should require infringing urls' do
@@ -160,7 +160,7 @@ describe 'notices/new.html.erb' do
 
     render
 
-    expect(rendered).to have_content('Allegedly Infringing URL *')
+    expect(rendered).to have_words('Allegedly Infringing URL *')
   end
 
   Notice.type_models.each do |model|

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -251,9 +251,11 @@ describe 'notices/show.html.erb' do
 
     notice.file_uploads.each do |file_upload|
       expect(rendered).to have_css(
-        "ol.attachments .#{file_upload.file_type.downcase}")
+        "ol.attachments .#{file_upload.file_type.downcase}"
+      )
       expect(rendered).to have_css(
-        "ol.attachments a[href=\"#{file_upload.url}\"]")
+        "ol.attachments a[href=\"#{file_upload.url}\"]"
+      )
     end
   end
 

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -204,7 +204,7 @@ describe 'notices/show.html.erb' do
 
     render
 
-    expect(rendered).to have_content('Sent via: Arbitrary source')
+    expect(rendered).to have_words('Sent via: Arbitrary source')
   end
 
   Notice::VALID_ACTIONS.each do |action|
@@ -213,7 +213,7 @@ describe 'notices/show.html.erb' do
 
       render
 
-      expect(rendered).to have_content("Action taken: #{action}")
+      expect(rendered).to have_words("Action taken: #{action}")
     end
   end
 
@@ -222,7 +222,7 @@ describe 'notices/show.html.erb' do
 
     render
 
-    expect(rendered).to have_content('Sent via: Unknown')
+    expect(rendered).to have_words('Sent via: Unknown')
   end
 
   it "displays the notice's subject" do
@@ -230,7 +230,7 @@ describe 'notices/show.html.erb' do
 
     render
 
-    expect(rendered).to have_content('Re: Some subject')
+    expect(rendered).to have_words('Re: Some subject')
   end
 
   it 'does not link to the notices original' do
@@ -262,7 +262,7 @@ describe 'notices/show.html.erb' do
 
     render
 
-    expect(rendered).not_to have_content('Supporting Documents')
+    expect(rendered).not_to have_words('Supporting Documents')
     expect(rendered).not_to have_css('.attachments')
   end
 

--- a/spec/views/rails_admin/application/redact_notice.html.erb_spec.rb
+++ b/spec/views/rails_admin/application/redact_notice.html.erb_spec.rb
@@ -22,12 +22,12 @@ describe 'rails_admin/application/redact_notice.html.erb' do
 
     render
 
-    expect(rendered).to have_words("Time in queue: about 2 hours")
+    expect(rendered).to have_words('Time in queue: about 2 hours')
   end
 
   it 'displays notice id, and entity names' do
     notice = build_stubbed(
-      :dmca, role_names: %w( submitter recipient sender )
+      :dmca, role_names: %w[submitter recipient sender]
     )
     assign(:object, notice)
     allow(notice).to receive(:sender_name).and_return('sender name')
@@ -49,7 +49,7 @@ describe 'rails_admin/application/redact_notice.html.erb' do
       body_original: 'Original'
     )
     assign(:object, notice)
-    assign(:redactable_fields, %i( body ))
+    assign(:redactable_fields, %i[body])
 
     render
 
@@ -78,7 +78,7 @@ describe 'rails_admin/application/redact_notice.html.erb' do
     expect(rendered).to have_css('input#notice_review_required')
   end
 
-  context "buttons and links" do
+  context 'buttons and links' do
     before do
       assign(:object, build_stubbed(:dmca))
       assign(:redactable_fields, [])

--- a/spec/views/rails_admin/application/redact_notice.html.erb_spec.rb
+++ b/spec/views/rails_admin/application/redact_notice.html.erb_spec.rb
@@ -22,7 +22,7 @@ describe 'rails_admin/application/redact_notice.html.erb' do
 
     render
 
-    expect(rendered).to have_content("Time in queue: about 2 hours")
+    expect(rendered).to have_words("Time in queue: about 2 hours")
   end
 
   it 'displays notice id, and entity names' do
@@ -30,13 +30,16 @@ describe 'rails_admin/application/redact_notice.html.erb' do
       :dmca, role_names: %w( submitter recipient sender )
     )
     assign(:object, notice)
+    allow(notice).to receive(:sender_name).and_return('sender name')
+    allow(notice).to receive(:recipient_name).and_return('recipient name')
+    allow(notice).to receive(:submitter_name).and_return('submitter name')
 
     render
 
     expect(rendered).to have_content(notice.id)
-    expect(rendered).to have_content(notice.submitter_name)
-    expect(rendered).to have_content(notice.recipient_name)
-    expect(rendered).to have_content(notice.sender_name)
+    expect(rendered).to have_words(notice.submitter_name)
+    expect(rendered).to have_words(notice.recipient_name)
+    expect(rendered).to have_words(notice.sender_name)
   end
 
   it 'shows redactable_fields alongside originals' do

--- a/spec/views/rails_admin/application/redact_queue.html.erb_spec.rb
+++ b/spec/views/rails_admin/application/redact_queue.html.erb_spec.rb
@@ -19,16 +19,18 @@ describe 'rails_admin/application/redact_queue.html.erb' do
       date_received: Time.now
     )
     assign(:objects, [notice])
+    allow(notice).to receive(:sender_name).and_return('sender name')
+    allow(notice).to receive(:recipient_name).and_return('recipient name')
+    allow(notice).to receive(:submitter_name).and_return('submitter name')
 
     render
 
     expect(rendered).to have_content(notice.id)
-    expect(rendered).to have_content(notice.title)
-    expect(rendered).to have_content(notice.body)
-    expect(rendered).to have_content(notice.sender_name)
-    expect(rendered).to have_content(notice.recipient_name)
-    expect(rendered).to have_content(notice.submitter_name)
-    expect(rendered).to have_content(notice.date_received.to_s(:simple))
+    expect(rendered).to have_words(notice.title)
+    expect(rendered).to have_words(notice.body)
+    expect(rendered).to have_words(notice.sender_name)
+    expect(rendered).to have_words(notice.recipient_name)
+    expect(rendered).to have_words(notice.submitter_name)
+    expect(rendered).to have_words(notice.date_received.to_s(:simple))
   end
-
 end

--- a/spec/views/rails_admin/application/redact_queue.html.erb_spec.rb
+++ b/spec/views/rails_admin/application/redact_queue.html.erb_spec.rb
@@ -11,11 +11,11 @@ describe 'rails_admin/application/redact_queue.html.erb' do
     assign(:objects, [])
   end
 
-  it "Includes the ID, Title, Body, Entities, and Date received" do
+  it 'Includes the ID, Title, Body, Entities, and Date received' do
     notice = build_stubbed(
       :dmca,
       :with_body,
-      role_names: %w( sender, recipient, submitter ),
+      role_names: %w[sender recipient submitter],
       date_received: Time.now
     )
     assign(:objects, [notice])

--- a/spec/views/shared/_topic_list.html.erb_spec.rb
+++ b/spec/views/shared/_topic_list.html.erb_spec.rb
@@ -16,6 +16,6 @@ describe 'shared/_topic_list.html.erb' do
 
     render 'shared/topic_list', topics: topics
 
-    expect(rendered).to have_content(/^#{topics.map(&:name).join(', ')}$/)
+    expect(rendered).to have_words(topics.map(&:name).join(', ').to_s)
   end
 end

--- a/spec/views/shared/_topic_list.html.erb_spec.rb
+++ b/spec/views/shared/_topic_list.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'shared/_topic_list.html.erb' do
-  it "includes links to each topic by name" do
+  it 'includes links to each topic by name' do
     topics = build_stubbed_list(:topic, 3)
 
     render 'shared/topic_list', topics: topics
@@ -11,7 +11,7 @@ describe 'shared/_topic_list.html.erb' do
     end
   end
 
-  it "builds the comma-separated list correctly" do
+  it 'builds the comma-separated list correctly' do
     topics = build_stubbed_list(:topic, 3)
 
     render 'shared/topic_list', topics: topics


### PR DESCRIPTION
This requires some rewrites to the tests because Capybara3 handles
whitespace differently than Capybara2 did.

## Ready for merge?
**YES**

#### What does this PR do?
Upgrades poltergeist and capybara in hopes of better test stability (they were pretty old versions).

#### How can a reviewer manually see the effects of these changes?
There shouldn't be any - bundle install and then run tests as normal.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15903

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- ~~[ ] Documentation~~
- ~~[ ] Stakeholder approval~~

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES