### PR TITLE
16359 better throttling

### DIFF
--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -45,7 +45,12 @@ class Rack::Attack
     req.ip if req.env['HTTP_ACCEPT'] == 'application/json' || req.env['CONTENT_TYPE'] == 'application/json' || req.path.include?('json')
   end
 
-  throttle('request limit', limit: 200, period: 5.minutes) do |req|
+  throttle('request limit', limit: 10, period: 1.minute) do |req|
+    Rails.logger.debug "[rack-attack] request limit ip: #{req.ip}, content_type: #{req.content_type}"
+    req.ip
+  end
+
+  throttle('request limit', limit: 30, period: 1.hour) do |req|
     Rails.logger.debug "[rack-attack] request limit ip: #{req.ip}, content_type: #{req.content_type}"
     req.ip
   end


### PR DESCRIPTION
## Ready for merge?
**NO**

Still testing out throttling policies in prod. In particular, the blacklist syntax is fiddly, and we need to talk about how much of this should be handled on the apache end.

#### What does this PR do?
prevent the server from crumbling under bot farm load

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Graphs on cordelia before and after April 2 (when I started trialing throttling policies in prod)

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/16359

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
