### PR TITLE
Update failing blog tests

### DIFF
--- a/spec/integration/page_titles_spec.rb
+++ b/spec/integration/page_titles_spec.rb
@@ -15,23 +15,6 @@ feature 'Page titles' do
     expect(page).to have_exact_title('Search :: Lumen')
   end
 
-  scenario "Blog" do
-    blog_entry = create(:blog_entry, :published)
-
-    visit '/'
-    click_on 'Blog'
-
-    # index
-    expect(page).to have_exact_title('Blog :: Lumen')
-    expect(page).to have_heading('Blog')
-
-    click_on blog_entry.title
-
-    # show
-    expect(page).to have_exact_title("#{blog_entry.title} :: Blog :: Lumen")
-    expect(page).to have_heading('Blog')
-  end
-
   scenario "Topics", search: true do
     topic = create(:topic)
 

--- a/spec/integration/reading_the_blog_spec.rb
+++ b/spec/integration/reading_the_blog_spec.rb
@@ -1,17 +1,16 @@
 require 'rails_helper'
 
-feature "The Blog" do
-  scenario "A user reads a blog entry" do
+feature 'The Blog' do
+  scenario 'A user reads a blog entry' do
     blog_entry = create(:blog_entry, :published, :with_content)
 
-    visit '/'
-    click_on 'Blog'
+    visit '/blog_entries'
     click_on blog_entry.title
 
     expect(page.html).to include(blog_entry.content_html)
   end
 
-  scenario "A user opens a blog entry from the home page" do
+  scenario 'A user opens a blog entry from the home page' do
     blog_entry = create(:blog_entry, :published)
 
     visit '/'

--- a/spec/views/shared/_navigation.html.erb_spec.rb
+++ b/spec/views/shared/_navigation.html.erb_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 describe 'shared/_navigation.html.erb' do
-  it 'shows a link to read the blog' do
-    render
-
-    expect(rendered).to contain_link(blog_entries_path)
-  end
-
   it 'shows a link to research' do
     render
 


### PR DESCRIPTION
91b25eaf8 removed the blog link from the navigation bar, which means
that tests which mandate visiting / and clicking on 'Blog' no longer
work. These tests are removed or updated.

## Ready for merge?
**YES**

#### What does this PR do?
(see above)

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
`rspec` should succeed, whereas it fails on dev.

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- ~[ ] Documentation~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO