### PR TITLE
Add "Submitted to Lumen" date to notice search results

### DIFF
--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -19,6 +19,10 @@ module NoticesHelper
     display_date_field(notice, :date_received)
   end
 
+  def date_submitted(notice)
+    display_date_field(notice, :created_at)
+  end
+
   def subject(notice)
     if notice.subject.present?
       notice.subject

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -45,8 +45,8 @@ class Notice < ActiveRecord::Base
   SORTINGS = [
     Sorting.new('relevancy desc', [:_score, :desc], 'Most Relevant'),
     Sorting.new('relevancy asc', [:_score, :asc], 'Least Relevant'),
-    Sorting.new('date_received desc', [:date_received, :desc], 'Date - newest'),
-    Sorting.new('date_received asc', [:date_received, :asc], 'Date - oldest'),
+    Sorting.new('date_received desc', [:date_received, :desc], 'Date Received - newest'),
+    Sorting.new('date_received asc', [:date_received, :asc], 'Date Received - oldest'),
     Sorting.new('created_at desc', [:created_at, :desc], 'Reported to Lumen - newest'),
     Sorting.new('created_at asc', [:created_at, :asc], 'Reported to Lumen - oldest')
   ].freeze

--- a/app/views/notices/search/_result.html.erb
+++ b/app/views/notices/search/_result.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag_for(:li, result, class: "result") do %>
   <h3 class="title"><%= link_to result.title, notice_path(result.id) %></h3>
   <div class="metadata">
-    <div class="date-received"><%= date_received(result) %></div>
+    <div class="date-received">Received: <%= date_received(result) %></div>
     <div class="sender-receiver">
       <% if result.on_behalf_of_principal? %>
         <%= on_behalf_of(result.sender_name, result.principal_name) %>
@@ -17,6 +17,7 @@
         <%= link_to(result.recipient_name, faceted_search_path(recipient_name: result.recipient_name), class: 'receiver' )%>
       <% end %>
     </div>
+    <div class="date-submitted">Submitted to Lumen: <%= date_submitted(result) %></div>
     <ol class="excerpt">
       <% result.highlight.each do |highlight_elem| %>
         <li class="excerpt">

--- a/app/views/notices/search/_result.html.erb
+++ b/app/views/notices/search/_result.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag_for(:li, result, class: "result") do %>
   <h3 class="title"><%= link_to result.title, notice_path(result.id) %></h3>
   <div class="metadata">
-    <div class="date-received">Received: <%= date_received(result) %></div>
+    <div class="date-received">Date Received: <%= date_received(result) %></div>
     <div class="sender-receiver">
       <% if result.on_behalf_of_principal? %>
         <%= on_behalf_of(result.sender_name, result.principal_name) %>
@@ -17,7 +17,7 @@
         <%= link_to(result.recipient_name, faceted_search_path(recipient_name: result.recipient_name), class: 'receiver' )%>
       <% end %>
     </div>
-    <div class="date-submitted">Submitted to Lumen: <%= date_submitted(result) %></div>
+    <div class="date-submitted">Reported to Lumen: <%= date_submitted(result) %></div>
     <ol class="excerpt">
       <% result.highlight.each do |highlight_elem| %>
         <li class="excerpt">

--- a/spec/integration/fielded_notice_search_spec.rb
+++ b/spec/integration/fielded_notice_search_spec.rb
@@ -84,7 +84,7 @@ feature 'Fielded searches of Notices' do
       search_on_page = FieldedSearchOnPage.new
       search_on_page.define_sort_order('date_received desc')
 
-      expect(page).to have_sort_order_selection_of('Date - newest')
+      expect(page).to have_sort_order_selection_of('Date Received - newest')
       search_on_page.within_results do
         expect(page).to have_first_notice_of(@notice_new_received)
         expect(page).to have_last_notice_of(@notice_old_received)
@@ -95,7 +95,7 @@ feature 'Fielded searches of Notices' do
       search_on_page = FieldedSearchOnPage.new
       search_on_page.define_sort_order('date_received asc')
 
-      expect(page).to have_sort_order_selection_of('Date - oldest')
+      expect(page).to have_sort_order_selection_of('Date Received - oldest')
       search_on_page.within_results do
         expect(page).to have_first_notice_of(@notice_old_received)
         expect(page).to have_last_notice_of(@notice_new_received)


### PR DESCRIPTION
## Ready for merge?
YES

#### What does this PR do?
Adds the `created_at` date field (labeled `Submitted to Lumen`) to the notice search result.

#### How can a reviewer manually see the effects of these changes?
Try to search and check if every single result item has the `Submitted to Lumen` included.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/15495

#### Todo:
~~- [ ] Tests~~
~~- [ ] Documentation~~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
