### PR TITLE
Make it easy to update researcher IP whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ config/elasticsearch.yml
 .rubocop.yml
 rspec_examples.txt
 .reek.yml
+whitelisted_ips.rb

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -6,6 +6,16 @@ class Rack::Attack
     ['127.0.0.1', '::1'].include? req.ip
   end
 
+  whitelist('allow from special IPs') do |req|
+    # IP addresses of known legitimate researchers who might otherwise be
+    # caught up in rate limits.
+    if defined? WhitelistedIps::IPS
+      WhitelistedIps::IPS.include? req.ip
+    else
+      false
+    end
+  end
+
   whitelist('allow unlimited requests from API users') do |req|
     token = nil
 

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -10,7 +10,7 @@ class Rack::Attack
     # IP addresses of known legitimate researchers who might otherwise be
     # caught up in rate limits.
     if defined? WhitelistedIps::IPS
-      WhitelistedIps::IPS.include? req.ip
+      WhitelistedIps::IPS.map { |iprange| iprange.include? req.ip }.any?
     else
       false
     end

--- a/config/initializers/whitelisted_ips.rb.example
+++ b/config/initializers/whitelisted_ips.rb.example
@@ -1,0 +1,7 @@
+# Copy this to whitelisted_ips.rb in this directory and fill in any IPs you
+# want to whitelist. The file whitelisted_ips.rb is gitignored to protect
+# researchers' privacy.
+module WhitelistedIps
+  IPS = [
+  ]
+end

--- a/config/initializers/whitelisted_ips.rb.example
+++ b/config/initializers/whitelisted_ips.rb.example
@@ -1,7 +1,11 @@
-# Copy this to whitelisted_ips.rb in this directory and fill in any IPs you
-# want to whitelist. The file whitelisted_ips.rb is gitignored to protect
-# researchers' privacy.
+# Copy this to whitelisted_ips.rb in this directory and fill in any IPs and
+# ranges you want to whitelist. The file whitelisted_ips.rb is gitignored to
+# protect researchers' privacy.
 module WhitelistedIps
+  individuals = [
+    # list of individual IPs to whitelist, like '127.0.0.1'
+  ]
   IPS = [
+    # list of ranges of ips to whitelist, like IPAddr.new('140.247.218.0/25')
   ]
 end


### PR DESCRIPTION
We should be able to configure the safelist without having to redeploy
code.

## Ready for merge?
**YES**

#### What does this PR do?
Lets us maintain a private list of IPs to whitelist.

#### Helpful background context (if appropriate)
Some legitimate researchers have been caught up in our DDOS prevention efforts, and we should be able to whitelist them as we get their IPs without needing to redeploy code.

#### How can a reviewer manually see the effects of these changes?
Comment out the localhost whitelist, dramatically reduce the request limit, and hammer the server. Then add your localhost IP to the list (see config/initializers/whitelisted_ips.rb.example) and lo! access for you.

#### What are the relevant tickets?
n/a
#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
