### PR TITLE
Make it possible to whitelist notices and show their full version

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,7 +35,10 @@ module ApplicationHelper
   end
 
   def can_see_full_notice_version?(notice)
-    return true if can?(:view_full_version, notice)
+    whitelisted_notices = (ENV['WHITELISTED_NOTICES_FULL'] || []).split(',')
+
+    return true if can?(:view_full_version, notice) ||
+                   whitelisted_notices.include?(notice.id.to_s)
 
     TokenUrl.valid?(params[:access_token], notice)
   end

--- a/spec/integration/viewing_notices.spec.rb
+++ b/spec/integration/viewing_notices.spec.rb
@@ -56,6 +56,14 @@ feature 'Viewing notices' do
     check_full_works_urls
   end
 
+  scenario 'as an anonymous user viewing whitelisted notice' do
+    ENV['WHITELISTED_NOTICES_FULL'] = "1234,#{Notice.last.id}"
+
+    visit notice_url(Notice.last)
+
+    check_full_works_urls
+  end
+
   def check_full_works_urls
     within('#works') do
       expect(page).to have_content 'http://www.example.com/original_work.pdf'


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Makes it possible to set a list of notices in the `.env` file that will be default show the full notice view.

#### What are the relevant tickets?
https://cyber.harvard.edu/projectmanagement/issues/16884

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
~~- [ ] Documentation~~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
