### PR TITLE
Give documentation link in response for missing auth token

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -17,7 +17,11 @@ class NoticesController < ApplicationController
   def create
     respond_to do |format|
       format.json do
-        return unless authorized_to_create?
+        unless authorized_to_create?
+          self.status = :unauthorized
+          self.response_body = { documentation_link: Rails.configuration.x.api_documentation_link }.to_json
+          return
+        end
         create_respond_json
       end
 
@@ -176,7 +180,6 @@ class NoticesController < ApplicationController
 
   def authorized_to_create?
     if cannot?(:submit, Notice)
-      head :unauthorized
       false
     else
       true

--- a/config/application.rb
+++ b/config/application.rb
@@ -94,7 +94,8 @@ module Chill
       timestamp = datetime.strftime '%Y-%m-%d %H:%M:%S (%Z)'
       "#{timestamp} #{severity}: #{progname} #{msg}\n"
     end
-
+    # Configuration settings
+    config.x.api_documentation_link = "https://github.com/berkmancenter/lumendatabase/wiki/Lumen-API-Documentation"
     # Mailer settings
     config.default_sender = ENV['DEFAULT_SENDER'] || 'no-reply@example.com'
     config.return_path = ENV['RETURN_PATH'] || 'user@example.com'

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -343,10 +343,11 @@ describe NoticesController do
       it 'returns unauthorized if one cannot submit' do
         stub_submit_notice
         @ability.cannot(:submit, Notice)
-
+        response_body = { documentation_link: Rails.configuration.x.api_documentation_link }.to_json
         post_create :json
 
         expect(response.status).to eq 401
+        expect(response.body).to eq response_body 
       end
 
       it 'returns a proper Location header when saved successfully' do


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
If in the API call to add a notice the authentication_token is missing, then an empty response is returned. After merger of this PR link of the API documentation would be given in response


#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/14395


#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO 
