### PR TITLE
Prevent deep pagination

### DIFF
--- a/app/assets/stylesheets/layouts/_application.scss
+++ b/app/assets/stylesheets/layouts/_application.scss
@@ -48,8 +48,7 @@ section.main.app {
 }
 
 // Add inner padding to certain pages
-body.topics-show,
-body.high_voltage-pages {
+body.topics-show, .high_voltage-pages {
   .main-inner {
     padding: $base-padding;
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,6 +7,9 @@
 # - item_searcher
 # They may also define html_responder.
 class SearchController < ApplicationController
+  before_filter :prevent_impossible_pagination
+  before_filter :restrict_deep_pagination
+
   layout 'search'
 
   EACH_SERIALIZER = nil
@@ -72,5 +75,32 @@ class SearchController < ApplicationController
     @searchdata.results
                .map { |r| augment_instance(r) }
                .compact
+  end
+
+  # Elasticsearch cannot return more than 20_000 results in production (2000
+  # pages at 10 results per page).
+  def prevent_impossible_pagination
+    return if params[:page].to_i < 2000
+
+    render 'shared/_error',
+           status: :not_found,
+           locals: {
+             message: 'Lumen cannot display more than 2000 pages of results.'
+           }
+  end
+
+  # Deep pagination is expensive for the CPU, so don't let anonymous users
+  # do it.
+  def restrict_deep_pagination
+    return if (user_signed_in? || params[:page].to_i < 10)
+
+    render 'shared/_error',
+           status: :unauthorized,
+           locals: {
+             message: 'You must be logged in to see past the first 10 pages ' \
+                      'of results. ' \
+                      '<a href="https://lumendatabase.org/pages/researchers#key">Request ' \
+                      'a research account key</a>.'.html_safe
+           }
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -92,7 +92,7 @@ class SearchController < ApplicationController
   # Deep pagination is expensive for the CPU, so don't let anonymous users
   # do it.
   def restrict_deep_pagination
-    return if (user_signed_in? || params[:page].to_i < 10)
+    return if pagination_allowed?
 
     render 'shared/_error',
            status: :unauthorized,
@@ -102,5 +102,11 @@ class SearchController < ApplicationController
                       '<a href="https://lumendatabase.org/pages/researchers#key">Request ' \
                       'a research account key</a>.'.html_safe
            }
+  end
+
+  def pagination_allowed?
+    [user_signed_in?,
+     params[:page].to_i < 11,
+     request.format.json?].any?
   end
 end

--- a/app/views/shared/_error.html.erb
+++ b/app/views/shared/_error.html.erb
@@ -1,0 +1,18 @@
+<% title 'Error' %>
+
+<div class='high_voltage-pages'>
+  <section class="main-inner">
+    <% if defined? message %>
+      <p>
+        <%= message %>
+      </p>
+    <% else %>
+      <p>
+        The URL you are attempting to reach cannot be found. We apologize for the inconvenience.
+      </p>
+      <p>
+        Many older Lumen URLS (.cgi, .xml, etc) have changed.  Please explore the site starting at our <a href="/">homepage</a>.
+      </p>
+    <% end %>
+  </section>
+</div>

--- a/spec/controllers/notices/search_controller_spec.rb
+++ b/spec/controllers/notices/search_controller_spec.rb
@@ -11,4 +11,25 @@ describe Notices::SearchController do
       expect(response).to be_successful
     end
   end
+
+  scenario 'deep pagination allowed with json', search: true do
+    get :index, page: 100, term: 'batman', format: :json
+    expect(response).to have_http_status :success
+  end
+
+  scenario 'deep pagination not allowed with html', search: true do
+    get :index, page: 100, term: 'batman'
+    expect(response).to have_http_status :unauthorized
+  end
+
+  scenario 'shallow pagination allowed with html', search: true do
+    get :index, page: 10, term: 'batman'
+    expect(response).to have_http_status :success
+  end
+
+  scenario 'deep pagination allowed for signed-in users', search: true do
+    SearchController.any_instance.stub(:user_signed_in?).and_return(true)
+    get :index, page: 100, term: 'batman'
+    expect(response).to have_http_status :success
+  end
 end


### PR DESCRIPTION
## Ready for merge?
**NO**

Requires stakeholder approval; conversations in progress.

#### What does this PR do?
This prevents users from requesting search result pages past page 2000 (which just causes an elasticsearch error). It also prevents them from going too far into the search results unless they're authenticated or using the API, because it's computationally more intensive for us to serve those, and casual users are unlikely to page very far in.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Try visiting a search page with `page=10`, `page=11`, `page=11` while you are logged in, and `page=2001`.

Your localhost elasticsearch config may throw errors before page 2001, but production supports through 2000.

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
