### PR TITLE
Fix broken link in admin

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -258,7 +258,7 @@ RailsAdmin.config do |config|
     configure :url do
       formatted_value do
         url = "#{Chill::Application.config.site_host}/notices/#{bindings[:object].notice_id}?access_token=#{bindings[:object].token}"
-        %(<a href="#{url}">Token url</a>).html_safe
+        %(<a href="//#{url}">#{bindings[:object].token}</a>).html_safe
       end
       visible false
     end

--- a/spec/integration/rails_admin_dashboard_spec.rb
+++ b/spec/integration/rails_admin_dashboard_spec.rb
@@ -25,7 +25,6 @@ feature 'Rails admin dashboard' do
 
   scenario 'it can delete notices' do
     notice = create(:dmca)
-    notice.save
     orig_id = notice.id
     sign_in(create(:user, :super_admin))
     visit '/admin/notice'
@@ -34,5 +33,13 @@ feature 'Rails admin dashboard' do
 
     expect(current_path).to eq '/admin/notice'
     expect(Notice.where(id: orig_id)).to eq []
+  end
+
+  scenario 'token url links are clickable' do
+    token_url = create(:token_url)
+    sign_in(create(:user, :super_admin))
+    visit '/admin/token_url'
+    find('.token_url_row .url_field a').click
+    expect(page.status_code).to be(200)
   end
 end


### PR DESCRIPTION
Without the protocol-agnostic //, the url was being treated as a path
and appended onto the page's domain.

While we're at it, change the unhelpful "token url" link text to
something more specific.

## Ready for merge?
**YES**

#### What does this PR do?
(see above)

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Look at `/admin/token_url` on this branch vs the dev branch. (Make sure there is at least one token URL in your database.) Note that the link with the link text "Token url" on the dev branch is broken, whereas the corresponding link in this branch works.

#### What are the relevant tickets?
n/a (conversation with Adam in slack)

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] ~~Documentation~~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
