### PR TITLE
Job to populate domain count [Ready for review]

### DIFF
--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -133,4 +133,8 @@ module NoticesHelper
       key
     end
   end
+
+  def give_domains_from_urls(infringing_urls_list)
+    infringing_urls_list.map{ |x| Addressable::URI.parse(x.url).domain }.uniq
+  end
 end

--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -133,8 +133,4 @@ module NoticesHelper
       key
     end
   end
-
-  def give_domains_from_urls(infringing_urls_list)
-    infringing_urls_list.map{ |x| Addressable::URI.parse(x.url).domain }.uniq
-  end
 end

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -263,12 +263,14 @@ namespace :lumen do
     end
 
     domain_count_map = {}
-    Notice.all.each do |notice|
-      give_domains_from_urls(notice.infringing_urls).each do |domain|
-        unless domain_count_map.key?(domain)
-          domain_count_map[domain] = 0
+    Notice.find_in_batches do |notices|
+      notices.each do |notice|
+        give_domains_from_urls(notice.infringing_urls).each do |domain|
+          unless domain_count_map.key?(domain)
+            domain_count_map[domain] = 0
+          end
+          domain_count_map[domain] += 1
         end
-        domain_count_map[domain] += 1
       end
     end
     domain_count_map.each do |key, val|

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -5,8 +5,6 @@ require 'blog_importer'
 require 'question_importer'
 require 'collapses_topics'
 require 'csv'
-require '#{Rails.root}/app/helpers/notices_helper'
-include 'NoticesHelper'
 
 namespace :lumen do
   desc 'Delete elasticsearch index'


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
This PR adds a job to populate the table domains_count with data generated to date

#### Helpful background context (if appropriate)
Merge this only after merging of #560 

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/16597 (Subpart - 2)

#### Todo:
- [x] Tests
- [x] Documentation
- [ ] Stakeholder approval

#### Requires Database Migration
NO

#### Includes new or updated dependencies?
NO
