### PR TITLE
Force elasticsearch to update when instances do

### DIFF
--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -9,6 +9,7 @@ class Entity < ApplicationRecord
   include HierarchicalRelationships
   include DefaultNameOriginal
   include Elasticsearch::Model
+  include Elasticsearch::Model::Callbacks
 
   # == Constants ============================================================
   PER_PAGE = 10

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -7,6 +7,7 @@ require 'validates_automatically'
 class Notice < ApplicationRecord
   include Searchability
   include Elasticsearch::Model
+  include Elasticsearch::Model::Callbacks
 
   extend RecentScope
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -4,6 +4,12 @@ require 'webdrivers/chromedriver'
 # https://docs.travis-ci.com/user/common-build-problems/#capybara-im-getting-errors-about-elements-not-being-found
 Capybara.default_max_wait_time = 15
 
+# TROUBLESHOOTING: are your tests failing because of the wrong chromedriver
+# version, even though you know you have the right version installed, and
+# moreover webdrivers is automatically managing the upgrades?
+# Before you go editing these options, check for running Chrome processes and
+# kill them! Old running Chrome versions will disrupt Capybara's ability to find
+# and launch the new version.
 default_chrome_options = %w(
   --blink-settings=imagesEnabled=false
   --disable-extensions


### PR DESCRIPTION
This was on by default in the older version of elasticsearch-model, but
now you need to include the callbacks to trigger it. We didn't have a
test to verify the behavior, so we missed it.

## Ready for merge?
**YES**

#### What does this PR do?
As above. This cherry-picks one of the commits from #628 -- that PR won't be ready for deployment until the production index that backs it is ready, but this is ready now, and should be deployed ASAP.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://cyber.harvard.edu/projectmanagement/issues/*X*

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- ~[ ] Documentation~
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
