### PR TITLE
17341 default fields

### DIFF
--- a/app/assets/stylesheets/notices/_forms.scss
+++ b/app/assets/stylesheets/notices/_forms.scss
@@ -193,6 +193,10 @@ form.new_notice {
     padding-left: $form-label-width + $form-label-margin;
   }
 
+  label.half-width + input {
+    padding-left: $form-label-width / 2 + $form-label-margin;    
+  }
+
   textarea {
     height: 150px;
     width: 100%;

--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -77,6 +77,35 @@ module NoticesHelper
     url + (params[:access_token] ? "&access_token=#{params[:access_token]}" : '')
   end
 
+  # This prefills the submitter and recipient fields with info from a linked
+  # entity, if the user has one.
+  def placeholder_text(user, role, field)
+    return {} unless [
+      [:submitter, :recipient].include?(role.downcase.to_sym),
+      user&.entity.present?
+    ].all?
+
+    { value: user.entity.send(field) }
+  end
+
+  def placeholder_country(user, role)
+    return {} unless [
+      [:submitter, :recipient].include?(role.downcase.to_sym),
+      user&.entity&.country_code&.present?
+    ].all?
+
+    { selected: user&.entity&.country_code&.downcase.to_sym }
+  end
+
+  def placeholder_kind(user, role)
+    return {} unless [
+      [:submitter, :recipient].include?(role.downcase.to_sym),
+      user&.entity.present?
+    ].all?
+
+    { selected: user.entity.kind }
+  end
+
   private
 
   def display_date_field(record, field)

--- a/app/views/notices/form_components/_roles.html.erb
+++ b/app/views/notices/form_components/_roles.html.erb
@@ -10,20 +10,36 @@
     <%= roles_form.input :name, as: :hidden %>
     <%= roles_form.simple_fields_for(:entity) do |entity_form| %>
       <div class="body-wrapper left required">
-        <%= entity_form.input :name, label: "Name" %>
+        <%= entity_form.input :name, label: "Name",
+          input_html: placeholder_text(current_user, role, :name) %>
         <%= entity_form.input :kind,
-          label: "#{role} Type", prompt: nil, collection: Entity::KINDS %>
+          { label: "#{role} Type", prompt: nil, collection: Entity::KINDS }
+            .merge(placeholder_kind(current_user, role))
+        %>
       </div>
       <div class="body-wrapper right optional">
-        <%= entity_form.input :address_line_1, label: "Address Line 1" %>
-        <%= entity_form.input :address_line_2, label: "Address Line 2" %>
-        <%= entity_form.input :city, label: "City" %>
-        <%= entity_form.input :state, label: "State", label_html: { class: 'half-width' }, maxlength: "2" %>
-        <%= entity_form.input :zip, label: "Zip Code", label_html: { class: 'half-width' } %>
-        <%= entity_form.input :country_code, collection: iso_countries, label: "Country" %>
-        <%= entity_form.input :phone, label: "Phone" %>
-        <%= entity_form.input :email, label: "Email" %>
-        <%= entity_form.input :url, label: "#{role} URL" %>
+        <%= entity_form.input :address_line_1, label: "Address Line 1",
+          input_html: placeholder_text(current_user, role, :address_line_1) %>
+        <%= entity_form.input :address_line_2, label: "Address Line 2",
+          input_html: placeholder_text(current_user, role, :address_line_2) %>
+        <%= entity_form.input :city, label: "City",
+          input_html: placeholder_text(current_user, role, :city) %>
+        <%= entity_form.input :state, label: "State",
+          label_html: { class: 'half-width' }, maxlength: "2",
+          input_html: placeholder_text(current_user, role, :state) %>
+        <%= entity_form.input :zip, label: "Zip Code",
+          label_html: { class: 'half-width' },
+          input_html: placeholder_text(current_user, role, :zip) %>
+        <%= entity_form.input :country_code,
+          { collection: iso_countries, label: "Country" }.merge(
+            placeholder_country(current_user, role)
+          ) %>
+        <%= entity_form.input :phone, label: "Phone",
+          input_html: placeholder_text(current_user, role, :phone) %>
+        <%= entity_form.input :email, label: "Email",
+          input_html: placeholder_text(current_user, role, :email) %>
+        <%= entity_form.input :url, label: "#{role} URL",
+          input_html: placeholder_text(current_user, role, :url) %>
       </div>
     <% end %>
   </section>

--- a/spec/integration/submit_notice_via_web_spec.rb
+++ b/spec/integration/submit_notice_via_web_spec.rb
@@ -191,6 +191,28 @@ feature 'notice submission' do
     end
   end
 
+  scenario 'submitting as a user with a linked entity prefills form' do
+    user = create(:user, :submitter)
+    entity = create(
+      :entity, user: user, kind: 'organization',
+      address_line_1: '23 Everett St.', address_line_2: '2nd Floor',
+      city: 'Cambridge', state: 'MA', zip: '02138', phone: '(617) 495-7547',
+      country_code: 'US', email: 'totallyfake@cyber.harvard.edu',
+      url: 'https://cyber.harvard.edu'
+    )
+    user.reload
+    sign_in(user)
+
+    visit new_notice_path(type: 'DMCA')
+
+    within('.role.submitter') do
+      verify_entity_info(entity)
+    end
+    within('.role.recipient') do
+      verify_entity_info(entity)
+    end
+  end
+
   scenario 'submitting notices with duplicate items' do
     submit_recent_notice
     submit_recent_notice
@@ -524,5 +546,52 @@ feature 'notice submission' do
     expect(page).to have_css 'header'
     expect(page).to have_css '.role'
     expect(page).to have_css '.submit'
+  end
+
+  def verify_entity_info(entity)
+    expect(
+      find('.notice_entity_notice_roles_entity_name input')
+      .value
+    ).to eq entity.name
+    expect(
+      find('.notice_entity_notice_roles_entity_kind select')
+      .value
+    ).to eq entity.kind
+    expect(
+      find('.notice_entity_notice_roles_entity_address_line_1 input')
+      .value
+    ).to eq entity.address_line_1
+    expect(
+      find('.notice_entity_notice_roles_entity_address_line_2 input')
+      .value
+    ).to eq entity.address_line_2
+    expect(
+      find('.notice_entity_notice_roles_entity_city input')
+      .value
+    ).to eq entity.city
+    expect(
+      find('.notice_entity_notice_roles_entity_state input')
+      .value
+    ).to eq entity.state
+    expect(
+      find('.notice_entity_notice_roles_entity_zip input')
+      .value
+    ).to eq entity.zip
+    expect(
+      find('.notice_entity_notice_roles_entity_country_code select')
+      .value
+    ).to eq entity.country_code.downcase
+    expect(
+      find('.notice_entity_notice_roles_entity_phone input')
+      .value
+    ).to eq entity.phone
+    expect(
+      find('.notice_entity_notice_roles_entity_email input')
+      .value
+    ).to eq entity.email
+    expect(
+      find('.notice_entity_notice_roles_entity_url input')
+      .value
+    ).to eq entity.url
   end
 end


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Adds default data to submitter and recipient fields on the web form, when the user is connected to an entity.

#### Helpful background context (if appropriate)
It's annoing for users to have to hand-enter the same data repeatedly, and it leads to many near-duplicate entities in our db.

#### How can a reviewer manually see the effects of these changes?
Go to the create notices web form as a logged-in user with submitter privileges. If you have an associated entity, you will see that the submitter and recipient forms are prefilled.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/17341

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
