### PR TITLE
Expose Counternotice creation functionality

### DIFF
--- a/app/views/notices/select_type.html.erb
+++ b/app/views/notices/select_type.html.erb
@@ -7,14 +7,14 @@
   </p>
   <section class="notices-list">
     <ul>
-      <% Notice.type_models.each do |model| %>
+      <% (Notice.type_models + [Counternotice]).each do |model| %>
         <li data-id="<%= model.name %>"><%= model.label %></li>
       <% end %>
     </ul>
   </section>
 
   <section class="info-panel">
-    <% Notice.type_models.each do |model| %>
+    <% (Notice.type_models + [Counternotice]).each do |model| %>
       <div data-id="<%= model.name %>">
         <article>
           <b><%= model.label %>:</b>

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -305,6 +305,23 @@ feature 'notice submission' do
     expect(page).to have_text('Allegedly Infringing URL', count: 2)
   end
 
+  scenario 'menu page has all expected notice types' do
+    sign_in(create(:user, :submitter))
+
+    visit '/notices/new'
+
+    expect(page).to have_css '.notices-list li', text: 'Counternotice'
+    expect(page).to have_css '.notices-list li', text: 'Court Order'
+    expect(page).to have_css '.notices-list li', text: 'Data Protection'
+    expect(page).to have_css '.notices-list li', text: 'Defamation'
+    expect(page).to have_css '.notices-list li', text: 'DMCA'
+    expect(page).to have_css '.notices-list li', text: 'Government Request'
+    expect(page).to have_css '.notices-list li', text: 'Law Enforcement Request'
+    expect(page).to have_css '.notices-list li', text: 'Other'
+    expect(page).to have_css '.notices-list li', text: 'Private Information'
+    expect(page).to have_css '.notices-list li', text: 'Trademark'
+  end
+
   context 'template rendering' do
     scenario 'counternotice form' do
       sign_in(create(:user, :submitter))


### PR DESCRIPTION
This has worked for a while, but it wasn't offered on /notices/new --
since Counternotice is not a subtype of Notice it isn't caught in the
Notice.type_models net.

## Ready for merge?
**YES**

#### What does this PR do?
Adds Counternotice to the list of options at /notices/new, so that people are actually able to find the feature.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/17283

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- ~[ ] Documentation~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
