### PR TITLE
Update sorting options in notice search view

### DIFF
--- a/app/assets/stylesheets/search/_index.scss
+++ b/app/assets/stylesheets/search/_index.scss
@@ -25,16 +25,36 @@ section.search-results {
       margin-left: 0;
     }
 
-    &.open .dropdown-menu {
-      display: block;
-    }
-
     .dropdown-menu {
       @extend %dropdown-menu;
       margin-left: 32px;
 
       a {
         color: lighten($base-font-color, 5%);
+      }
+    }
+
+    &::after {
+      height: 0;
+      width: 0;
+      border-color: transparent;
+      border-style: solid;
+      border-width: 4px;
+      border-top-color: $base-font-color-2;
+      position: absolute;
+      content: "";
+      right: -12px;
+      top: calc(50% - 2px);
+    }
+
+    &.open {
+      .dropdown-menu {
+        display: block;
+      }
+
+      &::after {
+        border-top: none;
+        border-bottom-color: $base-font-color-2;
       }
     }
   }
@@ -203,4 +223,3 @@ ol.results-list {
     }
   }
 }
-

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -45,8 +45,10 @@ class Notice < ActiveRecord::Base
   SORTINGS = [
     Sorting.new('relevancy desc', [:_score, :desc], 'Most Relevant'),
     Sorting.new('relevancy asc', [:_score, :asc], 'Least Relevant'),
-    Sorting.new('date_received desc', [:date_received, :desc], 'Newest'),
-    Sorting.new('date_received asc', [:date_received, :asc], 'Oldest')
+    Sorting.new('date_received desc', [:date_received, :desc], 'Date - newest'),
+    Sorting.new('date_received asc', [:date_received, :asc], 'Date - oldest'),
+    Sorting.new('created_at desc', [:created_at, :desc], 'Reported to Lumen - newest'),
+    Sorting.new('created_at asc', [:created_at, :asc], 'Reported to Lumen - oldest')
   ].freeze
 
   REDACTABLE_FIELDS = %i[body].freeze

--- a/spec/integration/fielded_notice_search_spec.rb
+++ b/spec/integration/fielded_notice_search_spec.rb
@@ -68,12 +68,13 @@ feature 'Fielded searches of Notices' do
     end
   end
 
-  context 'sorting' do
+  context 'sorting by date_received' do
     before do
-      @notice = create(:dmca, title: 'Lion King', date_received: 1.day.ago)
-      @old_notice = create(
+      @notice_new_received = create(:dmca, title: 'Lion King', date_received: 1.day.ago)
+      @notice_old_received = create(
         :dmca, title: 'King Leon', date_received: 10.days.ago
       )
+
       index_changed_instances
 
       submit_search('king')
@@ -83,10 +84,10 @@ feature 'Fielded searches of Notices' do
       search_on_page = FieldedSearchOnPage.new
       search_on_page.define_sort_order('date_received desc')
 
-      expect(page).to have_sort_order_selection_of('Newest')
+      expect(page).to have_sort_order_selection_of('Date - newest')
       search_on_page.within_results do
-        expect(page).to have_first_notice_of(@notice)
-        expect(page).to have_last_notice_of(@old_notice)
+        expect(page).to have_first_notice_of(@notice_new_received)
+        expect(page).to have_last_notice_of(@notice_old_received)
       end
     end
 
@@ -94,10 +95,43 @@ feature 'Fielded searches of Notices' do
       search_on_page = FieldedSearchOnPage.new
       search_on_page.define_sort_order('date_received asc')
 
-      expect(page).to have_sort_order_selection_of('Oldest')
+      expect(page).to have_sort_order_selection_of('Date - oldest')
       search_on_page.within_results do
-        expect(page).to have_first_notice_of(@old_notice)
-        expect(page).to have_last_notice_of(@notice)
+        expect(page).to have_first_notice_of(@notice_old_received)
+        expect(page).to have_last_notice_of(@notice_new_received)
+      end
+    end
+  end
+
+  context 'sorting by created_at' do
+    before do
+      @notice_old_created = create(:dmca, title: 'King Leon')
+      @notice_new_created = create(:dmca, title: 'Lion King')
+
+      index_changed_instances
+
+      submit_search('king')
+    end
+
+    scenario 'by newest created_at', search: true, js: true do
+      search_on_page = FieldedSearchOnPage.new
+      search_on_page.define_sort_order('created_at desc')
+
+      expect(page).to have_sort_order_selection_of('Reported to Lumen - newest')
+      search_on_page.within_results do
+        expect(page).to have_first_notice_of(@notice_new_created)
+        expect(page).to have_last_notice_of(@notice_old_created)
+      end
+    end
+
+    scenario 'by oldest created_at', search: true, js: true do
+      search_on_page = FieldedSearchOnPage.new
+      search_on_page.define_sort_order('created_at asc')
+
+      expect(page).to have_sort_order_selection_of('Reported to Lumen - oldest')
+      search_on_page.within_results do
+        expect(page).to have_first_notice_of(@notice_old_created)
+        expect(page).to have_last_notice_of(@notice_new_created)
       end
     end
   end


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Adds a new sorting option to the notice search view called `Reported to Lumen` and updates the existing one called `Date`.

#### How can a reviewer manually see the effects of these changes?
Use the search and test the sorting.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15495

#### Todo:
- [x] Tests
~~- [ ] Documentation~~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
