### PR TITLE
Remove additional special characters from report

### DIFF
--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -787,9 +787,11 @@ class CourtOrderReporter
   end
 
   def copy_file_to_archive(f)
-    # The first two params ensure the filename is useful; the third ensures
-    # it is unique.
-    name = "#{f.notice_id}_#{f.id}_#{f.file_file_name}".gsub(/\s+/, "")
+    # The first and third params ensure the filename is useful; the second
+    # ensures it is unique. Stripping spaces and punctuation prevents problems
+    # with invalid filenames.
+    evil = /[\s$'"#=\[\]!><|;{}()*?~&\\]/
+    name = "#{f.notice_id}_#{f.id}_#{f.file_file_name}".gsub(evil, '')
     system("cp #{Shellwords.escape(f.file.path)} '#{File.join(@working_dir, name)}'")
   end
 

--- a/spec/tasks/redact_and_reindex_works_spec.rb
+++ b/spec/tasks/redact_and_reindex_works_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'rake lumen:redact_and_reindex_works', type: :task, search: true do
   it 'redacts the works' do
     w = sensitive_work
-    expect(Work.where(description: '123-45-6789').present?).to be true
+    expect(Work.where(description: '012-34-5678').present?).to be true
     task.execute
 
     w.reload
@@ -26,7 +26,7 @@ describe 'rake lumen:redact_and_reindex_works', type: :task, search: true do
     # Use update_columns because it doesn't trigger the before_save callback -
     # we want to make sure this isn't auto-redacted.
     w.update_columns(
-      description: '123-45-6789',      # triggers SSN validation
+      description: '012-34-5678',      # triggers SSN validation
       updated_at: Date.new(2008, 1, 1) # before the rake task's limit
     )
     w


### PR DESCRIPTION
We still get the occasional warning about filenames with special
characters not being handled correctly by the cron job.

## Ready for merge?
**YES**

#### What does this PR do?
(see above)

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
