### PR TITLE
Fix search timeout error

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -71,6 +71,8 @@ class SearchController < ApplicationController
   def wrap_instances
     # #records fetches the database instances while maintaining the search
     # response ordering.
+    # Note that the search definition above is lazy; this is the first line
+    # where anything with Elasticsearch actually gets executed.
     instances = @searchdata.records
     instances.map { |r| augment_instance(r) }
   end

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,6 +1,9 @@
 config = {
   host: 'http://localhost:9200',
-  request_timeout: 20
+  # This request timeout is ridiculously large, but searches with a very large
+  # number of hits will fail without it (throwing a Faraday::TimeoutError
+  # (Net::ReadTimeout)).
+  request_timeout: 40
 }
 
 if File.exist?('config/elasticsearch.yml')


### PR DESCRIPTION
## Ready for merge?
**YES**

#### What does this PR do?
Searches with a very large number of hits (e.g. "DMCA (Copyright) Complaint to Google") have been failing after the upgrade. This patches that by increasing the request timeout. (They're still very slow, but they complete within the timeout interval.)

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/17207

#### Screenshots (if appropriate)

#### Todo:
- ~~[ ] Tests~~
- [x] Documentation
- ~~[ ] Stakeholder approval~~

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
