### PR TITLE
16691 rate limiting but too much

### DIFF
--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -52,6 +52,20 @@ class Rack::Attack
     end
   end
 
+  # This logic prevents rackattack from throttling web requests from
+  # researchers and admins. They may still be throttled by the proxy for
+  # excessive use, as the proxy does not know that they are logged in.
+  whitelist('allow unlimited requests from permissioned users') do |req|
+    u = user_from_request(req)
+    if u.nil?
+      false
+    elsif (u.roles & [Role.researcher, Role.admin, Role.super_admin]).present?
+      true
+    else
+      false
+    end
+  end
+
   throttle('api limit', limit: 5, period: 24.hours) do |req|
     Rails.logger.debug "[rack-attack] api limit ip: #{req.ip}, req.env['HTTP_ACCEPT']: #{req.env['HTTP_ACCEPT']}, content_type: #{req.content_type}"
     req.ip if req.env['HTTP_ACCEPT'] == 'application/json' || req.env['CONTENT_TYPE'] == 'application/json' || req.path.include?('json')
@@ -75,4 +89,12 @@ class Rack::Attack
       ['Oops, you were browsing a little faster than we can keep up with. Please wait at least five minutes and try your request again. If you need to make more requests than our limit, please wait five minutes and then visit https://lumendatabase.org/pages/researchers#key to request a research account key.']
     ] # body
   end
+end
+
+def user_from_request(req)
+  User.find(req.session['warden.user.user.key'][0][0])
+rescue ActiveRecord::RecordNotFound  # no user with that ID exists
+  nil
+rescue NoMethodError  # [] is not defined on NilClass
+  nil
 end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -82,7 +82,7 @@ class Rack::Attack
   end
 
   self.throttled_response = lambda do |_env|
-    Rails.logger.info "[rack-attack] 429 issued for #{_env['rack.attack.match_discriminator']}"
+    Rails.logger.warn "[rack-attack] 429 issued for #{_env['rack.attack.match_discriminator']}"
     [
       429, # status
       { 'Content-Type' => 'text/plain' }, # headers

--- a/spec/config/initializers/rack-attack_spec.rb
+++ b/spec/config/initializers/rack-attack_spec.rb
@@ -2,49 +2,89 @@ require 'spec_helper'
 
 describe Rack::Attack do
   include Rack::Test::Methods
+  let(:notice) { create(:dmca) }
 
   def app
     Rails.application
   end
 
-  describe 'throttle excessive API requests by IP address', cache: true do
+  describe 'throttling excessive API requests by IP address', cache: true do
     let(:limit) { 5 }
 
     context 'number of requests is lower than the limit' do
-      it 'does not change the request status' do
-        limit.times do
+      it 'allows requests' do
+        limit.times do |i|
           get '/topics.json', {}, 'REMOTE_ADDR' => '1.2.3.4'
-          expect(last_response.status).to_not eq(429)
+          expect(last_response.status).to eq(200) if i == limit
         end
       end
     end
 
     context 'number of requests is higher than the limit', cache: true do
-      it 'changes the request status to 429' do
-        (limit * 2).times do |i|
+      it 'blocks requests' do
+        (limit + 1).times do |i|
           get '/topics.json', {}, 'REMOTE_ADDR' => '1.2.3.5'
+          puts 'hey' if i > limit
           expect(last_response.status).to eq(429) if i > limit
         end
       end
     end
   end
 
-  describe 'throttle excessive HTTP responses by IP address' do
-    let(:limit) { 200 }
+  describe 'throttling excessive HTTP responses by IP address' do
+    let(:limit) { 10 }
 
     context 'number of requests is lower than the limit', cache: true do
-      it 'does not change the request status' do
-        limit.times do
-          get '/pages/license', {}, 'REMOTE_ADDR' => '1.2.3.9'
-          expect(last_response.status).to_not eq(429)
+      it 'allows requests' do
+        limit.times do |i|
+          get notice_path(notice.id), {}, 'REMOTE_ADDR' => '1.2.3.9'
+          expect(last_response.status).to eq(200) if i == limit
         end
       end
     end
 
     context 'number of requests is higher than the limit', cache: true do
-      it 'changes the request status to 429' do
+      it 'blocks requests' do
         (limit + 1).times do |i|
-          get '/pages/license', {}, 'REMOTE_ADDR' => '1.2.4.7'
+          get notice_path(notice.id), {}, 'REMOTE_ADDR' => '1.2.4.7'
+          expect(last_response.status).to eq(200) if i > limit
+        end
+      end
+    end
+
+    context 'when user is logged in' do
+      it 'lets researchers have access' do
+        u = create(:user, :researcher)
+        sign_in u
+        (limit + 1).times do |i|
+          get notice_path(notice.id), {}, 'REMOTE_ADDR' => '1.2.3.10'
+          expect(last_response.status).to eq(200) if i > limit
+        end
+      end
+
+      it 'lets admins have access' do
+        u = create(:user, :admin)
+        sign_in u
+        (limit + 1).times do |i|
+          get notice_path(notice.id), {}, 'REMOTE_ADDR' => '1.2.3.11'
+          expect(last_response.status).to eq(200) if i > limit
+        end
+      end
+
+      it 'lets super_admins have access' do
+        u = create(:user, :super_admin)
+        sign_in u
+        (limit + 1).times do |i|
+          get notice_path(notice.id), {}, 'REMOTE_ADDR' => '1.2.3.12'
+          expect(last_response.status).to eq(200) if i > limit
+        end
+      end
+
+      it 'does not let non-permissioned users have access' do
+        u = create(:user)
+        sign_in u
+        (limit + 1).times do |i|
+          get notice_path(notice.id), {}, 'REMOTE_ADDR' => '1.2.3.13'
           expect(last_response.status).to eq(429) if i > limit
         end
       end

--- a/spec/config/initializers/rack-attack_spec.rb
+++ b/spec/config/initializers/rack-attack_spec.rb
@@ -24,7 +24,6 @@ describe Rack::Attack do
       it 'blocks requests' do
         (limit + 1).times do |i|
           get '/topics.json', {}, 'REMOTE_ADDR' => '1.2.3.5'
-          puts 'hey' if i > limit
           expect(last_response.status).to eq(429) if i > limit
         end
       end
@@ -37,7 +36,7 @@ describe Rack::Attack do
     context 'number of requests is lower than the limit', cache: true do
       it 'allows requests' do
         limit.times do |i|
-          get notice_path(notice.id), {}, 'REMOTE_ADDR' => '1.2.3.9'
+          get "/notices/#{notice.id}", {}, 'REMOTE_ADDR' => '1.2.3.9'
           expect(last_response.status).to eq(200) if i == limit
         end
       end
@@ -46,7 +45,7 @@ describe Rack::Attack do
     context 'number of requests is higher than the limit', cache: true do
       it 'blocks requests' do
         (limit + 1).times do |i|
-          get notice_path(notice.id), {}, 'REMOTE_ADDR' => '1.2.4.7'
+          get "/notices/#{notice.id}", {}, 'REMOTE_ADDR' => '1.2.4.7'
           expect(last_response.status).to eq(200) if i > limit
         end
       end
@@ -57,7 +56,7 @@ describe Rack::Attack do
         u = create(:user, :researcher)
         sign_in u
         (limit + 1).times do |i|
-          get notice_path(notice.id), {}, 'REMOTE_ADDR' => '1.2.3.10'
+          get "/notices/#{notice.id}", {}, 'REMOTE_ADDR' => '1.2.3.10'
           expect(last_response.status).to eq(200) if i > limit
         end
       end
@@ -66,7 +65,7 @@ describe Rack::Attack do
         u = create(:user, :admin)
         sign_in u
         (limit + 1).times do |i|
-          get notice_path(notice.id), {}, 'REMOTE_ADDR' => '1.2.3.11'
+          get "/notices/#{notice.id}", {}, 'REMOTE_ADDR' => '1.2.3.11'
           expect(last_response.status).to eq(200) if i > limit
         end
       end
@@ -75,7 +74,7 @@ describe Rack::Attack do
         u = create(:user, :super_admin)
         sign_in u
         (limit + 1).times do |i|
-          get notice_path(notice.id), {}, 'REMOTE_ADDR' => '1.2.3.12'
+          get "/notices/#{notice.id}", {}, 'REMOTE_ADDR' => '1.2.3.12'
           expect(last_response.status).to eq(200) if i > limit
         end
       end
@@ -84,7 +83,7 @@ describe Rack::Attack do
         u = create(:user)
         sign_in u
         (limit + 1).times do |i|
-          get notice_path(notice.id), {}, 'REMOTE_ADDR' => '1.2.3.13'
+          get "/notices/#{notice.id}", {}, 'REMOTE_ADDR' => '1.2.3.13'
           expect(last_response.status).to eq(429) if i > limit
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   config.order = 'random'
+  config.include Rails.application.routes.url_helpers
 
   # If you need to see the order your specs are running in (i.e. to debug
   # order-dependent test failures), uncomment the following. But you may find

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,6 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   config.order = 'random'
-  config.include Rails.application.routes.url_helpers
 
   # If you need to see the order your specs are running in (i.e. to debug
   # order-dependent test failures), uncomment the following. But you may find

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,6 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 RSpec.configure do |config|
   config.order = 'random'
   config.include Rails.application.routes.url_helpers
-  Rails.application.config.force_ssl = false
 
   # If you need to see the order your specs are running in (i.e. to debug
   # order-dependent test failures), uncomment the following. But you may find

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 RSpec.configure do |config|
   config.order = 'random'
   config.include Rails.application.routes.url_helpers
+  Rails.application.config.force_ssl = false
 
   # If you need to see the order your specs are running in (i.e. to debug
   # order-dependent test failures), uncomment the following. But you may find


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
We have been rate-limiting logged-in users who are using the web interface, even when their level of  permissions would allow unthrottled API access. We should not do this. This PR adds a new whitelist for authenticated users with suitable permissions.

They may still be throttled at the proxy, which cannot tell that they are logged in. However, if they're working at normal human speeds, that is unlikely to be a problem.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Log in as a researcher and issue a bunch of manual requests against dev; you'll get the 429. Do the same against this branch and you should not see 429. (You may need to clear the cache between runs, and you'll need to temporarily comment out the localhost whitelist if you're making requests against localhost.)

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/16691

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation - I am currently updating the github wiki
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
