### PR TITLE
Cms links

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/custom.js
+++ b/app/assets/javascripts/comfy/admin/cms/custom.js
@@ -1,2 +1,3 @@
 // Custom JS for the admin area
 //= require comfy/admin/cms/lib/underline
+//= require comfy/admin/cms/lib/definedlinks

--- a/app/assets/javascripts/comfy/admin/cms/lib/definedlinks.js.erb
+++ b/app/assets/javascripts/comfy/admin/cms/lib/definedlinks.js.erb
@@ -1,0 +1,7 @@
+if ($.Redactor !== undefined) {
+  $.Redactor.opts.definedLinks = [
+    <% Comfy::Cms::Site.first.pages.root.children.published.each do |page| %>
+      { "name": "<%= page.label %>", "url": "<%= page.full_path %>" },
+    <% end %>
+  ]
+}

--- a/app/assets/javascripts/comfy/vendor/redactor/definedlinks.js.erb
+++ b/app/assets/javascripts/comfy/vendor/redactor/definedlinks.js.erb
@@ -1,0 +1,57 @@
+if (!RedactorPlugins) var RedactorPlugins = {};
+
+(function($)
+{
+  RedactorPlugins.definedlinks = function()
+  {
+    return {
+      init: function()
+      {
+        if (!this.opts.definedLinks) return;
+
+        this.modal.addCallback('link', $.proxy(this.definedlinks.load, this));
+
+      },
+      load: function()
+      {
+        var $select = $('<select id="redactor-defined-links" />');
+        $('#redactor-modal-link-insert').prepend($select);
+
+        this.definedlinks.storage = {};
+        data = [
+          <% Comfy::Cms::Page.find_by_label('pages').children.published.each do |page| %>
+            { "name": "<%= page.label %>", "url": "<%= page.full_path %>" },
+          <% end %>
+        ]
+        data.push(
+          {"name": "Blog Archive",
+           "url": "<%= Comfy::Cms::Page.find_by_label('blog_entries').full_path %>"}
+         )
+
+        $.each(data, $.proxy(function(key, val)
+        {
+          this.definedlinks.storage[key] = val;
+          $select.append($('<option>').val(key).html(val.name));
+
+        }, this));
+
+        $select.on('change', $.proxy(this.definedlinks.select, this));
+      },
+      select: function(e)
+      {
+        var key = $(e.target).val();
+        var name = '', url = '';
+        if (key !== 0)
+        {
+          name = this.definedlinks.storage[key].name;
+          url = this.definedlinks.storage[key].url;
+        }
+
+        $('#redactor-link-url').val(url);
+
+        var $el = $('#redactor-link-url-text');
+        if ($el.val() === '') $el.val(name);
+      }
+    };
+  };
+})(jQuery);

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -24,10 +24,11 @@
 
 // Shared
 @import 'shared/fontello';
-@import 'shared/header';
 @import 'shared/pagination';
-@import 'shared/navigation';
+@import 'shared/header';
 @import 'shared/footer';
+@import 'shared/navigation';
+@import 'shared/flexnav';
 
 // Layouts
 @import 'layouts/application';

--- a/app/assets/stylesheets/home/index.scss
+++ b/app/assets/stylesheets/home/index.scss
@@ -170,30 +170,3 @@ section.home-search-form {
     margin: 0 0 0.4em;
   }
 }
-
-// Home Footer
-//************************************************************************//
-body.home footer.main {
-  background: none;
-  border: 0;
-
-  div.inner-wrapper {
-    font-size: $base-font-size-small-2;
-    margin: 0 auto;
-    max-width: $home-width;
-    padding: 0;
-  }
-
-  span, a {
-    margin: 0 15px 15px;
-    color: lighten($base-font-color-3, 20%);
-  }
-
-  a:hover {
-    color: $base-link-color;
-  }
-
-  nav {
-    float: right;
-  }
-}

--- a/app/assets/stylesheets/shared/_flexnav.scss
+++ b/app/assets/stylesheets/shared/_flexnav.scss
@@ -47,14 +47,18 @@ nav {
 .nav-wrapper {
   display: flex;
   justify-content: space-between;
+  padding-left: 25px;
+  padding-right: 25px;
 
   .nav-item, a {
-    padding: 25px 25px;
+    padding-top: 25px;
+    padding-bottom: 25px;
   }
 
   @include media($tablet) {
     .nav-item, a {
-      padding: 10px 25px;
+      padding-top: 10px;
+      padding-bottom: 10px;
     }
   }
 }

--- a/app/assets/stylesheets/shared/_flexnav.scss
+++ b/app/assets/stylesheets/shared/_flexnav.scss
@@ -1,0 +1,123 @@
+// Flexnav.
+// https://css-tricks.com/snippets/css/a-guide-to-flexbox/
+
+//************************************************************************//
+// Nav -- Basic styling (e.g. in footer)
+//************************************************************************//
+nav {
+  display: flex;
+  flex-wrap: wrap;
+
+  .item {
+    flex-grow: 1;
+  }
+
+  .dropdown {
+    position: relative;
+  }
+
+  #dropdown-topics {
+    @include media($small-screen){
+      background: darken($nav-bg, 4%);
+      left: 5%;
+      margin-left: 0;
+      margin-top: 0;
+      padding-top: 0;
+
+      > ol {
+        position: relative;
+        background: $nav-bg;
+      }
+
+      li.dropdown-submenu {
+        position: static;
+
+        .dropdown-menu {
+          margin-top: 0;
+          height: 100%;
+          width: 100%;
+        }
+      }
+    }
+  }
+}
+
+// For holding a left-justified item (like a logo) and a right-justified item
+// (like a nav bar).
+.nav-wrapper {
+  display: flex;
+  justify-content: space-between;
+
+  .nav-item, a {
+    padding: 25px 25px;
+  }
+
+  @include media($tablet) {
+    .nav-item, a {
+      padding: 10px 25px;
+    }
+  }
+}
+
+// Force right-justification of items in a nav bar by wrapping them in a
+// .flex-end div.
+.flex-end {
+  display: flex;
+  align-items: center;
+
+  nav {
+    display: flex;
+    justify-content: flex-end;
+    text-align: left;
+  }
+
+  .nav-item, a {
+    padding: 25px 0px 25px 25px;
+  }
+
+  @include media($tablet) {
+    .nav-item, a {
+      padding: 10px 0px 10px 25px;
+    }
+  }
+}
+
+//************************************************************************//
+// Nav -- white-on-blue style (as on home page)
+//************************************************************************//
+
+.blue-nav nav {
+  background: $nav-bg;
+  padding: 0 3em;
+
+  .nav-item {
+    padding: 0;
+    flex-grow: 1;
+  }
+
+  a {
+    @extend %nav-anchor;
+    color: $nav-color;
+    font-size: $base-font-size-small-1;
+    font-weight: bold;
+    padding: 8px 10px;
+    text-align: center;
+
+    @include media($mobile){
+      font-size: $base-font-size-small-2 - 1;
+      line-height: 1.4em;
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .search {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/shared/_footer.scss
+++ b/app/assets/stylesheets/shared/_footer.scss
@@ -4,29 +4,6 @@ footer.main {
   font-size: $base-font-size-small-1;
   font-weight: 500;
 
-  div.inner-wrapper {
-    @include clearfix;
-    @include container;
-    margin: 0 auto;
-    padding: 0;
-  }
-
-  span, nav {
-    float: left;
-  }
-
-  span, a {
-    margin: 40px 25px;
-    display: inline-block;
-  }
-
-  @include media($mobile) {
-    span, a {
-      margin: 10px 25px;
-      display: block;
-    }
-  }
-
   a {
     color: $base-font-color-3;
     text-decoration: none;
@@ -34,5 +11,24 @@ footer.main {
     &:hover {
       color: $base-link-color;
     }
+  }
+}
+
+body.home footer.main {
+  background: none;
+  border: 0;
+  font-size: $base-font-size-small-2;
+  margin: 0 auto;
+  max-width: $home-width;
+  padding: 0;
+
+  .nav-item, a {
+    &:first-child {
+      padding-left: 0;
+    }
+  }
+
+  @include media($tablet) {
+    padding: 0 10px;
   }
 }

--- a/app/assets/stylesheets/shared/_header.scss
+++ b/app/assets/stylesheets/shared/_header.scss
@@ -1,35 +1,64 @@
 //************************************************************************//
-// Form
+// Nav overrides for CMS/search-style pages
 //************************************************************************//
 header.app {
-  $padding: 20px;
-  background: $base-background-color-alt;
+  .nav-wrapper {
+    padding: 15px 0;
+  }
 
-  h1 {
-    display: block;
-    margin: 0 30px 30px 10px;
-    float: left;
+  .nav-item {
+    a {
+      border-radius: 2px;
+      color: $nav-link-color;
+      font-size: $base-font-size;
+      font-weight: 500;
+      text-decoration: none;
 
-    img {
-      margin-top: 10px;
-      display: block;
+      &:hover {
+        background: $nav-hover;
+        color: #fff;
+      }
+
+      &:focus {
+        outline: none;
+      }
+
+      &:hover, &:focus, &:link, &:visited {
+        text-decoration: none;
+      }
     }
 
-    @include media($mobile) {
-      float: none;
-      display: block;
-      text-align: center;
-      margin: 0;
-
-      img {
-        margin: 10px auto 15px;
-        display: block;
-        width: 80%;
-        height: 80%;
-      }
+    #dropdown-topics a {
+      color: #fff;
     }
   }
 
+  .nav-item {
+    padding: 25px 0px;
+  }
+
+  a {
+    padding: 10px 20px;
+  }
+
+  @include media($tablet) {
+    .nav-item {
+      padding: 10px 0px;
+    }
+  }
+
+  a#root {
+    display: inline-block;
+  }
+  #root img {
+    display: block;
+  }
+}
+
+//************************************************************************//
+// Form
+//************************************************************************//
+header.app {
   h2 {
     color: white;
     font-size: em(22, 15);

--- a/app/assets/stylesheets/shared/_header.scss
+++ b/app/assets/stylesheets/shared/_header.scss
@@ -55,6 +55,19 @@ header.app {
   }
 }
 
+header.search-header {
+  @include container;
+  margin: 0 auto;
+
+  @include media($small-screen) {
+    margin: 0 $base-padding;
+  }
+
+  @include media($mobile) {
+    margin: 0 10px;
+  }
+}
+
 //************************************************************************//
 // Form
 //************************************************************************//
@@ -79,6 +92,8 @@ header.app {
 
     &.header-bar {
       border-radius: 4px 4px 0 0;
+      max-width: $max-width;
+      margin: 0 auto;
     }
   }
 
@@ -318,5 +333,9 @@ header.app .container.advanced-search {
         width: 100%;
       }
     }
+  }
+
+  button {
+    max-width: 100%;
   }
 }

--- a/app/assets/stylesheets/shared/_navigation.scss
+++ b/app/assets/stylesheets/shared/_navigation.scss
@@ -1,180 +1,15 @@
 //************************************************************************//
-// Main Navigation Shared
-//************************************************************************//
-nav.main-nav {
-  background: $nav-bg;
-
-  ol.nav-list {
-    clear: left;
-    @include clearfix;
-    margin: 0 auto;
-    max-width: $home-width;
-    padding: 0;
-    width: 100%;
-
-    li.open {
-      background: $header-background-1;
-      color: #fff;
-    }
-  }
-
-  .nav-item {
-    float: left;
-    list-style: none;
-    position: relative;
-    text-align: center;
-    width: 33%;
-
-    @include media($small-screen){
-      position: static;
-    }
-
-    > a {
-      @extend %nav-anchor;
-      color: $nav-color;
-      font-size: $base-font-size-small-1;
-      font-weight: bold;
-
-      @include media($mobile){
-        font-size: $base-font-size-small-2 - 1;
-        line-height: 1.4em;
-      }
-
-      &:focus {
-        outline: none;
-      }
-
-      &:hover {
-        color: #fff;
-      }
-    }
-  }
-
-  #dropdown-topics {
-    @include media($small-screen){
-      background: darken($nav-bg, 4%);
-      left: 5%;
-      margin-left: 0;
-      margin-top: 0;
-      padding-top: 0;
-      width: 90%;
-
-      > ol {
-        position: relative;
-        width: 33.4%;
-        background: $nav-bg;
-      }
-
-      li.dropdown-submenu {
-        position: static;
-
-        .dropdown-menu {
-          margin-top: 0;
-          height: 100%;
-          width: 100%;
-        }
-      }
-    }
-  }
-}
-
-
-//************************************************************************//
-// Navigation
-//************************************************************************//
-nav.main-nav {
-}
-
-//************************************************************************//
-// Landing Page / Home
-//************************************************************************//
-body.home-index {
-  nav.main-nav {
-    li.search {
-      display: none;
-    }
-  }
-}
-
-//************************************************************************//
-// App Header Navigation - not landing
-//************************************************************************//
-header.app {
-  nav.main-nav {
-    position: fixed;
-    z-index: 10;
-    top: 0;
-    left: 0;
-    width: 100%;
-    float: none;
-
-    li.nav-item {
-      width: (100% / 5);
-    }
-
-    li.open {
-      background: none;
-    }
-  }
-
-  @include media(min-width 769px) {
-    nav.main-nav {
-      float: right;
-      position: static;
-      @include clearfix;
-      margin-top: 23px;
-      background: none;
-      width: auto;
-    }
-
-    ol.nav-list {
-      margin: 0;
-      padding: 0;
-      @include clearfix;
-
-
-      li.nav-item {
-        width: auto;
-
-        > a {
-          border-radius: 2px;
-          color: $nav-link-color;
-          font-size: $base-font-size;
-          font-weight: 500;
-          margin-right: 5px;
-          padding: 6px 15px;
-
-          &:hover {
-            background: $nav-hover;
-            color: #fff;
-          }
-
-          &:focus {
-            outline: none;
-          }
-        }
-
-        &.open > a {
-          background: $nav-hover;
-          color: #fff;
-        }
-      }
-    }
-  }
-}
-
-//************************************************************************//
 // Dropdown Menu
 //************************************************************************//
 .dropdown {
   &.open > .dropdown-menu {
-    display: block; // Open dropdown menu on click
+    display: flex; // Open dropdown menu on click
   }
 }
 
 // Global Dropdown Menu Styles
 //************************************************************************//
-li.nav-item .dropdown-menu {
+.nav-item .dropdown-menu {
   @include ui-dropdown(center, $width: 200px, $nub-bg-color: $nav-bg, $nub-border-color: none);
   background: $nav-bg;
   border: 0;
@@ -198,6 +33,7 @@ li.nav-item .dropdown-menu {
     line-height: 1.2;
     margin: 0;
     padding: 12px 15px;
+    text-align: left;
   }
 }
 
@@ -210,6 +46,13 @@ li.dropdown-submenu {
   > a {
     padding-right: 30px;
     position: relative;
+    font-size: $base-font-size-small-1;
+    font-weight: bold;
+
+    @include media($mobile){
+      font-size: $base-font-size-small-2 - 1;
+      line-height: 1.4em;
+    }
 
     &:after {
       @include triangle(12px, hsla(0, 0%, 100%, 0.6), right);

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,4 +42,16 @@ module ApplicationHelper
 
     TokenUrl.valid?(params[:access_token], notice)
   end
+
+  def footer_links
+    ids = Comfy::Cms::Fragment.where(identifier: 'link_in_footer', boolean: true)
+                              .pluck(:record_id)
+    Comfy::Cms::Page.where(id: ids)
+  end
+
+  def header_links
+    ids = Comfy::Cms::Fragment.where(identifier: 'link_in_header', boolean: true)
+                              .pluck(:record_id)
+    Comfy::Cms::Page.where(id: ids)
+  end
 end

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -8,7 +8,9 @@
 </head>
 <body class="<%= body_class %>">
   <%= render 'flashes' -%>
-  <%= render 'shared/navigation' -%>
+  <div class="blue-nav">
+    <%= render 'shared/navigation' -%>
+  </div>
   <section class="main home">
     <%= yield %>
   </section>

--- a/app/views/notices/search/index.html.erb
+++ b/app/views/notices/search/index.html.erb
@@ -1,7 +1,7 @@
 <%= title 'Search' %>
 <%= cache(@searcher.cache_key) do %>
   <section class="search-results">
-    <header>
+    <header class="app">
       <%= form_tag(notices_search_index_path, method: :get, id: 'facets-form') do %>
         <% if @searchdata.response['aggregations'] %>
           <ol class="results-facets">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,18 +1,22 @@
 <footer class="main">
-  <div class="inner-wrapper">
-    <span><%= image_tag 'Cc.logo.circle.svg', height: '16', style: 'vertical-align: middle;' %> 2017 Lumen</span>
-    <nav>
-      <% footer_links.each do |link| %>
-        <%= link_to cms_fragment_content('page_title', link), link.full_path %>
-      <% end %>
-      <% if user_signed_in? %>
-        <% if can? :access, :rails_admin %>
-          <%= link_to "Admin", rails_admin_path %>
+  <div class="nav-wrapper">
+    <div class="nav-item">
+      <span><%= image_tag 'Cc.logo.circle.svg', height: '16', style: 'vertical-align: middle;' %> 2017 Lumen</span>
+    </div>
+    <div class="flex-end">
+      <nav>
+        <% footer_links.each do |link| %>
+          <span class="nav-item"><%= link_to cms_fragment_content('page_title', link), link.full_path %></span>
         <% end %>
-        <%= link_to "Sign Out", destroy_user_session_path %>
-      <% else %>
-        <%= link_to "Sign In", new_user_session_path %>
-      <% end %>
-    </nav>
+        <% if user_signed_in? %>
+          <% if can? :access, :rails_admin %>
+            <span class="nav-item"><%= link_to "Admin", rails_admin_path %></span>
+          <% end %>
+          <span class="nav-item"><%= link_to "Sign Out", destroy_user_session_path %></span>
+        <% else %>
+          <span class="nav-item"><%= link_to "Sign In", new_user_session_path %></span>
+        <% end %>
+      </nav>
+    </div>
   </div>
 </footer>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,18 +2,17 @@
   <div class="inner-wrapper">
     <span><%= image_tag 'Cc.logo.circle.svg', height: '16', style: 'vertical-align: middle;' %> 2017 Lumen</span>
     <nav>
-	<%= link_to "License", page_path("license") %>
-    <%= link_to "Privacy", page_path("privacy") %>
-    <%= link_to "Legal", page_path("legal") %>
-    <%= link_to "Researchers", page_path("researchers") %>
-    <% if user_signed_in? %>
-      <% if can? :access, :rails_admin %>
-        <%= link_to "Admin", rails_admin_path %>
+      <% footer_links.each do |link| %>
+        <%= link_to cms_fragment_content('page_title', link), link.full_path %>
       <% end %>
-      <%= link_to "Sign Out", destroy_user_session_path %>
-    <% else %>
-      <%= link_to "Sign In", new_user_session_path %>
-    <% end %>
+      <% if user_signed_in? %>
+        <% if can? :access, :rails_admin %>
+          <%= link_to "Admin", rails_admin_path %>
+        <% end %>
+        <%= link_to "Sign Out", destroy_user_session_path %>
+      <% else %>
+        <%= link_to "Sign In", new_user_session_path %>
+      <% end %>
     </nav>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,13 +1,6 @@
 <header class="app">
-  <div class="header-inner">
-    <h1>
-      <%= link_to root_path, :id => "root" do %>
-        <%= image_tag("logo_2x.png", :size=> "265x64") %>
-      <% end %>
-    </h1>
-    <%= render 'shared/navigation' -%>
-    <div class="container header-bar">
-      <h2><%= yield(:header) %></h2>
-    </div>
+  <%= render "shared/header_nav" %>
+  <div class="container header-bar">
+    <h2><%= yield(:header) %></h2>
   </div>
 </header>

--- a/app/views/shared/_header_nav.html.erb
+++ b/app/views/shared/_header_nav.html.erb
@@ -1,0 +1,10 @@
+<div class="nav-wrapper">
+  <div>
+    <%= link_to root_path, id: "root" do %>
+      <%= image_tag("logo_2x.png", size: "265x64") %>
+    <% end %>
+  </div>
+  <div class="flex-end">
+    <%= render 'shared/navigation' %>
+  </div>
+</div>

--- a/app/views/shared/_header_search.html.erb
+++ b/app/views/shared/_header_search.html.erb
@@ -1,30 +1,23 @@
 <header class="app search-header">
-  <div class="header-inner">
-    <h1>
-      <%= link_to root_path, :id => "root" do %>
-        <%= image_tag("logo_2x.png", :size=> "265x64") %>
-      <% end %>
-    </h1>
-    <%= render 'shared/navigation' -%>
-    <div class="container search header-bar">
-      <%= render 'shared/search' %>
-    </div>
-    <%= form_tag(notices_search_index_path, method: :get) do %>
-      <div class="container advanced-search">
-        <div class="width-wrapper">
-          <h5>Advanced Search: <span>add additional search queries<span></h5>
-          <% Notice::SEARCHABLE_FIELDS.each do |field| %>
-            <%= render field %>
-          <% end %>
-          <a id="duplicate-field" href="javascript:void(0);" class="add-group">Add more</a>
-          <div class="resubmit">
-            <button class="button">Advanced Search</button>
-          </div>
+  <%= render "shared/header_nav" %> 
+  <div class="container search header-bar">
+    <%= render 'shared/search' %>
+  </div>
+  <%= form_tag(notices_search_index_path, method: :get) do %>
+    <div class="container advanced-search">
+      <div class="width-wrapper">
+        <h5>Advanced Search: <span>add additional search queries<span></h5>
+        <% Notice::SEARCHABLE_FIELDS.each do |field| %>
+          <%= render field %>
+        <% end %>
+        <a id="duplicate-field" href="javascript:void(0);" class="add-group">Add more</a>
+        <div class="resubmit">
+          <button class="button">Advanced Search</button>
         </div>
       </div>
-      <%= hidden_field_tag(:sort_by, params[:sort_by], class: 'sort_by_field') %>
-    <% end %>
-  </div>
+    </div>
+    <%= hidden_field_tag(:sort_by, params[:sort_by], class: 'sort_by_field') %>
+  <% end %>
 </header>
 
 <%= javascript_tag do -%>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,23 +1,21 @@
 <% cache '_navigation' do %>
   <nav class="main-nav">
-    <ol class="nav-list">
-      <li class="nav-item search">
-        <%= link_to("Search", root_path) %>
-      </li>
-      <li class="nav-item topics dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics</a>
-        <div id="dropdown-topics" class="dropdown-menu" role="menu">
-          <ol>
-            <% cache('dropdown-topics') do %>
-              <%= render partial: 'shared/topic_dropdown', collection: topic_roots,
-                  as: :topic %>
-            <% end %>
-          </ol>
-        </div>
-      </li>
-      <% header_links.each do |link| %>
-        <li class="nav-item about"><%= link_to cms_fragment_content('page_title', link), link.full_path %></li>
-      <% end %>
-    </ol>
+    <div class="nav-item search"><%= link_to("Search", root_path) %></div>
+    <div class="nav-item topics dropdown">
+      <a href="#" class="dropdown-toggle" data-toggle="dropdown">Topics</a>
+      <div id="dropdown-topics" class="dropdown-menu" role="menu">
+        <ol>
+          <% cache('dropdown-topics') do %>
+            <%= render partial: 'shared/topic_dropdown', collection: topic_roots,
+                as: :topic %>
+          <% end %>
+        </ol>
+      </div>
+    </div>
+    <% header_links.each do |link| %>
+      <div class="nav-item">
+        <%= link_to cms_fragment_content('page_title', link), link.full_path %>
+      </div>
+    <% end %>
   </nav>
 <% end %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -15,12 +15,9 @@
           </ol>
         </div>
       </li>
-      <li class="nav-item about">
-        <%= link_to "About", page_path("about") %>
-      </li>
-      <li class="nav-item research">
-        <%= link_to "Research", page_path("research") %>
-      </li>
+      <% header_links.each do |link| %>
+        <li class="nav-item about"><%= link_to cms_fragment_content('page_title', link), link.full_path %></li>
+      <% end %>
     </ol>
   </nav>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
   get '/n/:id', to: 'notices#show'
   get '/N/:id', to: 'notices#show'
 
+  # URLs conforming to old patterns, like /notice.cgi?sID=X, are rewritten by
+  # the proxies before they get here.
   get '/submission_id/:id', to: 'submission_ids#show'
   get '/original_notice_id/:id', to: 'original_notice_ids#show'
 

--- a/doc/cms.md
+++ b/doc/cms.md
@@ -25,6 +25,14 @@ during the authentication process.
 * Click 'Add Child Page' next to 'pages'
 * Fill out the fields
 
+### To add links to the header or footer:
+* Content of the 'page' type includes checkboxes for 'Link in Header' and 'Link in Footer'
+* If you check these, the content will appear in the header/footer, respectively
+* A few caveats:
+  - The header and footer will not update immediately (due to page caching)
+  - The text in the header/footer will be the text in the 'Page Title' field
+  - This does not support putting blog posts into the header/footer. We could add that support via 1) updating the blog layout (see [notes on the pull request](https://github.com/berkmancenter/lumendatabase/pull/596)) and 2) updating the code so that it pulls the correct title -- the title fields for blogs and pages have different names due to CMS limitations.
+
 ### Extra details for the curious
 You will also see an 'original_news_id' parent page (along with the 'blog_entries' and 'pages' parent pages). This exists to maintain permalinks for old versions of the content. Please don't touch it.
 

--- a/spec/views/shared/_navigation.html.erb_spec.rb
+++ b/spec/views/shared/_navigation.html.erb_spec.rb
@@ -3,12 +3,6 @@ require 'rails_helper'
 describe 'shared/_navigation.html.erb' do
   include Comfy::ComfyHelper
 
-  it 'shows a link to research' do
-    render
-
-    expect(rendered).to contain_link(page_path("research"))
-  end
-
   it 'has links to all topics' do
     topics = create_list(:topic, 3)
 


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Adds the ability for header/footer links to be managed via the CMS. This requires an edit to helpers & templates (to find the desired links) and to styles (to make sure that we can display an arbitrary number of links in the header and footer -- we can no longer hardcode the width of the links in CSS).

**Requires updates to the CMS page layout** -- it now expects
```
{{ cms:checkbox link_in_header, render: false }}
{{ cms:checkbox link_in_footer, render: false }}
```

Also the pages that are currently linked from the header and footer will need the appropriate checkboxes to be checked, so that they will appear in the new system.

Make sure to clobber and recompile styles on deploy, too.

#### Helpful background context (if appropriate)
PMs want to be able to manage links.

#### How can a reviewer manually see the effects of these changes?
Deploy code. Several header/footer links will vanish. Update layout per above and check the checkboxes on pages you want to appear in the header/footer. Lo, they do! Observe at various screen sizes; the header and footer remain more or less reasonable.

#### What are the relevant tickets?
n/a (personal conversation)

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
