### PR TITLE
16481 profile memory in prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development do
   gem 'bullet'
   gem 'derailed'
   gem 'foreman'
+  gem 'memory_profiler'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development do
   gem 'derailed'
   gem 'foreman'
   gem 'memory_profiler'
+  gem 'rack-mini-profiler'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'paperclip', '~> 5'
 gem 'pg', '0.20.0'
 gem 'rack', '>= 1.6.11'
 gem 'rack-attack'
+gem 'rack-mini-profiler', '~> 0.9.9'
 gem 'rails', '~> 4.2.11'
 gem 'rails_admin'
 gem 'rails_admin_tag_list'
@@ -51,7 +52,6 @@ group :development do
   gem 'derailed'
   gem 'foreman'
   gem 'memory_profiler'
-  gem 'rack-mini-profiler'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,8 +202,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    memoizable (0.4.2)
-      thread_safe (~> 0.3, >= 0.3.1)
     memory_profiler (0.9.13)
     metaclass (0.0.1)
     method_source (0.8.2)
@@ -256,7 +254,7 @@ GEM
       rack (>= 0.4)
     rack-attack (4.3.0)
       rack
-    rack-mini-profiler (1.0.2)
+    rack-mini-profiler (0.9.9.2)
       rack (>= 1.2.0)
     rack-pjax (1.0.0)
       nokogiri (~> 1.5)
@@ -462,7 +460,6 @@ DEPENDENCIES
   loofah (>= 2.2.3)
   memory_profiler
   mime-types
-  minitest
   neat
   oink
   paperclip (~> 5)
@@ -474,7 +471,7 @@ DEPENDENCIES
   pry-rails
   rack (>= 1.6.11)
   rack-attack
-  rack-mini-profiler
+  rack-mini-profiler (~> 0.9.9)
   rack-test
   rails (~> 4.2.11)
   rails_admin

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,8 @@ GEM
       rack (>= 0.4)
     rack-attack (4.3.0)
       rack
+    rack-mini-profiler (1.0.2)
+      rack (>= 1.2.0)
     rack-pjax (1.0.0)
       nokogiri (~> 1.5)
       rack (>= 1.1)
@@ -472,6 +474,7 @@ DEPENDENCIES
   pry-rails
   rack (>= 1.6.11)
   rack-attack
+  rack-mini-profiler
   rack-test
   rails (~> 4.2.11)
   rails_admin

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,8 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
     memory_profiler (0.9.13)
     metaclass (0.0.1)
     method_source (0.8.2)
@@ -456,7 +458,9 @@ DEPENDENCIES
   launchy
   lograge
   loofah (>= 2.2.3)
+  memory_profiler
   mime-types
+  minitest
   neat
   oink
   paperclip (~> 5)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,6 @@
 class ApplicationController < ActionController::Base
   layout :layout_by_resource
 
-  # This causes the sign out link to not be displayed -- somehow user_signed_in?
-  # no longer fires correctly. wat.
   before_filter :authenticate_user_from_token!
   before_filter :set_profiler_auth
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,21 +1,19 @@
-<% cache '_footer' do %>
-  <footer class="main">
-    <div class="inner-wrapper">
-      <span><%= image_tag 'Cc.logo.circle.svg', height: '16', style: 'vertical-align: middle;' %> 2017 Lumen</span>
-      <nav>
-  	<%= link_to "License", page_path("license") %>
-      <%= link_to "Privacy", page_path("privacy") %>
-      <%= link_to "Legal", page_path("legal") %>
-      <%= link_to "Researchers", page_path("researchers") %>
-      <% if user_signed_in? %>
-        <% if current_user.role?(Role.admin) %>
-          <%= link_to "Admin", rails_admin_path %>
-        <% end %>
-        <%= link_to "Sign Out", destroy_user_session_path %>
-      <% else %>
-        <%= link_to "Sign In", new_user_session_path %>
+<footer class="main">
+  <div class="inner-wrapper">
+    <span><%= image_tag 'Cc.logo.circle.svg', height: '16', style: 'vertical-align: middle;' %> 2017 Lumen</span>
+    <nav>
+	<%= link_to "License", page_path("license") %>
+    <%= link_to "Privacy", page_path("privacy") %>
+    <%= link_to "Legal", page_path("legal") %>
+    <%= link_to "Researchers", page_path("researchers") %>
+    <% if user_signed_in? %>
+      <% if can? :access, :rails_admin %>
+        <%= link_to "Admin", rails_admin_path %>
       <% end %>
-      </nav>
-    </div>
-  </footer>
-<% end %>
+      <%= link_to "Sign Out", destroy_user_session_path %>
+    <% else %>
+      <%= link_to "Sign In", new_user_session_path %>
+    <% end %>
+    </nav>
+  </div>
+</footer>

--- a/config/initializers/rack-mini-profiler.rb
+++ b/config/initializers/rack-mini-profiler.rb
@@ -1,0 +1,2 @@
+Rack::MiniProfiler.config.authorization_mode = :whitelist if Rails.env.production?
+Rack::MiniProfiler.config.disable_caching = false

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -669,7 +669,7 @@ where works.id in (
     # configuration.)
     cmd = "cd #{__dir__}/../../tmp/cache && " \
           "touch #{__dir__}/../../log/safer_cache_clear.log &&" \
-          "find . -type f -amin +60` -delete 2>> #{__dir__}/../../log/safer_cache_clear.log && " \
+          "find . -type f -amin +60 -delete 2>> #{__dir__}/../../log/safer_cache_clear.log && " \
           "find . -type d -empty -delete 2>> #{__dir__}/../../log/safer_cache_clear.log"
     system(cmd)
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,8 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = 'rspec_examples.txt'
 end
 
+RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     # Choose a test framework:

--- a/spec/views/shared/_footer.html.erb_spec.rb
+++ b/spec/views/shared/_footer.html.erb_spec.rb
@@ -5,10 +5,8 @@ describe 'shared/_footer.html.erb' do
 
   context 'signed in' do
     it 'gives a link to the admin for admin users' do
-      allow(controller).to receive_messages(user_signed_in?: true)
-      allow(controller.current_user).to receive(:role?)
-        .with(Role.admin)
-        .and_return(true)
+      allow(view).to receive(:user_signed_in?) { true }
+      allow(view).to receive(:can?).with(:access, :rails_admin) { true }
 
       render
 
@@ -16,10 +14,8 @@ describe 'shared/_footer.html.erb' do
     end
 
     it 'does not give a link to the admin for non-admin users' do
-      allow(controller).to receive_messages(user_signed_in?: true)
-      allow(controller.current_user).to receive(:role?)
-        .with(Role.admin)
-        .and_return(false)
+      allow(view).to receive(:user_signed_in?) { true }
+      allow(view).to receive(:can?).with(:access, :rails_admin) { false }
 
       render
 
@@ -27,11 +23,11 @@ describe 'shared/_footer.html.erb' do
     end
 
     it 'gives a link to sign out' do
-      allow(controller).to receive_messages(user_signed_in?: true)
+      allow(view).to receive(:user_signed_in?) { true }
 
       # It doesn't matter what we return here, but we do need to define the
       # behavior or the spec will fail when the template tries to call
-      # current_user.has_role?
+      # current_user.role? .
       allow(controller.current_user).to receive(:role?)
         .with(Role.admin)
         .and_return(false)
@@ -53,6 +49,7 @@ describe 'shared/_footer.html.erb' do
 
   context 'signed out' do
     it 'gives a link to sign in' do
+      allow(view).to receive(:user_signed_in?) { false }
       render
 
       expect(rendered).to have_css('a', text: 'Sign In')


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Adds rack-mini-profiler to all dev environments. Makes it visible in prod to super_admins. This will allow us to get much more detail on memory consumption in production, e.g. for fixing memory use problems in rails_admin. Because our elasticsearch and database situtions are so different in prod than in dev, there are certain things we can't metrize anywhere else.

#### Helpful background context (if appropriate)
omg the admin is so slow

#### How can a reviewer manually see the effects of these changes?
Fire up `rails s` in dev and check out the cute little badge in the upper left. Click on it for all kinds of good data! Then try `RAILS_ENV=production rails s`; the badge will go away unless you're logged in as super_admin.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/16481

#### Screenshots (if appropriate)

#### Todo:
- ~~[ ] Tests~~
- ~~[ ] Documentation~~
- ~~[ ] Stakeholder approval~~

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES
