### PR TITLE
16537 fix full notice request validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,9 +34,7 @@ gem 'rails', '~> 4.2.11'
 gem 'rails_admin'
 gem 'rails_admin_tag_list'
 # Monkeypatched temporarily for debugging purposes
-gem 'recaptcha',
-    git: 'https://github.com/berkmancenter/recaptcha',
-    branch: 'v4.14.0_plus_logging'
+gem 'recaptcha'
 gem 'recipient_interceptor', require: false
 gem 'redcarpet'
 gem 'select2-rails', '~> 4.0', '>= 4.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/berkmancenter/recaptcha
-  revision: f754c052b428a6ec5c6bb07239b6b0b69a8dc69e
-  branch: v4.14.0_plus_logging
-  specs:
-    recaptcha (4.14.0)
-      json
-
-GIT
   remote: https://github.com/sporkrb/spork-rails
   revision: 0dd45e59d3237b4c8f9efc215b46d9c07072a95e
   specs:
@@ -312,6 +304,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    recaptcha (4.14.0)
+      json
     recipient_interceptor (0.1.1)
       mail
     redcarpet (3.4.0)
@@ -482,7 +476,7 @@ DEPENDENCIES
   rails (~> 4.2.11)
   rails_admin
   rails_admin_tag_list
-  recaptcha!
+  recaptcha
   recipient_interceptor
   redcarpet
   rspec-collection_matchers (~> 1.1, >= 1.1.2)

--- a/app/controllers/token_urls_controller.rb
+++ b/app/controllers/token_urls_controller.rb
@@ -11,6 +11,7 @@ class TokenUrlsController < ApplicationController
     token_url_params[:email].gsub!(/(\+.*?)(?=@)/, '')
     @token_url = TokenUrl.new(token_url_params)
     @notice = Notice.where(id: token_url_params[:notice_id]).first
+    valid_to_submit = validate
 
     if valid_to_submit[:status]
       @token_url[:expiration_date] = Time.now + 24.hours
@@ -95,7 +96,7 @@ class TokenUrlsController < ApplicationController
     )
   end
 
-  def valid_to_submit
+  def validate
     if @notice.nil?
       return {
         status: false,

--- a/spec/controllers/token_urls_controller_spec.rb
+++ b/spec/controllers/token_urls_controller_spec.rb
@@ -94,5 +94,25 @@ describe TokenUrlsController do
 
       expect(TokenUrl.last.documents_notification).to eq(true)
     end
+
+    it 'won\'t call the validate method twice' do
+      allow(controller).to receive(:verify_recaptcha).and_return(true)
+      allow(controller).to receive(:validate).and_return(
+        status: false,
+        why: 'Captcha verification failed, please try again.'
+      )
+      expect(controller).to receive(:validate).once
+
+      notice = create(:dmca)
+
+      params = {
+        token_url: {
+          email: 'user@example.com',
+          notice_id: notice.id
+        }
+      }
+
+      post :create, params
+    end
   end
 end


### PR DESCRIPTION
## Ready for merge?
YES

#### What does this PR do?
Fixes an issue with the full notice request view captcha being validated twice unintentionally.

#### What are the relevant tickets?
https://cyber.harvard.edu/projectmanagement/issues/16537

#### Todo:
- [x] Tests
~~- [ ] Documentation~~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES
