### PR TITLE
Config change to start elasticsearch only for required tests

### DIFF
--- a/spec/controllers/original_notice_ids_controller_spec.rb
+++ b/spec/controllers/original_notice_ids_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe OriginalNoticeIdsController do
+describe OriginalNoticeIdsController, elasticsearch: true do
   it_behaves_like "a redirecting controller for",
     Notice, :dmca, :find_by_original_notice_id
 end

--- a/spec/integration/api_notice_search_spec.rb
+++ b/spec/integration/api_notice_search_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "Searching for Notices via the API" do
+feature "Searching for Notices via the API", elasticsearch: true do
   include CurbHelpers
   include SearchHelpers
 

--- a/spec/integration/faceted_notice_search_spec.rb
+++ b/spec/integration/faceted_notice_search_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Faceted search of Notices', search: true do
+feature 'Faceted search of Notices', elasticsearch: true do
   include SearchHelpers
 
   context 'filtering with a full-text search term' do

--- a/spec/integration/fielded_notice_search_spec.rb
+++ b/spec/integration/fielded_notice_search_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Fielded searches of Notices' do
+feature 'Fielded searches of Notices', elasticsearch: true do
   include SearchHelpers
 
   ADVANCED_SEARCH_FIELDS = Notice::SEARCHABLE_FIELDS.reject do |field|

--- a/spec/integration/generate_permanent_token_url_spec.rb
+++ b/spec/integration/generate_permanent_token_url_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'permanent token url generation' do
+feature 'permanent token url generation', elasticsearch: true do
   let(:notice) { create(:dmca) }
 
   scenario 'user with access can see the generation link and can generate successfully', js: true do

--- a/spec/integration/page_titles_spec.rb
+++ b/spec/integration/page_titles_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Page titles' do
+feature 'Page titles', elasticsearch: true do
   scenario "Home" do
     visit '/'
 

--- a/spec/integration/reading_the_blog_spec.rb
+++ b/spec/integration/reading_the_blog_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "The Blog" do
+feature "The Blog", elasticsearch: true do
   scenario "A user reads a blog entry" do
     blog_entry = create(:blog_entry, :published, :with_content)
 

--- a/spec/integration/submit_notice_via_api_spec.rb
+++ b/spec/integration/submit_notice_via_api_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'base64'
 
-feature 'notice submission' do
+feature 'notice submission', elasticsearch: true do
   include CurbHelpers
 
   scenario 'submitting as an unauthenticated user', js: true do

--- a/spec/integration/viewing_topics_spec.rb
+++ b/spec/integration/viewing_topics_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Topics' do
+feature 'Topics', elasticsearch: true do
   include SearchHelpers
 
   before :each do

--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -19,11 +19,8 @@ RSpec.configure do |config|
   # port 9250 so as not to interfere with development/production clusters.
   # This may throw a warning that the cluster is already running, but you can
   # ignore that.
-  config.before :suite do
-    if Elasticsearch::Extensions::Test::Cluster.running?(on: es_port)
-      Elasticsearch::Extensions::Test::Cluster.stop(**es_options)
-    end
-    Elasticsearch::Extensions::Test::Cluster.start(**es_options)
+  config.before :all, elasticsearch: true do
+    Elasticsearch::Extensions::Test::Cluster.start(**es_options) unless Elasticsearch::Extensions::Test::Cluster.running?(on: es_port)
   end
 
   # Reload connections periodically to avoid test failures due to exhausting

--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -27,7 +27,7 @@ RSpec.configure do |config|
   # the connection pool. (This may be a multithreading issue, with Capybara
   # and webrick running in different threads; in theory the connection pool
   # handling should be threadsafe but in practice maybe it isn't.)
-  config.before :all, type: :integration do
+  config.before :all, type: :integration, elasticsearch: true do
     searchable_models.each do |model|
       begin
         model.__elasticsearch__.client.transport.reload_connections!
@@ -42,7 +42,7 @@ RSpec.configure do |config|
   # prior tests, which will be reindexed when you refresh the index.
   # The rescue blocks suppress noisy but irrelevant error messages.
   %i[feature controller view].each do |type|
-    config.before :each, type: type do
+    config.before :each, type: type, elasticsearch: true do
       searchable_models.each do |model|
         begin
           model.__elasticsearch__.client.delete_by_query(
@@ -60,7 +60,9 @@ RSpec.configure do |config|
 
   # Stop elasticsearch cluster after test run
   config.after :suite do
-    Elasticsearch::Extensions::Test::Cluster.stop(**es_options)
+    if Elasticsearch::Extensions::Test::Cluster.running?(on: es_port)
+      Elasticsearch::Extensions::Test::Cluster.stop(**es_options)
+    end
   end
 end
 

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'home/index.html.erb' do
+describe 'home/index.html.erb', elasticsearch: true do
   let(:notices) { build_stubbed_list(:dmca, 3, date_received: 1.hour.ago) }
   let(:blog_entries) { build_stubbed_list(:blog_entry, 3) }
 

--- a/spec/views/rails_admin/application/redact_queue.html.erb_spec.rb
+++ b/spec/views/rails_admin/application/redact_queue.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'rails_admin/application/redact_queue.html.erb' do
+describe 'rails_admin/application/redact_queue.html.erb', elasticsearch: true do
   before do
     # in the view spec context, the default url for the form_tag is not
     # a valid route for some reason. there's no testable behavior there

--- a/spec/views/topics/show.html.erb_spec.rb
+++ b/spec/views/topics/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'topics/show.html.erb' do
+describe 'topics/show.html.erb', elasticsearch: true do
   it "shows the topic's name" do
     assign(:topic, build(:topic, name: 'The Name'))
     assign(:notices, [])


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
This PR is to fix elasticsearch and rspec test suite. Rspec should start elasticsearch only for tests that are tagged after this PR is merged.

#### How can a reviewer manually see the effects of these changes?

By running a test that is not tagged. This should not start elasticsearch.
Example : 
Run the spec/models/other_spec.rb tests on the dev branch. Elastic search server is started. Try running the same spec file on this branch, elasticsearch does not start. 

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
