### PR TITLE
Use monkeypatched recaptcha gem for debugging purposes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,10 @@ gem 'rack-mini-profiler', '~> 0.9.9'
 gem 'rails', '~> 4.2.11'
 gem 'rails_admin'
 gem 'rails_admin_tag_list'
-gem 'recaptcha'
+# Monkeypatched temporarily for debugging purposes
+gem 'recaptcha',
+    git: 'https://github.com/berkmancenter/recaptcha',
+    branch: 'v4.14.0_plus_logging'
 gem 'recipient_interceptor', require: false
 gem 'redcarpet'
 gem 'select2-rails', '~> 4.0', '>= 4.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/berkmancenter/recaptcha
+  revision: f754c052b428a6ec5c6bb07239b6b0b69a8dc69e
+  branch: v4.14.0_plus_logging
+  specs:
+    recaptcha (4.14.0)
+      json
+
+GIT
   remote: https://github.com/sporkrb/spork-rails
   revision: 0dd45e59d3237b4c8f9efc215b46d9c07072a95e
   specs:
@@ -304,8 +312,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    recaptcha (4.14.0)
-      json
     recipient_interceptor (0.1.1)
       mail
     redcarpet (3.4.0)
@@ -476,7 +482,7 @@ DEPENDENCIES
   rails (~> 4.2.11)
   rails_admin
   rails_admin_tag_list
-  recaptcha
+  recaptcha!
   recipient_interceptor
   redcarpet
   rspec-collection_matchers (~> 1.1, >= 1.1.2)


### PR DESCRIPTION
## Ready for merge?
YES

#### What does this PR do?
The recaptcha gem doesn't expose responses from the recaptcha server, let's fix that. The forked and fixed gem is here https://github.com/berkmancenter/recaptcha.
We also need to set the `LOG_RECAPTCHA_RESPONSES` env variable to `true` to explicitly tell it to log.

#### What are the relevant tickets?
https://cyber.harvard.edu/projectmanagement/issues/16537

#### Todo:
~~- [ ] Tests~~
~~- [ ] Documentation~~
~~- [ ] Stakeholder approval~~

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES
