### PR TITLE
Migrate cms content

### DIFF
--- a/app/helpers/comfy/comfy_helper.rb
+++ b/app/helpers/comfy/comfy_helper.rb
@@ -15,23 +15,4 @@ module Comfy::ComfyHelper
     Kaminari.paginate_array(scope.to_a, total_count: scope.count)
             .page(params[:page]).per(10)
   end
-
-  def fragment_title(page)
-    if (title = page.fragments.find_by_identifier('title').content).empty?
-      title = '(No title)'
-    end
-    # This can't return an empty string. Since we use the title to construct
-    # links to the blog post, there must be something to click on.
-    title
-  end
-
-  def fragment_content(page)
-    page.fragments.find_by_identifier('content').content
-  end
-
-  def fragment_abstract(page)
-    page.fragments.find_by_identifier('abstract').content
-  rescue NoMethodError
-    nil
-  end
 end

--- a/app/views/blog_entries/_comfy_entry.html.erb
+++ b/app/views/blog_entries/_comfy_entry.html.erb
@@ -1,11 +1,11 @@
 <article class="post-item">
   <h3 class="title">
     <% if blog_entry.full_path.present? %>
-      <%= link_to(fragment_title(blog_entry), "/cms#{blog_entry.full_path}") %>
+      <%= link_to(cms_fragment_content('title', blog_entry), "/cms#{blog_entry.full_path}") %>
     <% end %>
   </h3>
   <%= render 'blog_entries/comfy_metadata', blog_entry: blog_entry %>
   <a class="snippet" href="<%= blog_entry.full_path %>">
-    <%= raw fragment_abstract(blog_entry) %>
+    <%= raw cms_fragment_content('abstract', blog_entry) %>
   </a>
 </article>

--- a/app/views/cms_pages/_layout.html.erb
+++ b/app/views/cms_pages/_layout.html.erb
@@ -1,0 +1,9 @@
+<% title cms_fragment_content('page_title', @cms_page) %>
+
+<div class="high_voltage-pages">
+  <section class="main">
+    <div class="main-inner">
+      <%= raw cms_fragment_content('page_content', @cms_page) %>
+    </div>
+  </section>
+</div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+require 'uglifier'
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -721,13 +721,59 @@ where works.id in (
     puts "#{date_time_task.call} Finishing the task"
   end
 
+  desc 'Retain OriginalNewsId URLs in CMS'
+  task migrate_original_news_id_redirects: :environment do
+    # Find Site & Layout. ------------------------------------------------------
+    site = Comfy::Cms::Site.find_by_identifier('lumen_cms')
+    layout = Comfy::Cms::Layout.first
+
+    unless site.present? && layout.present?
+      $stdout.puts 'lumen_cms Site, and any Layout, must be defined before running this task'
+      exit
+    end
+
+    # Find or create parent for namespacing. -----------------------------------
+    parent = if (page = Comfy::Cms::Page.find_by_slug('original_news_id')).present?
+               page
+             else
+               Comfy::Cms::Page.create(
+                 site: site,
+                 layout: layout,
+                 label: 'original news ID parent',
+                 slug: 'original_news_id',
+                 is_published: false
+               )
+            end
+
+    # Create pages to preserve redirects. --------------------------------------
+    count = 0
+    BlogEntry.where.not(original_news_id: nil).each do |entry|
+      next if Comfy::Cms::Page.where(
+          parent: parent,
+          slug: entry.original_news_id
+        ).present?
+
+      Comfy::Cms::Page.create(
+        site: site,
+        layout: layout,
+        parent: parent,
+        label: "redirect_#{entry.original_news_id}",
+        slug: entry.original_news_id,
+        target_page: Comfy::Cms::Page.find_by_slug(entry.id)
+      )
+      count += 1
+    end
+
+    $stdout.puts "#{count} pages created"
+  end
+
   desc 'Migrate BlogEntries to CMS'
   task migrate_blog_entries_to_cms: :environment do
     site = Comfy::Cms::Site.find_by_identifier('lumen_cms')
     layout = Comfy::Cms::Layout.find_by_label('blawg')
     parent = Comfy::Cms::Page.find_by_label('blog_entries')
 
-    unless site && layout && parent
+    unless site.present? && layout.present? && parent.present?
       $stdout.puts 'lumen_cms Site, blawg Layout, and blog_entries Page must be defined before running this task'
       exit
     end

--- a/lib/tasks/lumen.rake
+++ b/lib/tasks/lumen.rake
@@ -753,6 +753,11 @@ where works.id in (
           slug: entry.original_news_id
         ).present?
 
+      unless Comfy::Cms::Page.find_by_slug(entry.id)
+        puts 'Must migrate blog entries before running this task'
+        raise
+      end
+
       Comfy::Cms::Page.create(
         site: site,
         layout: layout,

--- a/spec/lib/tasks/blog_import_to_cms_spec.rb
+++ b/spec/lib/tasks/blog_import_to_cms_spec.rb
@@ -13,8 +13,12 @@ describe 'lumen:migrate_blog_entries_to_cms', type: :request do
       image: 'overcast',
       content: 'content goes here'
     )
-    Rake::Task['lumen:set_up_cms'].invoke
-    Rake::Task['lumen:migrate_blog_entries_to_cms'].invoke
+    Rake::Task['lumen:set_up_cms'].execute
+    Rake::Task['lumen:migrate_blog_entries_to_cms'].execute
+  end
+
+  after(:all) do
+    BlogEntry.destroy_all
   end
 
   let(:blog_parent) { Comfy::Cms::Page.find_by_label('blog_entries') }

--- a/spec/lib/tasks/migrate_original_news_ids_to_cms_spec.rb
+++ b/spec/lib/tasks/migrate_original_news_ids_to_cms_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+require 'uri'
+
+describe 'lumen:migrate_original_news_id_redirects', type: :request do
+  before(:all) do
+    expect(BlogEntry.count).to eq 0
+    create(
+      :blog_entry,
+      author: 'John Rock',
+      title: 'Speech at Faneuil Hall',
+      abstract: 'abstract goes here',
+      image: 'overcast',
+      content: 'content goes here',
+      original_news_id: 1
+    )
+    Rake::Task['lumen:set_up_cms'].execute
+    Rake::Task['lumen:migrate_blog_entries_to_cms'].execute
+    Rake::Task['lumen:migrate_original_news_id_redirects'].execute
+  end
+
+  after(:all) do
+    BlogEntry.destroy_all
+  end
+
+  it 'creates redirects for original news IDs' do
+    get '/original_news_id/1'
+    original_path = URI::parse(response.location).path
+
+    page = Comfy::Cms::Page.find_by_full_path('/original_news_id/1')
+    expect(page.target_page).to be_present
+
+    # The full URL will not be the same because of namespacing under the CMS.
+    # This is good -- it means we're not inadvertently testing our existing
+    # controller. But the Comfy::Cms::Page.full_path attribute does not include
+    # the namespacing.
+    expect(page.target_page.full_path).to eq original_path
+  end
+end


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Adds a rails task to migrate the permalinks for original_notice_ids -- we need to migrate that content before we can rip it out in the final CMS deploy.

#### Helpful background context (if appropriate)
cool URIs don't change

#### How can a reviewer manually see the effects of these changes?
Run the task. At that point, for every `/original_news_id/X` to `/blog_entries/Y` redirect, there should also be a `/cms/original_news_id/X` to `/cms/blog_entries/Y` redirect

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/17078

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- ~[ ] Documentation~
- ~[ ] Stakeholder approval~

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
