### PR TITLE
Replace phantomjs with selenium

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,14 +61,9 @@ group :development do
 end
 
 group :development, :test do
-  gem 'factory_bot_rails'
-  gem 'parallel_tests'
-  gem 'phantomjs'
   gem 'pry', '~> 0.10.4'
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'rspec-collection_matchers', '~> 1.1', '>= 1.1.2'
-  gem 'rspec-rails'
   gem 'ruby-prof'
   gem 'sham_rack'
 end
@@ -83,17 +78,22 @@ group :development, :test, :assets do
 end
 
 group :test do
+  gem 'capybara-selenium'
   gem 'curb'
   gem 'database_cleaner'
   gem 'elasticsearch-extensions'
-  gem 'poltergeist'
+  gem 'factory_bot_rails'
+  gem 'parallel_tests'
   gem 'rack-test', require: 'rack/test'
+  gem 'rspec-collection_matchers', '~> 1.1', '>= 1.1.2'
   gem 'rails-controller-testing'
+  gem 'rspec-rails'
   gem 'rspec-pride'
   gem 'shoulda-matchers', '~> 3.1', '>= 3.1.1'
   gem 'simplecov', require: false
   gem 'test-prof'
   gem 'timecop'
   gem 'vcr'
+  gem 'webdrivers'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,16 +83,19 @@ GEM
       uniform_notifier (~> 1.11)
     byebug (11.0.1)
     cancancan (3.1.0)
-    capybara (3.15.1)
+    capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
-      regexp_parser (~> 1.2)
+      regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    capybara-selenium (0.0.6)
+      capybara
+      selenium-webdriver
+    childprocess (3.0.0)
     climate_control (0.2.0)
-    cliver (0.3.2)
     coderay (1.1.2)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -273,11 +276,6 @@ GEM
     parallel_tests (2.32.0)
       parallel
     pg (1.1.4)
-    phantomjs (2.1.1.0)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -355,7 +353,7 @@ GEM
       actionview (>= 5)
     redcarpet (3.5.0)
     ref (2.0.0)
-    regexp_parser (1.5.1)
+    regexp_parser (1.7.1)
     remotipart (1.4.4)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -391,6 +389,7 @@ GEM
     ruby-prof (1.3.2)
     ruby_parser (3.14.1)
       sexp_processor (~> 4.9)
+    rubyzip (2.3.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -407,6 +406,9 @@ GEM
       tilt
     select2-rails (4.0.3)
       thor (~> 0.14)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sexp_processor (4.13.0)
     sham_rack (1.4.1)
       rack
@@ -462,6 +464,10 @@ GEM
     vcr (4.0.0)
     warden (1.2.7)
       rack (>= 1.0)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -487,6 +493,7 @@ DEPENDENCIES
   bourbon
   bullet
   cancancan
+  capybara-selenium
   coffee-rails
   comfortable_mexican_sofa
   country_select (~> 1.2.0)
@@ -514,8 +521,6 @@ DEPENDENCIES
   paperclip (~> 5)
   parallel_tests
   pg (~> 1.1.4)
-  phantomjs
-  poltergeist
   pry (~> 0.10.4)
   pry-byebug
   pry-rails
@@ -549,6 +554,7 @@ DEPENDENCIES
   turnout
   uglifier
   vcr
+  webdrivers
   webmock
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Development
 * Java Runtime Environment (OpenJDK works fine)
 * Piwik Tracking (only used in prod)
 * Mail server (SMTP, Sendmail)
-* phantomjs (used only by test runner)
+* ChromeDriver (used only by test runner)
 
 #### Setup
 

--- a/spec/integration/submit_token_url_spec.rb
+++ b/spec/integration/submit_token_url_spec.rb
@@ -13,7 +13,7 @@ feature 'token url submission' do
     expect(page).to have_content 'A new single-use link has been generated and sent to'
   end
 
-  scenario 'won\'t allow to submit twice using the same email', js: true do
+  scenario "won't allow to submit twice using the same email", js: true do
     visit request_access_notice_path(notice)
 
     expect_correct_title
@@ -27,14 +27,16 @@ feature 'token url submission' do
     expect(page).to have_content 'This email address has been used already'
   end
 
-  scenario 'won\'t allow to submit using a not valid email', js: true do
+  scenario "won't allow to submit using a not valid email", js: true do
     visit request_access_notice_path(notice)
 
     expect_correct_title
 
     submit('hohoho')
+    message = page.find('#token_url_email').native.attribute('validationMessage')
 
-    expect(page).to have_content 'Email is invalid'
+    expect(message).to be_present
+    expect(current_path).to eq request_access_notice_path(notice)
   end
 
   scenario 'will contain all the form fields', js: true do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,29 +14,9 @@ end
 
 require 'rubygems'
 require 'rspec/rails'
-require 'capybara/poltergeist'
-require 'capybara/rspec'
 require 'webmock/rspec'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
-
-# https://docs.travis-ci.com/user/common-build-problems/#capybara-im-getting-errors-about-elements-not-being-found
-Capybara.default_max_wait_time = 15
-
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(
-    app,
-    port: 51674 + ENV['TEST_ENV_NUMBER'].to_i,
-    phantomjs_logger: File.open("#{Rails.root}/log/test_phantomjs.log", 'a')
-  )
-end
-
-Capybara.javascript_driver = :poltergeist
-Capybara.server = :webrick
-
-Capybara.configure do |config|
-  config.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
-end
 
 ActiveRecord::Migration.maintain_test_schema!
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,44 @@
+require 'capybara/rspec'
+require 'webdrivers/chromedriver'
+
+# https://docs.travis-ci.com/user/common-build-problems/#capybara-im-getting-errors-about-elements-not-being-found
+Capybara.default_max_wait_time = 15
+
+default_chrome_options = %w(
+  --blink-settings=imagesEnabled=false
+  --disable-extensions
+  --disable-gpu
+  --disable-infobars
+  --disable-notifications
+  --disable-password-generation
+  --disable-password-manager-reauthentication
+  --disable-popup-blocking
+  --disable-save-password-bubble
+  --headless
+  --ignore-certificate-errors
+  --incognito
+  --mute-audio
+  --remote-debugging-port=9222
+)
+
+chrome_options = Selenium::WebDriver::Chrome::Options.new
+default_chrome_options.each { |o| chrome_options.add_argument(o) }
+client = Selenium::WebDriver::Remote::Http::Default.new(open_timeout: nil, read_timeout: 120)
+
+Capybara.register_driver :headless do |app|
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    clear_local_storage: true,
+    clear_session_storage: true,
+    options: chrome_options,
+    http_client: client
+  )
+end
+
+Capybara.javascript_driver = :headless
+Capybara.server = :webrick
+
+Capybara.configure do |config|
+  config.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
+end

--- a/spec/support/notice_actions.rb
+++ b/spec/support/notice_actions.rb
@@ -52,6 +52,7 @@ module NoticeActions
 
     with_file('some content') do |file|
       attach_file field_name, file.path
+      find('body').send_keys(:escape)
     end
     @field_index += 1
   end


### PR DESCRIPTION
phantomjs development ceased in 2018, and it's increasingly hard to
integrate with CI.

## Ready for merge?
**YES**

#### What does this PR do?
Rips out phantomjs, uses headless chrome instead. Correspondingly rips out poltergeist, uses selenium.

#### Helpful background context (if appropriate)
I'm trying to migrate from travis (which is broken) to circle, and standing up phantomjs on circle is a pain.

#### How can a reviewer manually see the effects of these changes?
n/a

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)

#### Todo:
- ~~[ ] Tests~~ (existing tests still pass; no feature changes -> no new tests)
- [x] Documentation
- ~~[ ] Stakeholder approval~~

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES