### PR TITLE
Don't offer more notice content when there isn't any

### DIFF
--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -1,4 +1,16 @@
 module NoticesHelper
+  # Determines whether 'click to request access' should be an option.
+  # Yes, the messy function signature implies there is a lot going on with the
+  # business logic.
+  def access_requestable?(notice, show_original, show_infringing)
+    [
+      show_original || show_infringing,
+      # Additional access cannot be requested for confidential court orders
+      # as there is nothing further to display.
+      !confidential_order?(notice)
+    ].all?
+  end
+
   def form_partial_for(instance)
     "#{instance.class.name.tableize.singularize}_form"
   end
@@ -107,6 +119,11 @@ module NoticesHelper
   end
 
   private
+
+  def confidential_order?(notice)
+    notice.is_a?(CourtOrder) &&
+      notice.subject&.include?('Google has not provided a copy to Lumen')
+  end
 
   def display_date_field(record, field)
     return unless (date = record.send(field))

--- a/app/views/notices/_works_urls.html.erb
+++ b/app/views/notices/_works_urls.html.erb
@@ -51,7 +51,7 @@
     </div>
   <% end %>
 
-  <% if show_original || show_infringing %>
+  <% if access_requestable?(@notice, show_original, show_infringing) %>
     <div class="row">
       <p><%= link_to 'Click here', request_access_notice_path(@notice) %> to request access and see full URLs.</p>
     </div>

--- a/spec/integration/viewing_notices.spec.rb
+++ b/spec/integration/viewing_notices.spec.rb
@@ -68,6 +68,28 @@ feature 'Viewing notices' do
     check_full_works_urls
   end
 
+  context 'requesting additional access' do
+    scenario 'notice is safelisted' do
+      ENV['SAFELISTED_NOTICES_FULL'] = "1234,#{Notice.last.id}"
+
+      visit notice_url(Notice.last)
+
+      expect(page).not_to have_content('Click here to request access')
+    end
+
+    scenario 'confidential court orders' do
+      n = Notice.last
+      n.reset_type = 'CourtOrder'
+      n.update(subject: "Google received a request to remove content from our services based on a court order. Due to the nature of the court's order, Google has not provided a copy to Lumen.")
+      n.save
+      n
+
+      visit notice_url(n)
+
+      expect(page).not_to have_content('Click here to request access')
+    end
+  end
+
   def check_full_works_urls
     within('#works') do
       expect(page).to have_content 'http://www.example.com/original_work.pdf'


### PR DESCRIPTION
Safelisted notices don't have any more content because they're already
showing all content -- this doesn't require a change to our existing
logic, but this PR adds a test to verify.

Confidential court orders shouldn't offer more access because there
isn't anything else to access.

There are potentially enough edge cases in the business logic here
that I've extracted it to a helper method to make it easier to change.

## Ready for merge?
**YES**

#### What does this PR do?
See above.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/17383

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- ~[ ] Documentation~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
