### PR TITLE
16533 augment instance perf

### DIFF
--- a/app/models/counternotice.rb
+++ b/app/models/counternotice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Counternotice < Notice
   define_elasticsearch_mapping
 

--- a/app/models/court_order.rb
+++ b/app/models/court_order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CourtOrder < Notice
   DEFAULT_ENTITY_NOTICE_ROLES = (BASE_ENTITY_NOTICE_ROLES |
                                 %w[recipient sender principal issuing_court

--- a/app/models/data_protection.rb
+++ b/app/models/data_protection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DataProtection < Notice
   DEFAULT_ENTITY_NOTICE_ROLES = (BASE_ENTITY_NOTICE_ROLES |
                                  %w[recipient]).freeze

--- a/app/models/date_range_filter.rb
+++ b/app/models/date_range_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DateRangeFilter
 
   attr_reader :title, :parameter

--- a/app/models/defamation.rb
+++ b/app/models/defamation.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class Defamation < Notice
-  MASK = 'REDACTED'.freeze
+  MASK = 'REDACTED'
   REDACTION_REGEX = /google/i
 
   define_elasticsearch_mapping(works: [:description])

--- a/app/models/dmca.rb
+++ b/app/models/dmca.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DMCA < Notice
   define_elasticsearch_mapping
 

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'validates_automatically'
 require 'hierarchical_relationships'
 require 'entity_index_queuer'

--- a/app/models/entity_notice_role.rb
+++ b/app/models/entity_notice_role.rb
@@ -4,7 +4,7 @@ class EntityNoticeRole < ActiveRecord::Base
   include ValidatesAutomatically
 
   validates :name, length: { maximum: 255 }
-  
+
   belongs_to :entity
   belongs_to :notice, touch: true
 
@@ -21,7 +21,7 @@ class EntityNoticeRole < ActiveRecord::Base
     issuing_court
     plaintiff
     defendant
-  )
+  ).freeze
 
   accepts_nested_attributes_for :entity
 

--- a/app/models/file_upload.rb
+++ b/app/models/file_upload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'validates_automatically'
 
 class FileUpload < ActiveRecord::Base

--- a/app/models/government_request.rb
+++ b/app/models/government_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class GovernmentRequest < Notice
   DEFAULT_ENTITY_NOTICE_ROLES = (BASE_ENTITY_NOTICE_ROLES |
                                 %w[recipient sender principal submitter]).freeze

--- a/app/models/law_enforcement_request.rb
+++ b/app/models/law_enforcement_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LawEnforcementRequest < Notice
   DEFAULT_ENTITY_NOTICE_ROLES = (BASE_ENTITY_NOTICE_ROLES |
                                 %w[recipient sender principal]).freeze

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'language'
 require 'recent_scope'
 require 'validates_automatically'

--- a/app/models/other.rb
+++ b/app/models/other.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class Other < Notice
-  MASK = 'REDACTED'.freeze
+  MASK = 'REDACTED'
   REDACTION_REGEX = /google/i
 
   define_elasticsearch_mapping(works: [:description])

--- a/app/models/private_information.rb
+++ b/app/models/private_information.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PrivateInformation < Notice
   define_elasticsearch_mapping
 

--- a/app/models/searchability.rb
+++ b/app/models/searchability.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Searchability
   def self.included(base)
     base.extend ClassMethods

--- a/app/models/searches_models.rb
+++ b/app/models/searches_models.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SearchesModels
   attr_accessor :sort_by
   attr_reader :instances, :page

--- a/app/models/searches_models.rb
+++ b/app/models/searches_models.rb
@@ -177,7 +177,7 @@ class SearchesModels
   end
 
   def search_definition
-    @search_definition ||= {}
+    @search_definition ||= {'_source': ['score', 'id']}
   end
 
   def setup_aggregations

--- a/app/models/searches_models.rb
+++ b/app/models/searches_models.rb
@@ -177,7 +177,7 @@ class SearchesModels
   end
 
   def search_definition
-    @search_definition ||= {'_source': ['score', 'id']}
+    @search_definition ||= {'_source': ['score', 'id', 'title']}
   end
 
   def setup_aggregations

--- a/app/models/term_filter.rb
+++ b/app/models/term_filter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TermFilter
 
   attr_reader :title, :parameter

--- a/app/models/term_search.rb
+++ b/app/models/term_search.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TermSearch
 
   attr_reader :parameter, :title, :field

--- a/app/models/trademark.rb
+++ b/app/models/trademark.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Trademark < Notice
   define_elasticsearch_mapping
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'validates_automatically'
 
 class Work < ActiveRecord::Base

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -8,10 +8,9 @@
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics</a>
         <div id="dropdown-topics" class="dropdown-menu" role="menu">
           <ol>
-            <% topic_roots.each do |root| %>
-              <% cache(root) do %>
-                <%= render "shared/topic_dropdown", topic: root %>
-              <% end %>
+            <% cache('dropdown-topics') do %>
+              <%= render partial: 'shared/topic_dropdown', collection: topic_roots,
+                  as: :topic %>
             <% end %>
           </ol>
         </div>


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Improves performance of search page.

#### Helpful background context (if appropriate)
Notice search is one of our most popular pages, and also one of our slowest. Skylight logs show that we're spending a lot of time fetching data from elasticsearch and/or the database. Looking at the code, `augment_instance` was hitting the db once for every search result, rather than fetching all the results from the db in one go. In addition, elasticsearch is pulling in complete records, when in fact we only use a handful of its data. This PR fixes those, and also applies a few other performance improvements noticed along the way.

#### How can a reviewer manually see the effects of these changes?

In `rails c`, run something like
```
search_url = '/notices/search?term=batman&sort_by='
puts Benchmark.measure {
  30.times do { app.get search_url }
}
```
Compare this branch and the dev branch. For me, on a 5000-item database, the difference was:

On this branch:
```
14.340000   3.440000  17.880000 ( 20.313391)
```
(That's user, system, user + system, and wall clock time.)

On dev:
```
15.730000   3.490000  19.320000 ( 23.936961)
```
I expect the discrepancy will grow with larger databases, and when datasets have bigger records (e.g. notices with thousands of attached URLs).

You can also use the rack-mini-profiler badge to check out the time to execute the index action.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/16533

#### Screenshots (if appropriate)

#### Todo:
- ~~[ ] Tests~~ (no new tests needed as functionality should not change)
- ~~[ ] Documentation~~ (not required)
- ~~[ ] Stakeholder approval~~ (not required)

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
