### PR TITLE
Don't load assets gems in prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'acts-as-taggable-on'
 gem 'addressable'
 gem 'ancestry'
 gem 'bootstrap-datepicker-rails'
-gem 'bourbon'
 gem 'cancancan'
 gem 'country_select'
 gem 'coveralls', require: false
@@ -25,7 +24,6 @@ gem 'kaminari', '0.14.1'
 gem 'lograge'
 gem 'loofah', '>= 2.2.3'
 gem 'mime-types'
-gem 'neat'
 gem 'oink'
 gem 'paperclip', '~> 5'
 gem 'pg', '0.20.0'
@@ -47,13 +45,6 @@ gem 'turnout'
 gem 'elasticsearch-model'
 gem 'elasticsearch-rails'
 
-group :assets do
-  gem 'coffee-rails'
-  gem 'sass-rails'
-  gem 'therubyracer'
-  gem 'uglifier'
-end
-
 group :development do
   gem 'binding_of_caller'
   gem 'bullet'
@@ -71,6 +62,15 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'ruby-prof'
   gem 'sham_rack'
+end
+
+group :development, :test, :assets do
+  gem 'bourbon'
+  gem 'coffee-rails'
+  gem 'neat'
+  gem 'sass-rails'
+  gem 'therubyracer'
+  gem 'uglifier'
 end
 
 group :test do

--- a/doc/release.md
+++ b/doc/release.md
@@ -57,6 +57,8 @@ April 2019
 * `rake db:migrate`
   - If this throws a `PG::ConnectionBad:` and asks something like "Is the server running locally and accepting connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?", use `RAILS_ENV=production rake db:migrate`
 * `rake assets:clobber`
-* `rake assets:precompile`
+* `RAILS_ENV=development rake assets:precompile`
+  * This MUST specify the development environment, because bourbon is not loaded in production to save on memory.
+  * Prod will still be able to find the precompiled assets.
 * `rake lumen:maintenance_end`
   * This includes the `touch tmp/restart.txt` command, which tells Passenger to restart its listener.


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Stops us from loading bourbon in production. (It uses a lot of memory and we only need it for asset precompilation.)

#### Helpful background context (if appropriate)
our memory usage graphs

#### How can a reviewer manually see the effects of these changes?
`derailed bundle:mem` with this branch and with dev show memory load differences, but the real proof will be post-deploy.

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)

#### Todo:
- ~~[ ] Tests~~
- [x] Documentation (requires slightly different asset precompilation, which has been tested on the dev server)
- ~~[ ] Stakeholder approval~~

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
