### PR TITLE
Don't cache shared/head

### DIFF
--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -1,9 +1,7 @@
-<% cache '_head' do %>
-  <%= stylesheet_link_tag :application, :media => 'all' %>
-  <%= csrf_meta_tags %>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="shortcut icon" href="/favicon.ico">
-  <!--[if lt IE 9]>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.6.2/html5shiv.js"></script>
-  <![endif]-->
-<% end %>
+<%= stylesheet_link_tag :application, :media => 'all' %>
+<%= csrf_meta_tags %>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="shortcut icon" href="/favicon.ico">
+<!--[if lt IE 9]>
+<script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.6.2/html5shiv.js"></script>
+<![endif]-->


### PR DESCRIPTION
Caching this caches the output of the stylesheet tag, which means that
the stylesheet may not be found after a deployment/asset precompilation.

## Ready for merge?
**YES**

#### What does this PR do?

#### Helpful background context (if appropriate)
The stylesheet wasn't loading on api-beta so it looked gross and weird. Killing the cache fixed the problem, but this is a better way to fix it.

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/16045

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
