### PR TITLE
Fix risk triggers

### DIFF
--- a/app/models/risk_assessment.rb
+++ b/app/models/risk_assessment.rb
@@ -9,10 +9,7 @@ class RiskAssessment
     risk_triggers.each do |trigger|
       trigger_risky = trigger.risky?(notice)
 
-      if trigger_risky && trigger.force_not_risky_assessment?
-        risky = false
-        break
-      end
+      return false if trigger_risky && trigger.force_not_risky_assessment?
 
       risky = true if trigger_risky
     end

--- a/app/models/risk_assessment.rb
+++ b/app/models/risk_assessment.rb
@@ -4,7 +4,20 @@ class RiskAssessment
   end
 
   def high_risk?
-    risk_triggers.any? { |trigger| trigger.risky?(notice) }
+    risky = false
+
+    risk_triggers.each do |trigger|
+      trigger_risky = trigger.risky?(notice)
+
+      if trigger_risky && trigger.force_not_risky_assessment?
+        risky = false
+        break
+      end
+
+      risky = true if trigger_risky
+    end
+
+    risky
   end
 
   private

--- a/app/models/risk_assessment.rb
+++ b/app/models/risk_assessment.rb
@@ -4,17 +4,7 @@ class RiskAssessment
   end
 
   def high_risk?
-    risky = false
-
-    risk_triggers.each do |trigger|
-      trigger_risky = trigger.risky?(notice)
-
-      return false if trigger_risky && trigger.force_not_risky_assessment?
-
-      risky = true if trigger_risky
-    end
-
-    risky
+    risk_triggers.any? { |trigger| trigger.risky?(notice) }
   end
 
   private

--- a/app/models/risk_trigger.rb
+++ b/app/models/risk_trigger.rb
@@ -1,29 +1,18 @@
 class RiskTrigger < ActiveRecord::Base
+  ALLOWED_MATCHING_TYPES = %w[any all].freeze
+
+  has_many :risk_trigger_conditions, dependent: :destroy
+
+  validates_presence_of :name, :matching_type
+  validates_inclusion_of :matching_type, in: ALLOWED_MATCHING_TYPES
+
   def risky?(notice)
-    if notice.submitter.try(:email) == 'google@lumendatabase.org' &&
-       notice.try(:type) == 'Defamation'
-      false
+    return false unless risk_trigger_conditions.any?
+
+    if matching_type == 'any'
+      risk_trigger_conditions.any? { |condition| condition.risky?(notice) }
     else
-      begin
-        field_present?(notice) && condition_matches?(notice)
-      rescue NoMethodError => ex
-        Rails.logger.warn "Invalid risk trigger (#{id}): #{ex}"
-        false
-      end
-    end
-  end
-
-  private
-
-  def field_present?(notice)
-    notice.send(field).present?
-  end
-
-  def condition_matches?(notice)
-    if negated?
-      notice.send(condition_field) != condition_value
-    else
-      notice.send(condition_field) == condition_value
+      risk_trigger_conditions.all? { |condition| condition.risky?(notice) }
     end
   end
 end

--- a/app/models/risk_trigger_condition.rb
+++ b/app/models/risk_trigger_condition.rb
@@ -1,0 +1,69 @@
+class RiskTriggerCondition < ActiveRecord::Base
+  ALLOWED_FIELDS = %w[
+    title subject source tag_list language jurisdiction_list action_taken body
+    type
+    submitter.name submitter.kind submitter.address_line_1
+    submitter.address_line_2 submitter.city submitter.state submitter.zip
+    submitter.country_code submitter.phone submitter.email submitter.url
+    recipient.name recipient.kind recipient.address_line_1
+    recipient.address_line_2 recipient.city recipient.state recipient.zip
+    recipient.country_code recipient.phone recipient.email recipient.url
+    principal.name principal.kind principal.address_line_1
+    principal.address_line_2 principal.city principal.state principal.zip
+    principal.country_code principal.phone principal.email principal.url
+    sender.name sender.kind sender.address_line_1
+    sender.address_line_2 sender.city sender.state sender.zip
+    sender.country_code sender.phone sender.email sender.url
+  ].freeze
+
+  ALLOWED_MATCHING_TYPES = %w[exact broad].freeze
+
+  belongs_to :risk_trigger
+
+  validates_presence_of :field, :value
+  validates_inclusion_of :field, in: ALLOWED_FIELDS
+  validates_inclusion_of :matching_type, in: ALLOWED_MATCHING_TYPES
+
+  def risky?(notice)
+    field_present?(notice) && condition_matches?(notice)
+  rescue NoMethodError => ex
+    Rails.logger.warn "Invalid risk trigger condition (#{id}): #{ex}"
+    false
+  end
+
+  private
+
+  def field_present?(notice)
+    notice_field_value(notice).present?
+  end
+
+  def condition_matches?(notice)
+    notice_field_value = notice_field_value(notice)
+
+    if matching_type == 'exact'
+      match_exact(notice_field_value)
+    else
+      match_broad(notice_field_value)
+    end
+  end
+
+  def notice_field_value(notice)
+    field.split('.').inject(notice, :send)
+  end
+
+  def match_exact(notice_field_value)
+    if negated?
+      notice_field_value != value
+    else
+      notice_field_value == value
+    end
+  end
+
+  def match_broad(notice_field_value)
+    if negated?
+      !notice_field_value.include?(value)
+    else
+      notice_field_value.include?(value)
+    end
+  end
+end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -254,7 +254,7 @@ RailsAdmin.config do |config|
     edit do
       configure :field, :enum do
         enum do
-          RiskTriggerCondition::ALLOWED_FIELDS
+          RiskTriggerCondition::ALLOWED_FIELDS.sort
         end
       end
       configure :matching_type, :enum do

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -249,4 +249,29 @@ RailsAdmin.config do |config|
       end
     end
   end
+
+  config.model 'RiskTriggerCondition' do
+    edit do
+      configure :field, :enum do
+        enum do
+          RiskTriggerCondition::ALLOWED_FIELDS
+        end
+      end
+      configure :matching_type, :enum do
+        enum do
+          RiskTriggerCondition::ALLOWED_MATCHING_TYPES
+        end
+      end
+    end
+  end
+
+  config.model 'RiskTrigger' do
+    edit do
+      configure :matching_type, :enum do
+        enum do
+          RiskTrigger::ALLOWED_MATCHING_TYPES
+        end
+      end
+    end
+  end
 end

--- a/db/migrate/20190122150704_rename_risk_triggers.rb
+++ b/db/migrate/20190122150704_rename_risk_triggers.rb
@@ -1,0 +1,12 @@
+class RenameRiskTriggers < ActiveRecord::Migration
+  def change
+    rename_table :risk_triggers, :risk_trigger_conditions
+    remove_column :risk_trigger_conditions, :field
+    rename_column :risk_trigger_conditions, :condition_field, :field
+    rename_column :risk_trigger_conditions, :condition_value, :value
+    add_column :risk_trigger_conditions, :type, :string
+    add_column :risk_trigger_conditions, :matching_type, :string
+    change_column_null :risk_trigger_conditions, :field, false
+    change_column_null :risk_trigger_conditions, :value, false
+  end
+end

--- a/db/migrate/20190122151538_create_new_risk_triggers.rb
+++ b/db/migrate/20190122151538_create_new_risk_triggers.rb
@@ -1,0 +1,38 @@
+class CreateNewRiskTriggers < ActiveRecord::Migration
+  def change
+    # Create a new table
+    create_table :risk_triggers do |t|
+      t.string :name, null: false
+      t.string :matching_type, null: false
+      t.string :comment
+    end
+
+    # Add a reference field to the risk_trigger_conditions
+    add_reference :risk_trigger_conditions, :risk_trigger, index: true
+
+    # Create a default risk trigger
+    default_risk_trigger = RiskTrigger.create(
+      name: 'Default',
+      matching_type: 'all'
+    )
+
+    # Assign all the exisiting conditions to the default trigger
+    RiskTriggerCondition.update_all(risk_trigger_id: default_risk_trigger)
+
+    # Create a risk trigger conditions from the ones that were hard-coded in the RiskTrigger model
+    RiskTriggerCondition.create(
+      field: 'type',
+      value: 'Defamation',
+      negated: true,
+      risk_trigger_id: default_risk_trigger,
+      matching_type: 'exact'
+    )
+    RiskTriggerCondition.create(
+      field: 'submitter.email',
+      value: 'google@lumendatabase.org',
+      negated: true,
+      risk_trigger_id: default_risk_trigger,
+      matching_type: 'exact'
+    )
+  end
+end

--- a/db/migrate/20190122151538_create_new_risk_triggers.rb
+++ b/db/migrate/20190122151538_create_new_risk_triggers.rb
@@ -5,6 +5,7 @@ class CreateNewRiskTriggers < ActiveRecord::Migration
       t.string :name, null: false
       t.string :matching_type, null: false
       t.string :comment
+      t.boolean :force_not_risky_assessment, default: false, null: false
     end
 
     # Add a reference field to the risk_trigger_conditions
@@ -19,19 +20,24 @@ class CreateNewRiskTriggers < ActiveRecord::Migration
     # Assign all the exisiting conditions to the default trigger
     RiskTriggerCondition.update_all(risk_trigger_id: default_risk_trigger)
 
-    # Create a risk trigger conditions from the ones that were hard-coded in the RiskTrigger model
+    # Create a risk trigger and its conditions from the ones that were hard-coded in the RiskTrigger model
+    google_risk_trigger = RiskTrigger.create(
+      name: 'Google Defamation',
+      matching_type: 'all',
+      force_not_risky_assessment: true
+    )
     RiskTriggerCondition.create(
-      field: 'type',
+      field: 'notice.type',
       value: 'Defamation',
-      negated: true,
-      risk_trigger_id: default_risk_trigger,
+      negated: false,
+      risk_trigger: google_risk_trigger,
       matching_type: 'exact'
     )
     RiskTriggerCondition.create(
       field: 'submitter.email',
       value: 'google@lumendatabase.org',
-      negated: true,
-      risk_trigger_id: default_risk_trigger,
+      negated: false,
+      risk_trigger: google_risk_trigger,
       matching_type: 'exact'
     )
   end

--- a/db/migrate/20190122151538_create_new_risk_triggers.rb
+++ b/db/migrate/20190122151538_create_new_risk_triggers.rb
@@ -5,7 +5,6 @@ class CreateNewRiskTriggers < ActiveRecord::Migration
       t.string :name, null: false
       t.string :matching_type, null: false
       t.string :comment
-      t.boolean :force_not_risky_assessment, default: false, null: false
     end
 
     # Add a reference field to the risk_trigger_conditions
@@ -19,26 +18,5 @@ class CreateNewRiskTriggers < ActiveRecord::Migration
 
     # Assign all the exisiting conditions to the default trigger
     RiskTriggerCondition.update_all(risk_trigger_id: default_risk_trigger)
-
-    # Create a risk trigger and its conditions from the ones that were hard-coded in the RiskTrigger model
-    google_risk_trigger = RiskTrigger.create(
-      name: 'Google Defamation',
-      matching_type: 'all',
-      force_not_risky_assessment: true
-    )
-    RiskTriggerCondition.create(
-      field: 'notice.type',
-      value: 'Defamation',
-      negated: false,
-      risk_trigger: google_risk_trigger,
-      matching_type: 'exact'
-    )
-    RiskTriggerCondition.create(
-      field: 'submitter.email',
-      value: 'google@lumendatabase.org',
-      negated: false,
-      risk_trigger: google_risk_trigger,
-      matching_type: 'exact'
-    )
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -241,10 +241,9 @@ ActiveRecord::Schema.define(version: 20190122151538) do
   add_index "risk_trigger_conditions", ["risk_trigger_id"], name: "index_risk_trigger_conditions_on_risk_trigger_id", using: :btree
 
   create_table "risk_triggers", force: :cascade do |t|
-    t.string  "name",                                       null: false
-    t.string  "matching_type",                              null: false
-    t.string  "comment"
-    t.boolean "force_not_risky_assessment", default: false, null: false
+    t.string "name",          null: false
+    t.string "matching_type", null: false
+    t.string "comment"
   end
 
   create_table "roles", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180815162606) do
+ActiveRecord::Schema.define(version: 20190122151538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -229,11 +229,21 @@ ActiveRecord::Schema.define(version: 20180815162606) do
   add_index "relevant_questions_topics", ["relevant_question_id"], name: "index_relevant_questions_topics_on_relevant_question_id", using: :btree
   add_index "relevant_questions_topics", ["topic_id"], name: "index_relevant_questions_topics_on_topic_id", using: :btree
 
-  create_table "risk_triggers", force: :cascade do |t|
-    t.string  "field"
-    t.string  "condition_field"
-    t.string  "condition_value"
+  create_table "risk_trigger_conditions", force: :cascade do |t|
+    t.string  "field",           null: false
+    t.string  "value",           null: false
     t.boolean "negated"
+    t.string  "type"
+    t.string  "matching_type"
+    t.integer "risk_trigger_id"
+  end
+
+  add_index "risk_trigger_conditions", ["risk_trigger_id"], name: "index_risk_trigger_conditions_on_risk_trigger_id", using: :btree
+
+  create_table "risk_triggers", force: :cascade do |t|
+    t.string "name",          null: false
+    t.string "matching_type", null: false
+    t.string "comment"
   end
 
   create_table "roles", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -241,9 +241,10 @@ ActiveRecord::Schema.define(version: 20190122151538) do
   add_index "risk_trigger_conditions", ["risk_trigger_id"], name: "index_risk_trigger_conditions_on_risk_trigger_id", using: :btree
 
   create_table "risk_triggers", force: :cascade do |t|
-    t.string "name",          null: false
-    t.string "matching_type", null: false
-    t.string "comment"
+    t.string  "name",                                       null: false
+    t.string  "matching_type",                              null: false
+    t.string  "comment"
+    t.boolean "force_not_risky_assessment", default: false, null: false
   end
 
   create_table "roles", force: :cascade do |t|

--- a/db/seeds/risk_triggers.rb
+++ b/db/seeds/risk_triggers.rb
@@ -1,6 +1,12 @@
-RiskTrigger.create!(
-  field: :body,
-  condition_field: :country_code,
-  condition_value: 'us',
-  negated: true
+risk_trigger = RiskTrigger.create!(
+  name: 'Submitter country code not US',
+  matching_type: 'all'
+)
+
+RiskTriggerCondition.create!(
+  field: 'submitter.country_code',
+  value: 'us',
+  negated: true,
+  risk_trigger: risk_trigger,
+  matching_type: 'exact'
 )

--- a/spec/integration/reviewable_notice_spec.rb
+++ b/spec/integration/reviewable_notice_spec.rb
@@ -5,7 +5,7 @@ feature 'Publishing high risk notices' do
 
   let(:harmless_text) { 'Some harmless text' }
 
-  scenario 'A non-US notice with Body text' do
+  scenario 'A non-US notice with a non-us trigger condition is risky' do
     create_non_us_risk_trigger
 
     submit_notice_from('Spain') do
@@ -18,7 +18,7 @@ feature 'Publishing high risk notices' do
     end
   end
 
-  scenario 'A US notice with Body text' do
+  scenario 'A US notice with a non-us trigger condition is not risky' do
     create_non_us_risk_trigger
 
     submit_notice_from('United States') do
@@ -31,14 +31,105 @@ feature 'Publishing high risk notices' do
     end
   end
 
+  scenario 'A notice and a trigger that should match all with two conditions and matching all of them is risky' do
+    condition1 = create_condition('title', 'risky', false, 'broad')
+    condition2 = create_condition('body', 'risky', false, 'broad')
+    create_trigger('Risky stuff', 'all', [condition1, condition2])
+
+    submit_notice_from('United States') do
+      fill_in 'Title', with: 'I\'m so risky title, woooo!'
+      fill_in 'Body', with: 'I\'m so risky body, watch out!'
+    end
+
+    open_recent_notice
+    within('.notice-body') do
+      expect(page).to have_words Notice::UNDER_REVIEW_VALUE
+    end
+  end
+
+  scenario 'A notice and a trigger that should match all with two conditions and matching just one of them is not risky' do
+    condition1 = create_condition('title', 'risky', false, 'broad')
+    condition2 = create_condition('body', 'risky', false, 'broad')
+    create_trigger('Risky stuff', 'all', [condition1, condition2])
+
+    submit_notice_from('United States') do
+      fill_in 'Title', with: 'I\'m so risky title, woooo!'
+      fill_in 'Body', with: harmless_text
+    end
+
+    open_recent_notice
+    within('.notice-body') do
+      expect(page).to have_words harmless_text
+    end
+  end
+
+  scenario 'A notice and a trigger that should match any with two conditions and matching just one of them is risky' do
+    condition1 = create_condition('title', 'risky', false, 'broad')
+    condition2 = create_condition('body', 'risky', false, 'broad')
+    create_trigger('Risky stuff', 'any', [condition1, condition2])
+
+    submit_notice_from('United States') do
+      fill_in 'Title', with: 'I\'m so risky title, woooo!'
+      fill_in 'Body', with: harmless_text
+    end
+
+    open_recent_notice
+    within('.notice-body') do
+      expect(page).to have_words Notice::UNDER_REVIEW_VALUE
+    end
+  end
+
+  scenario 'A notice and a trigger with exact conditions match and is risky' do
+    condition1 = create_condition('title', 'risky1', false, 'exact')
+    condition2 = create_condition('body', 'risky2', false, 'exact')
+    create_trigger('Risky stuff', 'all', [condition1, condition2])
+
+    submit_notice_from('United States') do
+      fill_in 'Title', with: 'risky1'
+      fill_in 'Body', with: 'risky2'
+    end
+
+    open_recent_notice
+    within('.notice-body') do
+      expect(page).to have_words Notice::UNDER_REVIEW_VALUE
+    end
+  end
+
+  scenario 'A notice and a trigger with no conditions is not risky' do
+    create_trigger('Risky stuff', 'all', [])
+
+    submit_notice_from('United States') do
+      fill_in 'Title', with: 'risky1'
+      fill_in 'Body', with: 'risky2'
+    end
+
+    open_recent_notice
+    within('.notice-body') do
+      expect(page).not_to have_words Notice::UNDER_REVIEW_VALUE
+    end
+  end
+
   private
 
   def create_non_us_risk_trigger
+    risk_trigger_condition = create_condition('recipient.country_code', 'us', true, 'exact')
+    create_trigger('Non US risk trigger', 'all', [risk_trigger_condition])
+  end
+
+  def create_condition(field, value, negated, matching_type)
+    RiskTriggerCondition.create!(
+      field: field,
+      value: value,
+      negated: negated,
+      matching_type: matching_type
+    )
+  end
+
+  def create_trigger(name, matching_type, conditions)
     RiskTrigger.create!(
-      field: 'body',
-      condition_field: 'country_code',
-      condition_value: 'us',
-      negated: true
+      name: name,
+      matching_type: matching_type,
+      risk_trigger_conditions: conditions
     )
   end
 

--- a/spec/integration/reviewable_notice_spec.rb
+++ b/spec/integration/reviewable_notice_spec.rb
@@ -109,57 +109,6 @@ feature 'Publishing high risk notices' do
     end
   end
 
-  scenario 'A notice checked against two triggers when of the of triggers is force_not_risky_assessment is not risky' do
-    condition1 = create_condition('notice.title', 'risky1', false, 'exact')
-    create_trigger('Risky stuff', 'all', [condition1], false)
-
-    condition2 = create_condition('notice.source', 'risky2', false, 'exact')
-    create_trigger('Risky stuff', 'all', [condition2], true)
-
-    submit_notice_from('United States') do
-      fill_in 'Title', with: 'risky1'
-      fill_in 'Sent via', with: 'risky2'
-      fill_in 'Body', with: harmless_text
-    end
-
-    open_recent_notice
-    within('.notice-body') do
-      expect(page).to have_words harmless_text
-    end
-  end
-
-  scenario 'A defamation notice submitted by Google is not risky even when some other risk triggers are risky' do
-    condition = create_condition('notice.title', 'risky1', false, 'exact')
-    create_trigger('Risky stuff', 'all', [condition])
-
-    sign_in(create(:user, :submitter))
-
-    visit '/notices/new?type=Defamation'
-
-    fill_in 'Title', with: title
-    fill_in 'Legal Complaint', with: harmless_text
-    within('section.recipient') do
-      fill_in 'Name', with: 'Recipient the first'
-    end
-    within('section.sender') do
-      fill_in 'Name', with: 'Sender the first'
-    end
-    within('section.submitter') do
-      fill_in 'Name', with: 'Submitter the first'
-    end
-    within('section.recipient') do
-      select 'United States', from: 'Country'
-    end
-    fill_in 'Allegedly Defamatory URL', with: 'http://www.example.com/original_work.pdf'
-
-    click_on 'Submit'
-
-    open_recent_notice
-    within('.notice-body') do
-      expect(page).to have_words harmless_text
-    end
-  end
-
   private
 
   def create_non_us_risk_trigger
@@ -176,12 +125,11 @@ feature 'Publishing high risk notices' do
     )
   end
 
-  def create_trigger(name, matching_type, conditions, force_not_risky_assessment = false)
+  def create_trigger(name, matching_type, conditions)
     RiskTrigger.create!(
       name: name,
       matching_type: matching_type,
-      risk_trigger_conditions: conditions,
-      force_not_risky_assessment: force_not_risky_assessment
+      risk_trigger_conditions: conditions
     )
   end
 

--- a/spec/models/risk_assessment_spec.rb
+++ b/spec/models/risk_assessment_spec.rb
@@ -10,7 +10,6 @@ describe RiskAssessment, type: :model do
     notice = double("Notice")
     expect(trigger_1).to receive(:risky?).with(notice).and_return(false)
     expect(trigger_2).to receive(:risky?).with(notice).and_return(true)
-    expect(trigger_2).to receive(:force_not_risky_assessment?).and_return(false)
 
     assessment = RiskAssessment.new(notice)
 

--- a/spec/models/risk_assessment_spec.rb
+++ b/spec/models/risk_assessment_spec.rb
@@ -4,14 +4,13 @@ describe RiskAssessment, type: :model do
   it "returns true if any trigger triggers" do
     triggers = [
       trigger_1 = double("Trigger 1"),
-      trigger_2 = double("Trigger 2"),
-      trigger_3 = double("Trigger 3")
+      trigger_2 = double("Trigger 2")
     ]
     allow(RiskTrigger).to receive(:all).and_return(triggers)
     notice = double("Notice")
     expect(trigger_1).to receive(:risky?).with(notice).and_return(false)
     expect(trigger_2).to receive(:risky?).with(notice).and_return(true)
-    expect(trigger_3).not_to receive(:risky?) # enforce short-circuit logic
+    expect(trigger_2).to receive(:force_not_risky_assessment?).and_return(false)
 
     assessment = RiskAssessment.new(notice)
 

--- a/spec/models/risk_trigger_condition_spec.rb
+++ b/spec/models/risk_trigger_condition_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe RiskTriggerCondition, type: :model do
+  it { is_expected.to validate_presence_of :field }
+  it { is_expected.to validate_presence_of :value }
+  it { is_expected.to validate_inclusion_of(:field).in_array(RiskTriggerCondition::ALLOWED_FIELDS) }
+  it { is_expected.to validate_inclusion_of(:matching_type).in_array(RiskTriggerCondition::ALLOWED_MATCHING_TYPES) }
+  it { is_expected.to belong_to(:risk_trigger) }
+
+  it 'sees a risky notice as risky' do
+    notice = double('Notice')
+    allow(notice).to receive_message_chain(:submitter, country_code: 'Spain')
+
+    expect(example_trigger_condition).to be_risky(notice)
+  end
+
+  it 'uses negated to reverse the comparison' do
+    notice = double('Notice')
+    allow(notice).to receive_message_chain(:submitter, country_code: 'Spain')
+    trigger = example_trigger_condition
+    trigger.negated = false
+
+    expect(trigger).not_to be_risky(notice)
+  end
+
+  it 'sees a safe notice as safe' do
+    notice1 = double('Notice', country_code: 'United States')
+    allow(notice1).to receive_message_chain(:submitter, country_code: 'United States')
+    notice2 = double('Notice', country_code: 'Spain')
+    allow(notice2).to receive_message_chain(:submitter, country_code: 'Spain')
+
+    expect(example_trigger_condition).not_to be_risky(notice1)
+    expect(example_trigger_condition).to be_risky(notice2)
+  end
+
+  it 'gracefully handles non-existent notice attributes' do
+    invalid_trigger = RiskTriggerCondition.new(
+      field: 'i_dont_exist'
+    )
+
+    expect(invalid_trigger).not_to be_risky(Notice.new)
+  end
+
+  def example_trigger_condition
+    RiskTriggerCondition.new(
+      field: 'submitter.country_code',
+      value: 'United States',
+      negated: true
+    )
+  end
+end


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Updates the risk triggers functionality. The current implementation is not complete and not useful.

#### How can a reviewer manually see the effects of these changes?
Create a new risk trigger and risk trigger conditions. Assign the conditions to the trigger and try to add a new notice, properly configured it should make the notice as a risky one.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15785

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
~~- [ ] Documentation~~
- [x] Stakeholder approval

#### Requires Database Migrations?
YES 

#### Includes new or updated dependencies?
NO
