### PR TITLE
Don't send original URLs via API

### DIFF
--- a/app/serializers/notice_serializer.rb
+++ b/app/serializers/notice_serializer.rb
@@ -25,8 +25,8 @@ class NoticeSerializer < ActiveModel::Serializer
       base_works = object.works.as_json(
         only: [:description],
         include: {
-          infringing_urls: { only: %i[url url_original] },
-          copyrighted_urls: { only: %i[url url_original] }
+          infringing_urls: { only: %i[url] },
+          copyrighted_urls: { only: %i[url] }
         }
       )
     else

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -155,7 +155,8 @@ describe NoticesController do
         }
 
         json = JSON.parse(response.body)["dmca"]["works"][0]["infringing_urls"][0]
-        expect(json).to have_key('url_original')
+        expect(json).to have_key('url')
+        expect(json).not_to have_key('url_original')
       end
     end
 


### PR DESCRIPTION
If they've been redacted, we don't want to share them.

## Ready for merge?
**YES**

#### What does this PR do?
Removes `url_original` from serializers so we don't send potentiall redacted information via the API.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Send API requests or .json-formatted GET requests against this and dev, compare data.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/17356

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
