### PR TITLE
16485 index slow queries

### DIFF
--- a/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
+++ b/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
@@ -1,0 +1,43 @@
+:ruby
+  related_id = params[:associations] && params[:associations][field.name.to_s]
+  config = field.associated_model_config
+  source_abstract_model = RailsAdmin.config(form.object.class).abstract_model
+
+  if form.object.new_record? && related_id.present? && related_id != 'new'
+    selected = [config.abstract_model.get(related_id)]
+  else
+    selected = form.object.send(field.name)
+  end
+  selected_ids = selected.map{|s| s.send(field.associated_primary_key)}
+
+  current_action = params[:action].in?(['create', 'new']) ? 'create' : 'update'
+
+  xhr = true
+
+  collection = selected.map { |o| [o.send(field.associated_object_label_method), o.send(field.associated_primary_key)] }
+
+  js_data = {
+    xhr: xhr,
+    :'edit-url' => (authorized?(:edit, config.abstract_model) ? edit_path(model_name: config.abstract_model.to_param, id: '__ID__') : ''),
+    remote_source: index_path(config.abstract_model, source_object_id: form.object.id, source_abstract_model: source_abstract_model.to_param, associated_collection: field.name, current_action: current_action, compact: true),
+    sortable: !!field.orderable,
+    removable: !!field.removable,
+    cacheAll: !xhr,
+    regional: {
+      chooseAll: t("admin.misc.chose_all"),
+      chosen: t("admin.misc.chosen", name: config.label_plural),
+      clearAll: t("admin.misc.clear_all"),
+      search: t("admin.misc.search"),
+      up: t("admin.misc.up"),
+      down: t("admin.misc.down")
+    }
+  }
+
+%input{name: form.dom_name(field), type: "hidden", value: ""}
+
+- selected_ids = (hdv = field.form_default_value).nil? ? selected_ids : hdv
+= form.select field.method_name, collection, { selected: selected_ids, object: form.object }, field.html_attributes.reverse_merge({data: { filteringmultiselect: true, options: js_data.to_json }, multiple: true})
+- if authorized?(:new, config.abstract_model) && field.inline_add
+  - path_hash = { model_name: config.abstract_model.to_param, modal: true }
+  - path_hash.merge!({ associations: { field.inverse_of => (form.object.persisted? ? form.object.id : 'new') } }) if field.inverse_of
+  = link_to "<i class=\"icon-plus icon-white\"></i> ".html_safe + wording_for(:link, :new, config.abstract_model), '#', data: { link: new_path(path_hash) }, class: "create btn btn-info", style: 'margin-left:10px'

--- a/db/migrate/20190503161701_add_indices_to_notice.rb
+++ b/db/migrate/20190503161701_add_indices_to_notice.rb
@@ -1,0 +1,6 @@
+class AddIndicesToNotice < ActiveRecord::Migration
+  def change
+    add_index :notices, :updated_at
+    add_index :notices, :published
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190221190850) do
+ActiveRecord::Schema.define(version: 20190503161701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "ar_internal_metadata", primary_key: "key", force: :cascade do |t|
+    t.string   "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "blog_entries", force: :cascade do |t|
     t.integer  "user_id"
@@ -177,9 +183,11 @@ ActiveRecord::Schema.define(version: 20190221190850) do
 
   add_index "notices", ["created_at"], name: "index_notices_on_created_at", using: :btree
   add_index "notices", ["original_notice_id"], name: "index_notices_on_original_notice_id", using: :btree
+  add_index "notices", ["published"], name: "index_notices_on_published", using: :btree
   add_index "notices", ["reviewer_id"], name: "index_notices_on_reviewer_id", using: :btree
   add_index "notices", ["submission_id"], name: "index_notices_on_submission_id", using: :btree
   add_index "notices", ["type"], name: "index_notices_on_type", using: :btree
+  add_index "notices", ["updated_at"], name: "index_notices_on_updated_at", using: :btree
 
   create_table "notices_relevant_questions", force: :cascade do |t|
     t.integer "notice_id"
@@ -273,8 +281,15 @@ ActiveRecord::Schema.define(version: 20190221190850) do
     t.datetime "created_at"
   end
 
+  add_index "taggings", ["context"], name: "index_taggings_on_context", using: :btree
   add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+  add_index "taggings", ["tag_id"], name: "index_taggings_on_tag_id", using: :btree
   add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy", using: :btree
+  add_index "taggings", ["taggable_id"], name: "index_taggings_on_taggable_id", using: :btree
+  add_index "taggings", ["taggable_type"], name: "index_taggings_on_taggable_type", using: :btree
+  add_index "taggings", ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type", using: :btree
+  add_index "taggings", ["tagger_id"], name: "index_taggings_on_tagger_id", using: :btree
 
   create_table "tags", force: :cascade do |t|
     t.string  "name"


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Speeds things up in two ways (title of the PR notwithstanding) --

One, by indexing some columns on Notice that we need to be indexed, according to our postgres slow query logs.

Two, by finding a place that railsadmin regularly performs ~70 second postgres queries (`SELECT COUNT(*) FROM "works"`) and just...not doing those.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Post-deployment, `/admin/notice/X/edit` should be hella faster. I'm not sure where the queries against Notice were being run so I'm not sure how to see the effect of these indexes.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/16485
- https://cyber.harvard.edu/projectmanagement/issues/16422

#### Screenshots (if appropriate)

#### Todo:
- ~~[ ] Tests~~
- ~~[ ] Documentation~~
- [x] Stakeholder approval (discussed the migrations with @jsdiaz )

#### Requires Database Migrations?
YES

#### Includes new or updated dependencies?
NO
