### PR TITLE
13176 url kludge

### DIFF
--- a/app/serializers/copyrighted_url_serializer.rb
+++ b/app/serializers/copyrighted_url_serializer.rb
@@ -1,0 +1,3 @@
+class CopyrightedUrlSerializer < ActiveModel::Serializer
+  attributes :url
+end

--- a/app/serializers/infringing_url_serializer.rb
+++ b/app/serializers/infringing_url_serializer.rb
@@ -1,0 +1,3 @@
+class InfringingUrlSerializer < ActiveModel::Serializer
+  attributes :url
+end

--- a/app/serializers/notice_serializer.rb
+++ b/app/serializers/notice_serializer.rb
@@ -3,20 +3,12 @@ class NoticeSerializer < ActiveModel::Serializer
              :topics, :sender_name, :principal_name, :recipient_name, :works,
              :tags, :jurisdictions, :action_taken, :language
 
+  has_many :works
+
   # TODO: serialize additional entities
 
   def topics
     object.topics.map(&:name)
-  end
-
-  def works
-    object.works.as_json(
-      only: [:description],
-      include: {
-        infringing_urls: { only: %i[url url_original] },
-        copyrighted_urls: { only: %i[url url_original] }
-      }
-    )
   end
 
   def tags

--- a/app/serializers/work_serializer.rb
+++ b/app/serializers/work_serializer.rb
@@ -1,0 +1,17 @@
+class WorkSerializer < ActiveModel::Serializer
+  attributes :description
+  has_many :infringing_urls, :copyrighted_urls
+
+  FALLBACK = [{ url: 'No URL submitted' }].freeze
+
+  def as_json(options = {})
+    hash = super(options || {})
+    if hash[:work][:infringing_urls].empty?
+      hash[:work][:infringing_urls] = FALLBACK
+    end
+    if hash[:work][:copyrighted_urls].empty?
+      hash[:work][:copyrighted_urls] = FALLBACK
+    end
+    hash
+  end
+end

--- a/app/views/notices/_works_urls.html.erb
+++ b/app/views/notices/_works_urls.html.erb
@@ -2,8 +2,11 @@
   <div class="row">
     <span class="label original-title"><%= original_title %></span>
     <ol class="list original-urls">
-      <%# Don't do code style changes here, it's intentional to avoid additional spaces in the response %>
-      <% work.copyrighted_urls.each do |url| %><%= content_tag_for(:li, url) do %><%= url.url %><% end %><% end.empty? %>No copyrighted URLs were submitted.<% end %>
+      <% if work.copyrighted_urls.each do |url| %>
+        <%= content_tag_for(:li, url) do %><%= url.url %><% end %>
+      <% end.empty? %>
+        No copyrighted URLs were submitted.
+      <% end %>
     </ol>
   </div>
 <% end %>
@@ -12,8 +15,11 @@
   <div class="row">
     <span class="label infringing-title"><%= infringing_title %></span>
     <ol class="list infringing-urls">
-      <%# Don't do code style changes here, it's intentional to avoid additional spaces in the response %>
-      <% work.infringing_urls.each do |url| %><%= content_tag_for(:li, url) do %><%= url.url %><% end %><% end.empty? %>No infringing URLs were submitted.<% end %>
+      <% if work.infringing_urls.each do |url| %>
+        <%= content_tag_for(:li, url) do %><%= url.url %><% end %>
+      <% end.empty? %>
+        No infringing URLs were submitted.
+      <% end %>
     </ol>
   </div>
 <% end %>

--- a/app/views/notices/_works_urls.html.erb
+++ b/app/views/notices/_works_urls.html.erb
@@ -3,7 +3,7 @@
     <span class="label original-title"><%= original_title %></span>
     <ol class="list original-urls">
       <%# Don't do code style changes here, it's intentional to avoid additional spaces in the response %>
-      <% work.copyrighted_urls.each do |url| %><%= content_tag_for(:li, url) do %><%= url.url %><% end %><% end %>
+      <% work.copyrighted_urls.each do |url| %><%= content_tag_for(:li, url) do %><%= url.url %><% end %><% end.empty? %>No copyrighted URLs were submitted.<% end %>
     </ol>
   </div>
 <% end %>
@@ -13,7 +13,7 @@
     <span class="label infringing-title"><%= infringing_title %></span>
     <ol class="list infringing-urls">
       <%# Don't do code style changes here, it's intentional to avoid additional spaces in the response %>
-      <% work.infringing_urls.each do |url| %><%= content_tag_for(:li, url) do %><%= url.url %><% end %><% end %>
+      <% work.infringing_urls.each do |url| %><%= content_tag_for(:li, url) do %><%= url.url %><% end %><% end.empty? %>No infringing URLs were submitted.<% end %>
     </ol>
   </div>
 <% end %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -239,12 +239,12 @@ FactoryGirl.define do
 
   factory :infringing_url do
     url
-    url_original { url }
+    url_original { generate(:url) }
   end
 
   factory :copyrighted_url do
     url
-    url_original { url }
+    url_original { generate(:url) }
   end
 
   factory :blog_entry do

--- a/spec/serializers/copyrighted_url_serializer_spec.rb
+++ b/spec/serializers/copyrighted_url_serializer_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe InfringingUrlSerializer do
+  it 'shares only the URL field' do
+    url = build(:infringing_url)
+
+    serializer = InfringingUrlSerializer.new(url)
+    expect(serializer.as_json[:infringing_url].keys).to eq [:url]
+  end
+end

--- a/spec/serializers/infringing_url_serializer_spec.rb
+++ b/spec/serializers/infringing_url_serializer_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe CopyrightedUrlSerializer do
+  it 'shares only the URL field' do
+    url = build(:copyrighted_url)
+
+    serializer = CopyrightedUrlSerializer.new(url)
+    expect(serializer.as_json[:copyrighted_url].keys).to eq [:url]
+  end
+end

--- a/spec/serializers/notice_serializer_spec.rb
+++ b/spec/serializers/notice_serializer_spec.rb
@@ -5,14 +5,15 @@ describe NoticeSerializer do
 
   it 'includes works' do
     with_a_serialized_notice do |notice, json|
-      expect(json[:works].map { |w| w['description'] }).to eq(notice.works.map(&:description))
+      expect(json[:works].map { |w| w[:description] }).to eq(notice.works.map(&:description))
     end
   end
 
   %i|infringing_urls copyrighted_urls|.each do |url_relation|
     it "includes #{url_relation}" do
       with_a_serialized_notice do |notice, json|
-        relation_json = json[:works].first[url_relation.to_s].map{|u| u['url']}
+        $stdout.puts json
+        relation_json = json[:works].first[url_relation.to_sym].map{|u| u[:url]}
         expect(relation_json).to eq(
           notice.works.first.send(url_relation).map(&:url)
         )

--- a/spec/serializers/work_serializer_spec.rb
+++ b/spec/serializers/work_serializer_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe WorkSerializer do
+  it 'has a fallback when there are no associated urls' do
+    work = build(:work)
+    expect(work.infringing_urls).to be_empty
+    expect(work.copyrighted_urls).to be_empty
+
+    serializer = WorkSerializer.new(work)
+
+    [
+      serializer.as_json[:work][:infringing_urls][0][:url],
+      serializer.as_json[:work][:copyrighted_urls][0][:url]
+    ].each do |val|
+      expect(val).to eq 'No URL submitted'
+    end
+
+    expect(serializer.as_json[:work][:infringing_urls][0].keys).to eq [:url]
+    expect(serializer.as_json[:work][:copyrighted_urls][0].keys).to eq [:url]
+
+    expect(serializer.as_json[:work][:infringing_urls].length).to eq 1
+    expect(serializer.as_json[:work][:copyrighted_urls].length).to eq 1
+  end
+end

--- a/spec/views/notices/show.html.erb_spec.rb
+++ b/spec/views/notices/show.html.erb_spec.rb
@@ -199,6 +199,140 @@ describe 'notices/show.html.erb' do
     end
   end
 
+  it 'displays a warning about infringing urls when expected but absent' do
+    params = {
+      notice: {
+        title: 'A title',
+        type: 'DMCA',
+        subject: 'Infringement Notfication via Blogger Complaint',
+        date_sent: '2013-05-22',
+        date_received: '2013-05-23',
+        works_attributes: [
+          {
+            description: 'The Avengers',
+            copyrighted_urls_attributes: [
+              { url: 'http://example.com/test_url_1' },
+              { url: 'http://example.com/test_url_2' },
+              { url: 'http://example.com/test_url_3' }
+            ]
+          }
+        ],
+        entity_notice_roles_attributes: [
+          {
+            name: 'recipient',
+            entity_attributes: {
+              name: 'Google',
+              kind: 'organization',
+              address_line_1: '1600 Amphitheatre Parkway',
+              city: 'Mountain View',
+              state: 'CA',
+              zip: '94043',
+              country_code: 'US'
+            }
+          },
+          {
+            name: 'sender',
+            entity_attributes: {
+              name: 'Joe Lawyer',
+              kind: 'individual',
+              address_line_1: '1234 Anystreet St.',
+              city: 'Anytown',
+              state: 'CA',
+              zip: '94044',
+              country_code: 'US'
+            }
+          }
+        ]
+      }
+    }
+
+    notice = Notice.new(params[:notice])
+    notice.save
+
+    assign(:notice, notice)
+
+    render
+
+    notice.works.each do |work|
+      expect(rendered).to have_css("#work_#{work.id} .description",
+                                   text: work.description)
+
+      work.copyrighted_urls.each do |url|
+        expect(rendered).to have_css("#work_#{work.id} li.copyrighted_url",
+                                     text: url.url)
+      end
+
+      expect(rendered).to have_text 'No infringing URLs were submitted.'
+    end
+  end
+
+  it 'displays a warning about copyrighted urls when expected but absent' do
+    params = {
+      notice: {
+        title: 'A title',
+        type: 'DMCA',
+        subject: 'Infringement Notfication via Blogger Complaint',
+        date_sent: '2013-05-22',
+        date_received: '2013-05-23',
+        works_attributes: [
+          {
+            description: 'The Avengers',
+            infringing_urls_attributes: [
+              { url: 'http://example.com/test_url_1' },
+              { url: 'http://example.com/test_url_2' },
+              { url: 'http://example.com/test_url_3' }
+            ]
+          }
+        ],
+        entity_notice_roles_attributes: [
+          {
+            name: 'recipient',
+            entity_attributes: {
+              name: 'Google',
+              kind: 'organization',
+              address_line_1: '1600 Amphitheatre Parkway',
+              city: 'Mountain View',
+              state: 'CA',
+              zip: '94043',
+              country_code: 'US'
+            }
+          },
+          {
+            name: 'sender',
+            entity_attributes: {
+              name: 'Joe Lawyer',
+              kind: 'individual',
+              address_line_1: '1234 Anystreet St.',
+              city: 'Anytown',
+              state: 'CA',
+              zip: '94044',
+              country_code: 'US'
+            }
+          }
+        ]
+      }
+    }
+
+    notice = Notice.new(params[:notice])
+    notice.save
+
+    assign(:notice, notice)
+
+    render
+
+    notice.works.each do |work|
+      expect(rendered).to have_css("#work_#{work.id} .description",
+                                   text: work.description)
+
+      work.infringing_urls.each do |url|
+        expect(rendered).to have_css("#work_#{work.id} li.infringing_url",
+                                     text: url.url)
+      end
+
+      expect(rendered).to have_text 'No copyrighted URLs were submitted.'
+    end
+  end
+
   it 'displays the notice source' do
     assign(:notice, build(:dmca, source: 'Arbitrary source'))
 


### PR DESCRIPTION
## Ready for merge?
**NO**

Gotta track down the test failures on build.

#### What does this PR do?
Communicates better when works don't have associated problematic URLs. (This should have been handled via model validations a long time ago, but it wasn't, and now it's very hard to back ourselves out of that situation.)

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Disconnect all the infringing and/or copyrighted URLs from a work and then look at a page of a notice that references this work (or pull it from the API).

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/13176

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES | NO
