### PR TITLE
16186 placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). It uses [CalVer](https://calver.org/) as of May 2019.
 
 ## Unreleased
+### Added
+* [#617](https://github.com/berkmancenter/lumendatabase/pull/617) Plceholder notice type
+
 ### Fixed
 * [#615](https://github.com/berkmancenter/lumendatabase/pull/615) Fix ReindexRun metadata creation.
 * [#616](https://github.com/berkmancenter/lumendatabase/pull/616) Fixes bug in redirect behavior after notice submission through web form.
@@ -19,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Updated rack version.
 
 ## [20.05b](https://github.com/berkmancenter/lumendatabase/releases/tag/2020.05a) - 2020-05-29
-### Added 
+### Added
 * Counterfeit notice type [#604](https://github.com/berkmancenter/lumendatabase/pull/604)
 
 ### Changed

--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -1,14 +1,14 @@
 module NoticesHelper
   def form_partial_for(instance)
-    "#{instance.type.tableize.singularize}_form"
+    "#{instance.class.name.tableize.singularize}_form"
   end
 
   def show_partial_for(instance)
-    "#{instance.type.tableize.singularize}_show"
+    "#{instance.class.name.tableize.singularize}_show"
   end
 
   def works_partial_for(instance)
-    "#{instance.type.tableize.singularize}_works"
+    "#{instance.class.name.tableize.singularize}_works"
   end
 
   def date_sent(notice)
@@ -122,7 +122,7 @@ module NoticesHelper
 
   def truncatable_cache_key(key, can_see_full)
     key_part = "#{key}_#{params[:access_token]}"
-    
+
     if can_see_full
       "untruncated_#{key_part}"
     else

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -83,7 +83,7 @@ class Notice < ApplicationRecord
     'LawEnforcementRequest' => 'Law Enforcement Requests',
     'PrivateInformation'    => 'Right of Publicity',
     'Trademark'             => 'Trademark',
-    'Other'                 => OTHER_TOPIC
+    'Other'                 => OTHER_TOPIC,
     'Placeholder'           => OTHER_TOPIC
   }.freeze
 

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -169,6 +169,10 @@ class Notice < ApplicationRecord
     (TYPES - ['Counternotice']).map(&:constantize).freeze
   end
 
+  def self.display_models
+    (TYPES - ['Placeholder']).map(&:constantize).freeze
+  end
+
   def self.available_for_review
     where(
       review_required: true,

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -84,6 +84,7 @@ class Notice < ApplicationRecord
     'PrivateInformation'    => 'Right of Publicity',
     'Trademark'             => 'Trademark',
     'Other'                 => OTHER_TOPIC
+    'Placeholder'           => OTHER_TOPIC
   }.freeze
 
   TYPES = TYPES_TO_TOPICS.keys

--- a/app/models/placeholder.rb
+++ b/app/models/placeholder.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Placeholder notices are used when notice providers want to report every
+# takedown request of a particular class with, effectively, a form letter (e.g.
+# a generic response to law enforcement requests from a given jurisdiction).
+class Placeholder < Notice
+  def self.model_name
+    Notice.model_name
+  end
+
+  def self.label
+    'Placeholder'
+  end
+
+  def to_partial_path
+    'notices/placeholder'
+  end
+end

--- a/app/models/placeholder.rb
+++ b/app/models/placeholder.rb
@@ -4,6 +4,8 @@
 # takedown request of a particular class with, effectively, a form letter (e.g.
 # a generic response to law enforcement requests from a given jurisdiction).
 class Placeholder < Notice
+  DEFAULT_ENTITY_NOTICE_ROLES = %w[submitter].freeze
+
   def self.model_name
     Notice.model_name
   end

--- a/app/models/reindex_run.rb
+++ b/app/models/reindex_run.rb
@@ -52,6 +52,6 @@ class ReindexRun < ApplicationRecord
   end
 
   def updateable_set(model)
-    model.where('updated_at > ? or updated_at is null', last_run_time)
+    model.where('updated_at >= ? or updated_at is null', last_run_time)
   end
 end

--- a/app/serializers/notice_serializer.rb
+++ b/app/serializers/notice_serializer.rb
@@ -21,7 +21,7 @@ class NoticeSerializer < ActiveModel::Serializer
   # use hash operations on it within the hooks supported by
   # active-model-serializer.
   def works
-    if current_user && Ability.new(scope).can?(:view_full_version_api, object)
+    if defined?(current_user) && current_user && Ability.new(scope).can?(:view_full_version_api, object)
       base_works = object.works.as_json(
         only: [:description],
         include: {

--- a/app/views/notices/_placeholder_show.html.erb
+++ b/app/views/notices/_placeholder_show.html.erb
@@ -1,0 +1,13 @@
+<section class="notice-body">
+  <% if notice.body.present? %>
+    <h5 class="title">Explanation of complaint</h5>
+    <p class="body"><pre><%= notice.redacted(:body) %></pre></p>
+  <% end %>
+</section>
+
+<section class="works">
+  <dl class="urls">
+    <dt class="label">Problematic URLs</dt>
+    <dd class="field"><%= Lumen::REDACTION_MASK %></dd>
+  </dl>
+</section>

--- a/app/views/notices/select_type.html.erb
+++ b/app/views/notices/select_type.html.erb
@@ -7,14 +7,14 @@
   </p>
   <section class="notices-list">
     <ul>
-      <% (Notice.type_models + [Counternotice]).each do |model| %>
+      <% Notice.display_models.each do |model| %>
         <li data-id="<%= model.name %>"><%= model.label %></li>
       <% end %>
     </ul>
   </section>
 
   <section class="info-panel">
-    <% (Notice.type_models + [Counternotice]).each do |model| %>
+    <% Notice.display_models.each do |model| %>
       <div data-id="<%= model.name %>">
         <article>
           <b><%= model.label %>:</b>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -67,7 +67,7 @@
           <dd class="field"><%= @notice.type.titleize %></dd>
         </dl>
 
-    	  <% unless @notice.action_taken.nil? || @notice.action_taken.blank? %>
+    	  <% if @notice.action_taken.present? %>
           <dl class="action-taken">
             <dt class="label">Action taken:</dt>
             <dd class="field"><%= @notice.action_taken %></dd>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -132,6 +132,7 @@ FactoryBot.define do
     factory :other, class: 'Other'
     factory :private_information, class: 'PrivateInformation'
     factory :trademark, class: 'Trademark'
+    factory :placeholder, class: 'Placeholder'
   end
 
   factory :file_upload do

--- a/spec/integration/api_notice_search_spec.rb
+++ b/spec/integration/api_notice_search_spec.rb
@@ -108,7 +108,7 @@ feature "Searching for Notices via the API" do
     end
   end
 
-  Notice.type_models.each do |klass|
+  (Notice.type_models - [Placeholder]).each do |klass|
     class_factory = klass.to_s.tableize.singularize.to_sym
     scenario "a #{klass} notice has basic notice metadata", js: true, search: true do
 
@@ -123,6 +123,7 @@ feature "Searching for Notices via the API" do
 
       expect_api_search_to_find("king") do |json|
         json_item = json['notices'].first
+
         expect(json_item).to have_key('title').with_value(notice.title)
         expect(json_item).to have_key('id').with_value(notice.id)
         expect(json_item).to have_key('topics').with_value(expected_topics)

--- a/spec/views/notices/new.html.erb_spec.rb
+++ b/spec/views/notices/new.html.erb_spec.rb
@@ -11,7 +11,8 @@ describe 'notices/new.html.erb' do
     expect(rendered).to have_css 'form.new_notice'
   end
 
-  Notice.type_models.each do |model|
+  # Placeholders are an admin feature, not available through the web form.
+  (Notice.type_models - [Placeholder]).each do |model|
     it "knows the notice type for #{model}" do
       assign(:notice, model.new)
 
@@ -163,7 +164,7 @@ describe 'notices/new.html.erb' do
     expect(rendered).to have_words('Allegedly Infringing URL *')
   end
 
-  Notice.type_models.each do |model|
+  (Notice.type_models - [Placeholder]).each do |model|
     context "country selectors in \"#{model.label}\" notices" do
       it 'use ISO country codes' do
         factory_name = model.name.tableize.singularize

--- a/spec/views/notices/select_type.html.erb_spec.rb
+++ b/spec/views/notices/select_type.html.erb_spec.rb
@@ -1,17 +1,25 @@
 require 'rails_helper'
 
 describe 'notices/select_type.html.erb' do
-  it "is not missing any translations" do
+  it 'is not missing any translations' do
     render
 
     expect(rendered).not_to have_css('.translation_missing')
   end
 
-  Notice.type_models.each do |model|
+  (Notice.type_models - [Placeholder]).each do |model|
     it "displays the correct descriptive text for #{model} notices" do
       render
 
       expect(rendered).to have_css( "div[data-id=#{model.name}]", text: ActionController::Base.helpers.strip_tags(t("type_descriptions.#{model.name}")))
     end
+  end
+
+  it 'does not allow for Placeholder creation' do
+    model = Placeholder
+
+    render
+
+    expect(rendered).not_to have_css( "div[data-id=#{model.name}]", text: ActionController::Base.helpers.strip_tags(t("type_descriptions.#{model.name}")))
   end
 end


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Adds a Placeholder notice type.

#### Helpful background context (if appropriate)
Sometimes notice providers want to be able to link to a generic notice, representing a class of notices they receive in large numbers, whose specifics are not relevant and/or shareable.

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/16186

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
