### PR TITLE
17279 malformed url edge case

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,7 +479,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -140,9 +140,13 @@ class Work < ApplicationRecord
   # We can't just split on 'http', because doing so will result in strings
   # which no longer contain it. We need to look at the pairs of 'http' and
   # $the_rest_of_the_URL which split produces and then mash them back together.
+  # Note: this will NOT WORK on URLs which contain other URLs as
+  # path/querystring options, like Wayback Machine URLs. Unfortunately URLs do
+  # not follow a regular grammar so we have a mess of twisty little edge cases.
+  # If they become a problem in the wild, we can deal with it then.
   def conservative_split(s)
     b = []
-    s.split(/(http)/).reject { |x| x.blank? }.each_slice(2) { |s| b << s.join }
+    s.split(/(https?:\/\/)/).reject { |x| x.blank? }.each_slice(2) { |s| b << s.join }
     b
   end
 end


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
The work to fix concatenated URLs caused us to reject URLs of the form `http://httpweb.whatever.com`.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Compare submitting the above example URL on this branch and on dev.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/17279

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES