### PR TITLE
Change name of Markdown parser

### DIFF
--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -44,7 +44,7 @@ module NoticesHelper
   end
 
   def first_time_visitor_content
-    Markdown.render(t('first_time_visitor'))
+    MarkdownParser.render(t('first_time_visitor'))
   end
 
   def label_for_url_input(url_type, notice)

--- a/app/models/blog_entry.rb
+++ b/app/models/blog_entry.rb
@@ -52,11 +52,11 @@ class BlogEntry < ActiveRecord::Base
   end
 
   def content_html
-    Markdown.render(content.to_s)
+    MarkdownParser.render(content.to_s)
   end
 
   def abstract_html
-    Markdown.render(abstract.to_s)
+    MarkdownParser.render(abstract.to_s)
   end
 
   # https://github.com/sferik/rails_admin/wiki/Enumeration

--- a/app/models/relevant_question.rb
+++ b/app/models/relevant_question.rb
@@ -5,7 +5,7 @@ class RelevantQuestion < ActiveRecord::Base
   include ValidatesAutomatically
 
   def answer_html
-    Markdown.render(answer.to_s)
+    MarkdownParser.render(answer.to_s)
   end
 
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -24,7 +24,7 @@ class Topic < ActiveRecord::Base
   after_update { TopicIndexQueuer.for(self.id) }
 
   def description_html
-    Markdown.render(description.to_s)
+    MarkdownParser.render(description.to_s)
   end
 
 end

--- a/config/initializers/markdown.rb
+++ b/config/initializers/markdown.rb
@@ -5,4 +5,6 @@ extensions = {
   disable_indented_code_blocks: true
 }
 
-Markdown = Redcarpet::Markdown.new(renderer, extensions)
+# Don't call this Markdown or you'll get loud, frequent warnings about its
+# collision with the Markdown constant previously defined inside Redcarpet.
+MarkdownParser = Redcarpet::Markdown.new(renderer, extensions)

--- a/spec/renders_markdown_spec.rb
+++ b/spec/renders_markdown_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Markdown do
+describe MarkdownParser do
   it "renders markdown to html" do
-    html = Markdown.render("some *nice* markdown")
+    html = MarkdownParser.render("some *nice* markdown")
 
     expect(html).to eq "<p>some <em>nice</em> markdown</p>\n"
   end
@@ -10,7 +10,7 @@ describe Markdown do
   it "reuses the same RedCarpet::Markdown instance" do
     expect(Redcarpet::Markdown).not_to receive(:new)
 
-    Markdown.render("markdown")
-    Markdown.render("markdown")
+    MarkdownParser.render("markdown")
+    MarkdownParser.render("markdown")
   end
 end


### PR DESCRIPTION
There is also a Markdown constant defined within Redcarpet. They
clash; there can only be one. This results in continual irritated emails
from the server. Let's not.

## Ready for merge?
**YES**

#### What does this PR do?
A few sentences describing the overall goals of the pull request's commits.
Why are we making these changes? Is there more work to be done to fully
achieve these goals?

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/*X*

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
YES | NO

#### Includes new or updated dependencies?
YES | NO
