### PR TITLE
Cache notice attachment urls per access token to avoid wrong links

### DIFF
--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -121,10 +121,12 @@ module NoticesHelper
   end
 
   def truncatable_cache_key(key, can_see_full)
+    key_part = "#{key}_#{params[:access_token]}"
+    
     if can_see_full
-      "untruncated_#{key}"
+      "untruncated_#{key_part}"
     else
-      key
+      "truncated_#{key_part}"
     end
   end
 end


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Fixes an issue with caching wrong notice attachment urls (with a missing access token).

#### What are the relevant tickets?
https://cyber.harvard.edu/projectmanagement/issues/17288

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
