### PR TITLE
Make sure date_sent shows when sender is redacted

### DIFF
--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -126,7 +126,7 @@ module NoticesHelper
   end
 
   def display_date_field(record, field)
-    return unless (date = record.send(field))
+    return unless record && (date = record.send(field))
     time_tag date, date.to_s(:simple)
   end
 

--- a/app/views/entities/_address.html.erb
+++ b/app/views/entities/_address.html.erb
@@ -1,4 +1,4 @@
 <span class="private">[Private]</span>
 <span>
-  <%= [entity.city, entity.state, entity.zip, entity.country_code&.upcase].compact.join (', ') %>
+  <%= [entity.city, entity.state, entity.zip, entity.country_code&.upcase].reject { |item| item&.blank? }.join (', ') %>
 </span>

--- a/app/views/entities/_entity.html.erb
+++ b/app/views/entities/_entity.html.erb
@@ -1,9 +1,8 @@
 <% additional_css ||= '' %>
-<% hide_identities = local_assigns.has_key?(:hide_identities) ? hide_identities : false %>
 <section class="<%= role %> <%= additional_css %>">
   <h5><%= role %></h5>
   <h6>
-    <% if hide_identities %>
+    <% if role == :sender && notice.hide_identities? %>
       REDACTED
     <% else %>
       <%=
@@ -15,29 +14,6 @@
     <% end %>
   </h6>
 
-  <% if role == :sender && !hide_identities %>
-    <% if notice.on_behalf_of_principal? %>
-      <h6>
-        <span class="on_behalf_of">on behalf of</span>
-        <%=
-          link_to(
-            notice.principal_name,
-            faceted_search_path('principal_name' => notice.principal_name)
-          )
-        %>
-      </h6>
-    <% end %>
-    <%= render 'entities/address', entity: entity, role: role %>
-    <% if date_sent(notice).present? %>
-      <span class="date sent">Sent on <%= date_sent(notice) %></span>
-    <% end %>
-  <% elsif role == :recipient %>
-    <%= render 'entities/address', entity: entity, role: role %>
-
-    <% if date_sent(notice) != date_received(notice) %>
-      <span class="date received">Received on <%= date_received(notice) %></span>
-    <% end %>
-  <% elsif role == :sender && entity.country_code.present? %>
-    <span><%= t 'views.entities.entity.country' %>: <%= entity.country_code.upcase %></span>
-  <% end %>
+  <%= render 'entities/sender', notice: notice, entity: entity, role: role if role == :sender %>
+  <%= render 'entities/recipient', notice: notice, entity: entity, role: role if role == :recipient %>
 </section>

--- a/app/views/entities/_recipient.html.erb
+++ b/app/views/entities/_recipient.html.erb
@@ -1,0 +1,5 @@
+<%= render 'entities/address', entity: entity %>
+
+<% if date_sent(notice) != date_received(notice) %>
+  <span class="date received">Received on <%= date_received(notice) %></span>
+<% end %>

--- a/app/views/entities/_sender.html.erb
+++ b/app/views/entities/_sender.html.erb
@@ -1,0 +1,22 @@
+<% if !notice.hide_identities? %>
+  <% if notice.on_behalf_of_principal? %>
+    <h6>
+      <span class="on_behalf_of">on behalf of</span>
+      <%=
+        link_to(
+          notice.principal_name,
+          faceted_search_path('principal_name' => notice.principal_name)
+        )
+      %>
+    </h6>
+  <% end %>
+  <%= render 'entities/address', entity: entity %>
+<% end %>
+
+<% if date_sent(notice).present? %>
+  <span class="date sent">Sent on <%= date_sent(notice) %></span>
+<% end %>
+
+<% if entity.country_code.present? %>
+  <span><%= t 'views.entities.entity.country' %>: <%= entity.country_code.upcase %></span>
+<% end %>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -29,7 +29,7 @@
         <h1><%= @notice.title %></h1>
         <div class="entities-wrapper">
           <% if @notice.sender %>
-            <%= render @notice.sender, notice: @notice, role: :sender, hide_identities: @notice.hide_identities? %>
+            <%= render @notice.sender, notice: @notice, role: :sender %>
           <% end %>
           <% if @notice.recipient %>
             <%= render @notice.recipient, notice: @notice, role: :recipient %>

--- a/spec/integration/viewing_notices.spec.rb
+++ b/spec/integration/viewing_notices.spec.rb
@@ -68,6 +68,29 @@ feature 'Viewing notices' do
     check_full_works_urls
   end
 
+  context 'entities' do
+    scenario 'can see the date when the sender is redacted' do
+      n = Notice.last
+      n.update(date_sent: Date.new(2020, 9, 2))
+      n.reload
+      allow(n).to receive(:hide_identities?).and_return(true)
+
+      visit notice_url(n)
+
+      expect(page).to have_content('Sent on September 02, 2020')
+    end
+
+    scenario 'blank addresses do not lead to lines of commas' do
+      n = Notice.last
+      n.submitter.update(city: '', state: '', zip: '', country_code: '')
+      n.reload
+
+      visit notice_url(n)
+
+      expect(page).not_to have_content(',,,')
+    end
+  end
+
   context 'requesting additional access' do
     scenario 'notice is safelisted' do
       ENV['SAFELISTED_NOTICES_FULL'] = "1234,#{Notice.last.id}"


### PR DESCRIPTION
...that was the scope of the ticket, anyway. This ends up refactoring
the entity template because the conditionals were tangled enough that
it was hard to tell why the date wasn't displaying. It's now been
separated into its constituent parts, with some cruft removed.

While we're at it, fixed the bug that made empty addresses display as
",,,".

## Ready for merge?
**YES**

#### What does this PR do?
Above.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Go to a notice whose sender is redacted (that is, has hide_entities set to true on the notice); you will see the date_sent.

Go to a notice whose sender or recipient does not have an address; you will NOT see ",,," on the address line.

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/16003

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- ~[ ] Documentation~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
