### PR TITLE
Fallback to /notices/X when /submission_id/X not found

### DIFF
--- a/app/controllers/redirecting_controller.rb
+++ b/app/controllers/redirecting_controller.rb
@@ -1,9 +1,17 @@
 class RedirectingController < ApplicationController
 
   def show(class_model, finder_method_name)
-    instance = class_model.send(finder_method_name, params[:id])
-
-    if instance
+    # Try to find the Notice with the given ID number and ID type.
+    # If there is no such notice, try finding one with that ID number for the
+    # standard :id -- we think outside parties' scripts are interpolating new
+    # notice ID numbers into old format URLs.
+    # 404 only if neither of these is found.
+    if (instance = class_model.send(finder_method_name, params[:id]))
+      redirect_to(
+        send("#{singular_model_name(class_model)}_path".to_sym, instance),
+        status: :moved_permanently
+      )
+    elsif (instance = class_model.send(:find_by_id, params[:id]))
       redirect_to(
         send("#{singular_model_name(class_model)}_path".to_sym, instance),
         status: :moved_permanently

--- a/spec/support/shared_examples/redirecting_controller_for.rb
+++ b/spec/support/shared_examples/redirecting_controller_for.rb
@@ -6,14 +6,24 @@ shared_examples 'a redirecting controller for' do |model_class, factory_name, id
     get :show, params: { id: 2000 }
 
     expect(response).to redirect_to("/#{model_class.name.tableize}/1000")
-      expect(response.code).to eq "301"
+    expect(response.code).to eq "301"
+  end
+
+  it "checks Notice ID when id method does not find anything" do
+    instance = create(factory_name, id: 2000)  # must persist to db
+    expect(model_class.send(id_method, 2000)).to eq nil
+
+    get :show, params: { id: 2000 }
+
+    expect(response).to redirect_to("/#{model_class.name.tableize}/2000")
+    expect(response.code).to eq "301"
   end
 
   it "gives a 404 when a mapping isn't found" do
     expect(model_class).to receive(id_method).and_return(nil)
 
     get :show, params: { id: 2000 }
-    
+
     expect(response.code).to eq "404"
   end
 end


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
When someone accesses a submission_id or original_notice_id page and we don't find a notice with that submission_id or original_notice_id, but there IS a notice with that id, we redirect to its page. This is in addition to the existing behavior of handling submission_ids or original_notice_ids when they do exist, and 404ing if we can't find anything (having tested both the given type of ID and the regular id).

#### Helpful background context (if appropriate)
We think outside parties' scripts are interpolating new notice ID
numbers into old format URLs, leading to 404s where users expect data.

We don't have enough log/customer information to be certain, but if we
try this and stop getting these complaints we were right; if we start
getting a different kind of complaints ("I clicked the URL and got
something irrelevant!") we were wrong.

#### How can a reviewer manually see the effects of these changes?
Go to /submission_id/X, where there is not a Notice with submission_id of X but there is a Notice with id of X. You should be redirected to the page for that notice.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/17182

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
