### PR TITLE
Add turnout back

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+AllCops:
+  Exclude:
+    - '**/*.html.erb'
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'simple_form'
 gem 'skylight'
 gem 'spork-rails', git: 'https://github.com/sporkrb/spork-rails'
 gem 'stackprof'
+gem 'turnout'
 gem 'twitter'
 gem 'twitter-text'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     country_select (1.2.0)
     coveralls (0.7.1)
       multi_json (~> 1.3)
@@ -155,7 +155,8 @@ GEM
       thor (>= 0.13.6)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    haml (4.0.7)
+    haml (5.0.4)
+      temple (>= 0.8.0)
       tilt
     hashdiff (0.3.7)
     hashie (3.5.6)
@@ -178,7 +179,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (5.0.5)
+    jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (1.8.6)
     kaminari (0.14.1)
@@ -204,7 +205,7 @@ GEM
     mime-types (2.99.3)
     mimemagic (0.3.2)
     mini_mime (1.0.1)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
@@ -216,8 +217,8 @@ GEM
       sass (>= 3.2)
     nested_form (0.3.2)
     netrc (0.11.0)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.9.1)
+      mini_portile2 (~> 2.4.0)
     oink (0.10.1)
       activerecord
       hodel_3000_compliant_logger
@@ -245,6 +246,8 @@ GEM
       pry (>= 0.9.10)
     public_suffix (3.0.3)
     rack (1.6.11)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
     rack-attack (4.3.0)
       rack
     rack-pjax (1.0.0)
@@ -271,7 +274,7 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rails_admin (1.4.1)
+    rails_admin (1.4.2)
       builder (~> 3.1)
       coffee-rails (~> 4.0)
       font-awesome-rails (>= 3.0, < 5)
@@ -293,8 +296,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     recipient_interceptor (0.1.1)
       mail
     redcarpet (2.3.0)
@@ -331,7 +334,7 @@ GEM
     ruby-prof (0.13.0)
     ruby-progressbar (1.5.1)
     safe_yaml (1.0.4)
-    sass (3.5.7)
+    sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -368,6 +371,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     stackprof (0.2.10)
+    temple (0.8.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
     terrapin (0.6.0)
@@ -377,9 +381,14 @@ GEM
       ref
     thor (0.20.3)
     thread_safe (0.3.6)
-    tilt (2.0.8)
+    tilt (2.0.9)
     timecop (0.6.1)
     tins (1.16.3)
+    turnout (2.5.0)
+      i18n (>= 0.7, < 2)
+      rack (>= 1.3, < 3)
+      rack-accept (~> 0.4)
+      tilt (>= 1.4, < 3)
     twitter (5.15.0)
       addressable (~> 2.3)
       buftok (~> 0.2.0)
@@ -487,6 +496,7 @@ DEPENDENCIES
   stackprof
   therubyracer
   timecop
+  turnout
   twitter
   twitter-text
   uglifier

--- a/app/views/pages/maintenance.html.erb
+++ b/app/views/pages/maintenance.html.erb
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta charset="utf-8">
+    <meta name='ROBOTS' content='NOODP' />
+    <title>Lumen - Maintenance</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="/error_style.css" rel="stylesheet" type="text/css">
+  </head>
+  <body class="home">
+    <nav class="main-nav">&nbsp;</nav>
+    <section class="main home">
+      <section class="home-search-form">
+        <a href="/"><h1><img alt="Lumen Logo" src="/assets/logo_2x.png" height="52" width="340"></h1></a>
+
+        <div class="info">
+          <p>
+            Lumen is down for maintenance. It should be back shortly.
+          </p>
+        </div>
+      </section>
+    </section>
+    <footer class="main">
+      <div class="inner-wrapper">
+        <span>© 2019 Lumen</span>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/app/views/pages/maintenance.html.erb
+++ b/app/views/pages/maintenance.html.erb
@@ -1,30 +1,36 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <meta charset="utf-8">
-    <meta name='ROBOTS' content='NOODP' />
-    <title>Lumen - Maintenance</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="/error_style.css" rel="stylesheet" type="text/css">
-  </head>
-  <body class="home">
-    <nav class="main-nav">&nbsp;</nav>
-    <section class="main home">
-      <section class="home-search-form">
-        <a href="/"><h1><img alt="Lumen Logo" src="/assets/logo_2x.png" height="52" width="340"></h1></a>
-
-        <div class="info">
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta charset="utf-8">
+  <meta name='ROBOTS' content='NOODP' />
+  <title>Lumen - Maintenance</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="/error_style.css" rel="stylesheet" type="text/css">
+</head>
+<body class="home">
+  <nav class="main-nav">&nbsp;</nav>
+  <section class="main home">
+    <section class="home-search-form">
+      <h1><img alt="Lumen Logo" src="/logo_2x.png" height="82" width="340"></h1>
+    </section>
+    <div class="site-news">
+      <section>
+        <h2>Down for Maintenance</h2>
+        <% if reason.present? %>
+          <%= reason %>
+        <% else %>
           <p>
             Lumen is down for maintenance. It should be back shortly.
           </p>
-        </div>
+        <% end %>
       </section>
-    </section>
-    <footer class="main">
-      <div class="inner-wrapper">
-        <span>© 2019 Lumen</span>
-      </div>
-    </footer>
-  </body>
+    </div>
+  </section>
+  <footer class="main">
+    <div class="inner-wrapper">
+      <span>© 2019 Lumen</span>
+    </div>
+  </footer>
+</body>
 </html>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the rails application
-require File.expand_path('../application', __FILE__)
+require File.expand_path('application', __dir__)
 
 # Initialize the rails application
 Chill::Application.initialize!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,8 +12,10 @@ Chill::Application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # Disable Rails's static files server (Apache or nginx will already do this)
-  config.serve_static_files = false
+  # In general we want to disable Rails's static files server (Apache or nginx
+  # will already do this), but when turnout is enabled we need to be able to
+  # serve the stylesheet and logo.
+  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/config/initializers/turnout.rb
+++ b/config/initializers/turnout.rb
@@ -1,0 +1,5 @@
+Turnout.configure do |config|
+  config.maintenance_pages_path = 'app/views/pages'
+  config.default_reason = 'Lumen is temporarily unavailable due to site upgrades.'
+  config.default_allowed_paths = ['^/admin/']
+end

--- a/config/initializers/turnout.rb
+++ b/config/initializers/turnout.rb
@@ -1,6 +1,6 @@
 Turnout.configure do |config|
-  config.maintenance_pages_path = 'app/views/pages'
-  config.default_reason = 'Lumen is temporarily unavailable due to site upgrades.'
+  config.maintenance_pages_path = Rails.root.join('app', 'views', 'pages')
+  config.default_reason = 'Lumen is down for maintenance. It should be back shortly.'
   config.default_allowed_paths = [
     '^/admin',
     # The following are required for the admin to be usable.
@@ -9,6 +9,6 @@ Turnout.configure do |config|
     '^/users/sign_out',
     # The following are required to style the maintenance page correctly.
     '^/error_style.css',
-    '^/assets/logo_2x.png'
+    '^/logo_2x.png'
   ]
 end

--- a/config/initializers/turnout.rb
+++ b/config/initializers/turnout.rb
@@ -1,5 +1,14 @@
 Turnout.configure do |config|
   config.maintenance_pages_path = 'app/views/pages'
   config.default_reason = 'Lumen is temporarily unavailable due to site upgrades.'
-  config.default_allowed_paths = ['^/admin/']
+  config.default_allowed_paths = [
+    '^/admin',
+    # The following are required for the admin to be usable.
+    '^/assets/',
+    '^/users/sign_in',
+    '^/users/sign_out',
+    # The following are required to style the maintenance page correctly.
+    '^/error_style.css',
+    '^/assets/logo_2x.png'
+  ]
 end

--- a/doc/release.md
+++ b/doc/release.md
@@ -5,8 +5,6 @@ Maintenance windows are Wednesday and Saturday nights (after 5pm Eastern).
 ## Special instructions
 If any deploys have special instructions, write them here, with a date and PR number. When that PR has been deployed, you can erase the special instructions.
 
-PR #512 - add cron job for work redaction rake task, running every 2 hours with lockrun to avoid duplicating db queries.
-
 ## Hotfix
 * Write code, code-review, and merge into `dev` via the normal process.
 * Give Adam a heads-up: what you're doing, what it fixes, why it needs to be pushed out ASAP.
@@ -43,6 +41,7 @@ PR #512 - add cron job for work redaction rake task, running every 2 hours with 
 * Log in to the relevant server (`psh <servername>`)
 * `sudo -su chill-prod` (enyos) or `sudo -su chill-dev` (flutie) or `sudo -su chill-api` (percy)
 * cd into the directory where chill files live (look under `/web/<servername>`)
+* `rake lumen:maintenance_start`
 * `cp .env ../` (as a precaution)
 * `git checkout db/schema.rb`
 * `git checkout <branch>`
@@ -56,5 +55,5 @@ PR #512 - add cron job for work redaction rake task, running every 2 hours with 
   - If this throws a `PG::ConnectionBad:` and asks something like "Is the server running locally and accepting connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?", use `RAILS_ENV=production rake db:migrate`
 * `rake assets:clobber`
 * `rake assets:precompile`
-* `touch tmp/restart.txt`
-  * This tells Passenger to restart its listener
+* `rake lumen:maintenance_end`
+  * This includes the `touch tmp/restart.txt` command, which tells Passenger to restart its listener.

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -682,4 +682,22 @@ where works.id in (
           "find . -type d -empty -delete 2>> #{__dir__}/../../log/safer_cache_clear.log"
     system(cmd)
   end
+
+  # We have special maintenance start & end tasks so that we can toggle the
+  # RAILS_SERVE_STATIC_FILES env as part of the process; we normally want this
+  # to be false (it's Apache's responsibility), but it must be true for turnout
+  # to find its stylesheets.
+  desc 'maintenance start'
+  task maintenance_start: :environment do
+    ENV['RAILS_SERVE_STATIC_FILES'] = 'true'
+    Rake::Task['maintenance:start'].invoke
+    system('touch tmp/restart.txt')
+  end
+
+  desc 'maintenance end'
+  task maintenance_end: :environment do
+    ENV['RAILS_SERVE_STATIC_FILES'] = nil
+    Rake::Task['maintenance:end'].invoke
+    system('touch tmp/restart.txt')
+  end
 end

--- a/public/500.html
+++ b/public/500.html
@@ -18,11 +18,9 @@
       <div class="site-news">
         <section>
           <h2>Temporary Server Error</h2>
-          <ol>
-            <li>
-             Lumen is currently unavailable.  We apologize for the inconvenience, please check back later.
-            </li>
-          </ol>
+          <p>
+            Lumen is currently unavailable.  We apologize for the inconvenience; please check back later.
+          </p>
         </section>
       </div>
   </section>


### PR DESCRIPTION
This requires upgrading rails_admin - there was a bug in 1.4.1 that
was making it impossible to modify middleware, thereby clashing with
turnout.

## Ready for merge?
**YES**

#### What does this PR do?
I had removed the turnout gem because it made the test suite crash. Then I was sad that I wasn't able to put the site into maintenance mode when I deployed last night. Now I have figured out how to use turnout without making things crash.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
`rake maintenance:start`, then visit any page on localhost. `rake maintenance:end` when you're tired of maintenance mode.

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES
