### PR TITLE
Update taggable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'elasticsearch-model', '~> 5.0'
 gem 'elasticsearch-rails', '~> 5.0'
 
 group :development do
+  gem 'allocation_tracer'
   gem 'bullet'
   gem 'derailed'
   gem 'memory_profiler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,10 +59,11 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    acts-as-taggable-on (6.0.0)
-      activerecord (~> 5.0)
+    acts-as-taggable-on (6.5.0)
+      activerecord (>= 5.0, < 6.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    allocation_tracer (0.6.3)
     ancestry (3.0.7)
       activerecord (>= 3.2.0)
     ansi (1.5.0)
@@ -490,6 +491,7 @@ DEPENDENCIES
   activerecord-import
   acts-as-taggable-on
   addressable
+  allocation_tracer
   ancestry
   bootsnap
   bootstrap-datepicker-rails

--- a/config/initializers/acts-as-taggable-on.rb
+++ b/config/initializers/acts-as-taggable-on.rb
@@ -1,1 +1,7 @@
+require './lib/acts_as_taggable_on/comma_parser'
+
 ActsAsTaggableOn.remove_unused_tags = true
+# This hardcodes some behavior in the default parser which is more flexible,
+# but results in a tremendous number of allocations (and we aren't using
+# the flexibility).
+ActsAsTaggableOn.default_parser = CommaParser

--- a/lib/acts_as_taggable_on/comma_parser.rb
+++ b/lib/acts_as_taggable_on/comma_parser.rb
@@ -1,0 +1,13 @@
+class CommaParser < ActsAsTaggableOn::DefaultParser
+  def delimiter
+    ','.freeze
+  end
+
+  def double_quote_pattern
+    /(\A|,)\s*"(.*?)"\s*(?=,\s*|\z)/
+  end
+
+  def single_quote_pattern
+    /(\A|,)\s*'(.*?)'\s*(?=,\s*|\z)/
+  end
+end


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Updates the version of ActsAsTaggableOn (there are big performance improvements between v6 and v6.5). Overrides the default parser with one that uses fewer allocations (at the cost of some flexibility, but we weren't using that flexibility).

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
There shouldn't be visible changes, except that notice creation perf should improve.

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Todo:
- ~~[ ] Tests~~
- [x] Documentation
- ~~[ ] Stakeholder approval~~

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES
