### PR TITLE
17179 form data bug

### DIFF
--- a/lib/validates_urls.rb
+++ b/lib/validates_urls.rb
@@ -17,19 +17,20 @@ module ValidatesUrls
       value = self.send(attr)
       next unless value.present?
 
-      unless ( is_ordinary_uri?(value) || is_noprotocol_uri?(value) )
+      encoded_value = URI.encode(value)
+      unless ( is_ordinary_uri?(encoded_value) || is_noprotocol_uri?(encoded_value) )
         errors.add(attr, 'Must be a valid URL')
       end
     end
   end
 
   def is_ordinary_uri?(value)
-    !!(value =~ URI::regexp)
+    !!(value =~ /\A#{URI::regexp}\z/)
   end
 
   # Matches things like "//bar.com".
   def is_noprotocol_uri?(value)
-    value.start_with?('//') && (('http:' + value) =~ URI::regexp)
+    value.start_with?('//') && (('http:' + value) =~ /\A#{URI::regexp}\z/)
   end
 
   def length_ok_when_split?

--- a/lib/validates_urls.rb
+++ b/lib/validates_urls.rb
@@ -17,8 +17,9 @@ module ValidatesUrls
       value = self.send(attr)
       next unless value.present?
 
-      encoded_value = URI.encode(value)
-      unless ( is_ordinary_uri?(encoded_value) || is_noprotocol_uri?(encoded_value) )
+      # This is invalid per the spec but common, so let's allow it.
+      munged_value = value.gsub('utf8=✓', 'utf8%3D%E2%9C%93')
+      unless ( is_ordinary_uri?(munged_value) || is_noprotocol_uri?(munged_value) )
         errors.add(attr, 'Must be a valid URL')
       end
     end

--- a/spec/models/infringing_url_spec.rb
+++ b/spec/models/infringing_url_spec.rb
@@ -11,19 +11,22 @@ describe InfringingUrl, type: :model do
 
     it 'validates format of URLs' do
       url = 'https://tilde.club:443/path/to/myfile.html?utf8=✓#AnchorGoesHere'
-      assert !!(url =~ URI::regexp)
-      assert CopyrightedUrl.new(url: url).valid?
+      assert InfringingUrl.new(url: url).valid?
     end
 
     it 'allows URLs without a protocol' do
       url = '//tilde.club:443/path/to/myfile.html?utf8=✓#AnchorGoesHere'
-      assert !!("http:#{url}" =~ URI::regexp)
-      assert CopyrightedUrl.new(url: url).valid?
+      assert InfringingUrl.new(url: url).valid?
+    end
+
+    it 'disallows bad URLs' do
+      url = 'https://this.url.has.a space'
+      assert !InfringingUrl.new(url: url).valid?
     end
 
     it 'allows concatenated URLs' do
       url = 'https://amazon.com/book/here/http://amazon.com/another/book/'
-      assert CopyrightedUrl.new(url: url).valid?
+      assert InfringingUrl.new(url: url).valid?
     end
   end
 


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
One of our submitters was having 500 errors submitting notices. This seems to be linked to differences in data representation between JSON data and multipart form data (the latter is what they were submitting). I've gotten around this by converting everything to JSON format early in the process and verified that it works on production with an example failed submission that they shared with us.

Unfortunately, the failed submission *worked on localhost and a test server* even with the prior, failing-on-production, code. This means I was unable to use it to generate a test that failed before the fix, so I don't have a programmatic way to verify the fix, or guard against breaking it in future. Nor do I know what element in the stack on production might have been causing this difference.

Software: [it's full of demons](http://beza1e1.tuxen.de/lore/).

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/17179

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [x] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
