### PR TITLE
Add cron job to aid user in his research

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ config/database.yml
 rspec_examples.txt
 .reek.yml
 whitelisted_ips.rb
+free_as_in_kittens/

--- a/doc/release.md
+++ b/doc/release.md
@@ -7,6 +7,7 @@ If any deploys have special instructions, write them here, with a date and PR nu
 
 April 2019
 - remove Twitter env variables
+- Add cron job to run `lumen:generate_court_order_report` once per week
 
 ## Hotfix
 * Write code, code-review, and merge into `dev` via the normal process.

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -695,7 +695,7 @@ where works.id in (
     files.each do |f|
       # The first two params ensure the filename is useful; the third ensures
       # it is unique.
-      name = "#{f.notice_id}_#{f.file_file_name}_#{f.id}"
+      name = "#{f.notice_id}_#{f.id}_#{f.file_file_name}"
       File.write(File.join(working_dir, name), f.file)
     end
 

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -701,8 +701,8 @@ where works.id in (
 
     # Make archive.
     filename = Date.today.iso8601
-    system("tar -czvf #{File.join(dir, filename)}.tar.gz #{working_dir}")
-    Dir.rmdir(working_dir)
+    system("tar -czvf #{File.join(dir, filename)}.tar.gz -C #{working_dir} .")
+    system("rm -r #{working_dir}")
 
     # Write HTML page allowing file access.
     html = <<-HEREDOC

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -696,7 +696,7 @@ where works.id in (
       # The first two params ensure the filename is useful; the third ensures
       # it is unique.
       name = "#{f.notice_id}_#{f.id}_#{f.file_file_name}"
-      File.write(File.join(working_dir, name), f.file)
+      system("cp #{f.file.path} #{File.join(working_dir, name)}")
     end
 
     # Make archive.


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Adds a cron job to fetch all recent file attachments of a certain type, to make it easier for one of our major users to do his research.

#### Helpful background context (if appropriate)
We ❤️ our researchers.

#### How can a reviewer manually see the effects of these changes?
If you run the cron job, you'll end up with a `tar.gz` file and an `index.html` in `public/free_as_in_kittens`. You can then go to `/free_as_in_kittens/index.html` in your browser and download the file. Good times.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/14122

#### Screenshots (if appropriate)

#### Todo:
- ~~[ ] Tests~~
- [x] Documentation -- I've written this into the ticket for private transmission to our user, since it's an essentially private API.
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
